### PR TITLE
Fix registry blob client and some minor refactors

### DIFF
--- a/build-index/main.go
+++ b/build-index/main.go
@@ -25,6 +25,7 @@ import (
 	// Import all backend client packages to register them with backend manager.
 	_ "github.com/uber/kraken/lib/backend/hdfsbackend"
 	_ "github.com/uber/kraken/lib/backend/httpbackend"
+	_ "github.com/uber/kraken/lib/backend/registrybackend"
 	_ "github.com/uber/kraken/lib/backend/s3backend"
 	_ "github.com/uber/kraken/lib/backend/testfs"
 )

--- a/lib/backend/registrybackend/blobclient_test.go
+++ b/lib/backend/registrybackend/blobclient_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/uber/kraken/utils/testutil"
 )
 
-func TestBlobDownloadSuccess(t *testing.T) {
+func TestBlobDownloadBlobSuccess(t *testing.T) {
 	require := require.New(t)
 
 	blob := randutil.Blob(32 * memsize.KB)
@@ -28,6 +28,36 @@ func TestBlobDownloadSuccess(t *testing.T) {
 		require.NoError(err)
 	})
 	r.Head(fmt.Sprintf("/v2/%s/blobs/:blob", namespace), func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(blob)))
+	})
+	addr, stop := testutil.StartServer(r)
+	defer stop()
+
+	config := Config{Address: addr}
+	client, err := NewBlobClient(config)
+	require.NoError(err)
+
+	info, err := client.Stat(namespace, "data")
+	require.NoError(err)
+	require.Equal(int64(len(blob)), info.Size)
+
+	var b bytes.Buffer
+	require.NoError(client.Download(namespace, "data", &b))
+	require.Equal(blob, b.Bytes())
+}
+
+func TestBlobDownloadManifestSuccess(t *testing.T) {
+	require := require.New(t)
+
+	blob := randutil.Blob(32 * memsize.KB)
+	namespace := core.NamespaceFixture()
+
+	r := chi.NewRouter()
+	r.Get(fmt.Sprintf("/v2/%s/manifests/:blob", namespace), func(w http.ResponseWriter, req *http.Request) {
+		_, err := io.Copy(w, bytes.NewReader(blob))
+		require.NoError(err)
+	})
+	r.Head(fmt.Sprintf("/v2/%s/manifests/:blob", namespace), func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(blob)))
 	})
 	addr, stop := testutil.StartServer(r)

--- a/origin/main.go
+++ b/origin/main.go
@@ -35,6 +35,7 @@ import (
 	// Import all backend client packages to register them with backend manager.
 	_ "github.com/uber/kraken/lib/backend/hdfsbackend"
 	_ "github.com/uber/kraken/lib/backend/httpbackend"
+	_ "github.com/uber/kraken/lib/backend/registrybackend"
 	_ "github.com/uber/kraken/lib/backend/s3backend"
 	_ "github.com/uber/kraken/lib/backend/testfs"
 )


### PR DESCRIPTION
- Fix the issue with `Docker-Content-Digest` maybe not be the hash the the actual manifest content
- Add a retry for pulling manifest blob because `http://registry/v2/namespace/blobs/sha256:<manifest_digest>` always returns 404