### PR TITLE
Only allow agent to serve localhost by default

### DIFF
--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -23,6 +23,10 @@ upstream registry-backend {
 server {
   listen {{.port}};
 
+  # Only allow agent to serve localhost request.
+  allow 127.0.0.1;
+  deny all;
+
   {{.client_verification}}
 
   access_log {{.log_dir}}/nginx-access.v2.log;

--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -31,7 +31,7 @@ server {
   {{.client_verification}}
 
   access_log {{.log_dir}}/nginx-access.v2.log;
-  error_log {{.log_dir}}/nginx-error.v2.log debug;
+  error_log {{.log_dir}}/nginx-error.v2.log;
 
   gzip on;
   gzip_types text/plain test/csv application/json;

--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -23,7 +23,7 @@ upstream registry-backend {
 server {
   listen {{.port}};
 
-  # Only allow agent to serve localhost request.
+  # Allow agent to only serve localhost request.
   allow 127.0.0.1;
   deny all;
 

--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -23,14 +23,15 @@ upstream registry-backend {
 server {
   listen {{.port}};
 
-  # Allow agent to only serve localhost request.
+  # Allow agent to only serve localhost and Docker default bridge requests.
   allow 127.0.0.1;
+  allow 172.17.0.1;
   deny all;
 
   {{.client_verification}}
 
   access_log {{.log_dir}}/nginx-access.v2.log;
-  error_log {{.log_dir}}/nginx-error.v2.log;
+  error_log {{.log_dir}}/nginx-error.v2.log debug;
 
   gzip on;
   gzip_types text/plain test/csv application/json;


### PR DESCRIPTION
Since agents are deployed as a localhost registry and serving non-encrypted http requests (by default), it is more secure to deny all requests that are not from localhost.