### PR TITLE
Add simulation script for soft connection limit

### DIFF
--- a/tools/bin/simulation/procedural_generated_graph.py
+++ b/tools/bin/simulation/procedural_generated_graph.py
@@ -4,12 +4,12 @@ import sets
 
 """
 Procedural generated graph with soft connection limit of 5, max limit of 20:
- - 5000 peers, 500MB: 18 sec
- - 1000 peers, 10GB: p50 297 sec, p100 384 sec (65% ~ 84% speed)
+ - 5000 peers, 500MB: 18 iterations
+ - 1000 peers, 10GB: p50 297 iterations, p100 384 iterations (65% ~ 84% speed)
 """
 PEER_COUNT = 5000
 PIECE_COUNT = 125
-PIECE_TRANSMIT_LIMIT = 10  # Number of pieces uploaded/downloaded per "sec"
+PIECE_TRANSMIT_LIMIT = 10  # Number of pieces uploaded/downloaded per iteration
 SOFT_CONNECTION_LIMIT = 5
 MAX_CONNECTION_LIMIT = 20
 

--- a/tools/bin/simulation/random_regular_graph.py
+++ b/tools/bin/simulation/random_regular_graph.py
@@ -6,12 +6,12 @@ import networkx as nx
 
 """
 Random regular graph with connection limit of 5:
- - 5000 peers, 500MB: 17 sec
- - 1000 peers, 10GB: p50 294 sec, p100 298 sec (84% ~ 85% speed)
+ - 5000 peers, 500MB: 17 iterations
+ - 1000 peers, 10GB: p50 294 iterations, p100 298 iterations (84% ~ 85% speed)
 """
 PEER_COUNT = 5000
 PIECE_COUNT = 125
-PIECE_TRANSMIT_LIMIT = 10  # Number of pieces uploaded/downloaded per "sec"
+PIECE_TRANSMIT_LIMIT = 10  # Number of pieces uploaded/downloaded per iteration
 DEGREE = 5
 
 


### PR DESCRIPTION
Speed comparison with random regular graph:
- Random regular graph with connection limit of 5
  - 5000 peers, 500MB: 17 iterations
  - 1000 peers, 10GB: p50 294 iterations, p100 298 iterations (84% ~ 85% speed)
- Procedural generated graph with soft connection limit of 5, max connection limit of 20
  - 5000 peers, 500MB: 18 iterations
  - 1000 peers, 10GB: p50 297 iterations, p100 384 iterations (65% ~ 84% speed)
