### PR TITLE
Revamped config package

### DIFF
--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -44,6 +44,7 @@ var (
 	configFile        string
 	zone              string
 	krakenCluster     string
+	secretsFile       string
 
 	rootCmd = &cobra.Command{
 		Short: "kraken-agent implements docker registry interface and downloads data as a peer " +
@@ -69,6 +70,8 @@ func init() {
 		&zone, "zone", "", "", "zone/datacenter name")
 	rootCmd.PersistentFlags().StringVarP(
 		&krakenCluster, "cluster", "", "", "cluster name (e.g. prod01-zone1)")
+	rootCmd.PersistentFlags().StringVarP(
+		&secretsFile, "secrets", "", "", "path to a secrets YAML file to load into configuration")
 }
 
 func Execute() {
@@ -87,6 +90,8 @@ func run() {
 	}
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
+		panic(err)
+	} else if err := configutil.Load(secretsFile, &config); err != nil {
 		panic(err)
 	}
 

--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -91,8 +91,11 @@ func run() {
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
 		panic(err)
-	} else if err := configutil.Load(secretsFile, &config); err != nil {
-		panic(err)
+	}
+	if secretsFile != "" {
+		if err := configutil.Load(secretsFile, &config); err != nil {
+			panic(err)
+		}
 	}
 
 	zlog := log.ConfigureLogger(config.ZapLogging)

--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -73,8 +73,11 @@ func run() {
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
 		panic(err)
-	} else if err := configutil.Load(secretsFile, &config); err != nil {
-		panic(err)
+	}
+	if secretsFile != "" {
+		if err := configutil.Load(secretsFile, &config); err != nil {
+			panic(err)
+		}
 	}
 	log.ConfigureLogger(config.ZapLogging)
 

--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -40,6 +40,7 @@ var (
 	port          int
 	configFile    string
 	krakenCluster string
+	secretsFile   string
 
 	rootCmd = &cobra.Command{
 		Short: "kraken-index handles all tag related requests and cross cluster replications",
@@ -56,6 +57,8 @@ func init() {
 		&configFile, "config", "", "", "configuration file path")
 	rootCmd.PersistentFlags().StringVarP(
 		&krakenCluster, "cluster", "", "", "cluster name (e.g. prod01-zone1)")
+	rootCmd.PersistentFlags().StringVarP(
+		&secretsFile, "secrets", "", "", "path to a secrets YAML file to load into configuration")
 }
 
 func Execute() {
@@ -69,6 +72,8 @@ func run() {
 
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
+		panic(err)
+	} else if err := configutil.Load(secretsFile, &config); err != nil {
 		panic(err)
 	}
 	log.ConfigureLogger(config.ZapLogging)

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -54,6 +54,7 @@ var (
 	configFile         string
 	zone               string
 	krakenCluster      string
+	secretsFile        string
 
 	rootCmd = &cobra.Command{
 		Short: "kraken-origin serves as dedicated seeder in kraken's p2p network.",
@@ -78,6 +79,8 @@ func init() {
 		&zone, "zone", "", "", "zone/datacenter name")
 	rootCmd.PersistentFlags().StringVarP(
 		&krakenCluster, "cluster", "", "", "cluster name (e.g. prod01-zone1)")
+	rootCmd.PersistentFlags().StringVarP(
+		&secretsFile, "secrets", "", "", "path to a secrets YAML file to load into configuration")
 }
 
 func Execute() {
@@ -106,6 +109,8 @@ func run() {
 
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
+		panic(err)
+	} else if err := configutil.Load(secretsFile, &config); err != nil {
 		panic(err)
 	}
 

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -110,8 +110,11 @@ func run() {
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
 		panic(err)
-	} else if err := configutil.Load(secretsFile, &config); err != nil {
-		panic(err)
+	}
+	if secretsFile != "" {
+		if err := configutil.Load(secretsFile, &config); err != nil {
+			panic(err)
+		}
 	}
 
 	zlog := log.ConfigureLogger(config.ZapLogging)

--- a/proxy/cmd/cmd.go
+++ b/proxy/cmd/cmd.go
@@ -33,6 +33,7 @@ var (
 	ports         []int
 	configFile    string
 	krakenCluster string
+	secretsFile   string
 
 	rootCmd = &cobra.Command{
 		Short: "kraken-proxy handles uploads and direct downloads",
@@ -49,6 +50,8 @@ func init() {
 		&configFile, "config", "", "", "configuration file path")
 	rootCmd.PersistentFlags().StringVarP(
 		&krakenCluster, "cluster", "", "", "cluster name (e.g. prod01-zone1)")
+	rootCmd.PersistentFlags().StringVarP(
+		&secretsFile, "secrets", "", "", "path to a secrets YAML file to load into configuration")
 }
 
 func Execute() {
@@ -62,6 +65,8 @@ func run() {
 
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
+		panic(err)
+	} else if err := configutil.Load(secretsFile, &config); err != nil {
 		panic(err)
 	}
 

--- a/proxy/cmd/cmd.go
+++ b/proxy/cmd/cmd.go
@@ -66,8 +66,11 @@ func run() {
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
 		panic(err)
-	} else if err := configutil.Load(secretsFile, &config); err != nil {
-		panic(err)
+	}
+	if secretsFile != "" {
+		if err := configutil.Load(secretsFile, &config); err != nil {
+			panic(err)
+		}
 	}
 
 	log.ConfigureLogger(config.ZapLogging)

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -62,8 +62,11 @@ func run() {
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
 		panic(err)
-	} else if err := configutil.Load(secretsFile, &config); err != nil {
-		panic(err)
+	}
+	if secretsFile != "" {
+		if err := configutil.Load(secretsFile, &config); err != nil {
+			panic(err)
+		}
 	}
 	log.ConfigureLogger(config.ZapLogging)
 

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -33,6 +33,7 @@ var (
 	port          int
 	configFile    string
 	krakenCluster string
+	secretsFile   string
 
 	rootCmd = &cobra.Command{
 		Short: "kraken-tracker keeps track of all the peers and their data in the p2p network.",
@@ -49,6 +50,8 @@ func init() {
 		&configFile, "config", "", "", "configuration file path")
 	rootCmd.PersistentFlags().StringVarP(
 		&krakenCluster, "cluster", "", "", "cluster name (e.g. prod01-zone1)")
+	rootCmd.PersistentFlags().StringVarP(
+		&secretsFile, "secrets", "", "", "path to a secrets YAML file to load into configuration")
 }
 
 func Execute() {
@@ -58,6 +61,8 @@ func Execute() {
 func run() {
 	var config Config
 	if err := configutil.Load(configFile, &config); err != nil {
+		panic(err)
+	} else if err := configutil.Load(secretsFile, &config); err != nil {
 		panic(err)
 	}
 	log.ConfigureLogger(config.ZapLogging)

--- a/utils/configutil/config.go
+++ b/utils/configutil/config.go
@@ -20,15 +20,10 @@
 // extends: base.yaml
 //
 // There is no multiple inheritance supported. Dependency tree suppossed to
-// form a directed acyclic graph(DAG).
+// form a linked list.
 //
 //
 // Values from multiple configurations within the same hierarchy are deep merged
-//
-// Package support multiple configuraton directories potentially having multiple files
-// with the the same name. In this the we just follow the path in extends and load all
-// the file accroding to the relative directory, i.e configA: base.yaml production.yaml(extends base.yaml), configB: base.yaml the load sequance
-// will be the following: configA(base.yaml), configA(production.yaml)
 //
 // Note regarding configuration merging:
 //   Array defined in YAML will be overriden based on load sequence.
@@ -63,23 +58,13 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/uber/kraken/utils/stringset"
 
 	"gopkg.in/validator.v2"
 	"gopkg.in/yaml.v2"
-)
-
-const (
-	configDirKey = "UBER_CONFIG_DIR"
-
-	configDir       = "config"
-	secretsFile     = "secrets.yaml"
-	configSeparator = ":"
 )
 
 // ErrNoFilesToLoad is returned when you attemp to call LoadFiles without valid
@@ -106,6 +91,7 @@ func (e ValidationError) ErrForField(name string) error {
 	return e.errorMap[name]
 }
 
+// Error implements the `error` interface.
 func (e ValidationError) Error() string {
 	var w bytes.Buffer
 
@@ -117,111 +103,70 @@ func (e ValidationError) Error() string {
 	return w.String()
 }
 
-// FilterCandidates filters candidate config files into only the ones that
-// exist.
-func FilterCandidates(fname string) ([]string, error) {
-	realConfigDirs := []string{configDir}
-	// Allow overriding the directory config is loaded from, useful for tests
-	// inside subdirectories when the config dir is at the top-level of a
-	// project.
-	if configRoot := os.Getenv(configDirKey); configRoot != "" {
-		realConfigDirs = strings.Split(configRoot, configSeparator)
+// Load loads configuration based on config file name. It will
+// follow extends directives and do a deep merge of those config
+// files.
+func Load(filename string, config interface{}) error {
+	filenames, err := resolveExtends(filename, readExtend)
+	if err != nil {
+		return err
 	}
-	return filterCandidatesFromDirs(fname, realConfigDirs)
+	return loadFiles(config, filenames...)
+}
+
+type getExtend func(filename string) (extends string, err error)
+
+// resolveExtends returns the list of config paths that the original config `filename`
+// points to.
+func resolveExtends(filename string, extendReader getExtend) ([]string, error) {
+	filenames := []string{filename}
+	fileSet := make(stringset.Set)
+	for {
+		extends, err := extendReader(filename)
+		if err != nil {
+			return nil, err
+		} else if extends == "" {
+			break
+		}
+
+		// If the file path of the extends field in the config is not absolute
+		// we assume that it is in the same directory as the current config
+		// file.
+		if !filepath.IsAbs(extends) {
+			extends = path.Join(filepath.Dir(filename), extends)
+		}
+
+		// Prevent circular references.
+		if fileSet.Has(extends) {
+			return nil, ErrCycleRef
+		}
+
+		filenames = append([]string{extends}, filenames...)
+		fileSet.Add(extends)
+		filename = extends
+	}
+	return filenames, nil
 }
 
 func readExtend(configFile string) (string, error) {
-	var cfg Extends
-
 	data, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		return "", err
 	}
 
+	var cfg Extends
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return "", fmt.Errorf("unmarshal %s: %s", configFile, err)
 	}
 	return cfg.Extends, nil
 }
 
-func getCandidate(fname string, dirs []string) string {
-	candidate := ""
-	for _, realConfigDir := range dirs {
-		configFile := path.Join(realConfigDir, fname)
-		if _, err := os.Stat(configFile); err == nil {
-			candidate = configFile
-		}
-	}
-	return candidate
-}
-
-func filterCandidatesFromDirs(fname string, dirs []string) ([]string, error) {
-	var paths []string
-	cSet := make(stringset.Set)
-
-	// Go through all the 'extends' hierarchy until there is no base anymore or
-	// some reference cycles have been detected.
-	cSet.Add(fname)
-
-	candidate := getCandidate(fname, dirs)
-	fmt.Fprintf(os.Stderr, "candidate: %s\n", candidate)
-	if candidate == "" {
-		return nil, ErrNoFilesToLoad
-	}
-
-	for {
-		extends, err := readExtend(candidate)
-		if err != nil {
-			return nil, err
-		}
-
-		paths = append([]string{candidate}, paths...)
-		if extends != "" {
-			// Prevent circular references.
-			if !cSet.Has(extends) {
-				candidate = path.Join(filepath.Dir(candidate), extends)
-				cSet.Add(extends)
-			} else {
-				return nil, ErrCycleRef
-			}
-		} else {
-			break
-		}
-	}
-
-	// Append secrets.
-	candidate = getCandidate(secretsFile, dirs)
-	if candidate != "" {
-		paths = append(paths, candidate)
-	}
-
-	return paths, nil
-}
-
-// Load loads configuration based on config file name.
-// If config directory cannot be derived from file name, get it from environment
-// variables.
-func Load(fname string, config interface{}) error {
-	candidates, err := filterCandidatesFromDirs(
-		filepath.Base(fname), []string{filepath.Dir(fname)})
-	if err != nil && err != ErrNoFilesToLoad {
-		return fmt.Errorf("find config under %s: %s", filepath.Dir(fname), err)
-	} else if err == ErrNoFilesToLoad {
-		candidates, err = FilterCandidates(fname)
-		if err != nil {
-			return fmt.Errorf(
-				"find config under %s and %s: %s", filepath.Dir(fname), configDirKey, err)
-		}
-	}
-
-	return loadFiles(config, candidates...)
-}
-
-// LoadFiles loads a list of files, deep-merging values.
+// loadFiles loads a list of files, deep-merging values.
 func loadFiles(config interface{}, fnames ...string) error {
 	if len(fnames) == 0 {
 		return ErrNoFilesToLoad
 	}
+
 	for _, fname := range fnames {
 		data, err := ioutil.ReadFile(fname)
 		if err != nil {

--- a/utils/configutil/config_test.go
+++ b/utils/configutil/config_test.go
@@ -125,7 +125,7 @@ func TestLoadFilesExtends(t *testing.T) {
 	defer os.Remove(partial)
 
 	var cfg configuration
-	err := loadFiles(&cfg, fname, partial)
+	err := loadFiles(&cfg, []string{fname, partial})
 	require.NoError(err)
 
 	require.Equal(8080, cfg.BufferSpace)
@@ -177,7 +177,7 @@ func TestLoadFilesValidateOnce(t *testing.T) {
 
 	// But merging load has no error.
 	var mergedCfg configuration
-	err = loadFiles(&mergedCfg, fname1, fname2)
+	err = loadFiles(&mergedCfg, []string{fname1, fname2})
 	require.NoError(err)
 
 	require.Equal("localhost:8080", mergedCfg.ListenAddress)

--- a/utils/configutil/config_test.go
+++ b/utils/configutil/config_test.go
@@ -311,222 +311,53 @@ func TestExtendsConfigCircularRef(t *testing.T) {
 	require.Contains(err.Error(), "cyclic reference in configuration extends detected")
 }
 
-func stubEnv(key, value string) func() {
-	old := os.Getenv(key)
-	os.Setenv(key, value)
-	return func() {
-		os.Setenv(key, old)
-	}
-}
-
-func TestDefaultConfigFilesWithMultiplyConfigDir(t *testing.T) {
-	defer stubEnv(configDirKey, "config")()
-
-	tests := []struct {
-		ConfigDir string
-		Result    []string
-	}{
-		{
-			ConfigDir: "testdata/multiple/configA:testdata/multiple/configB",
-			Result: []string{
-				"testdata/multiple/configB/base.yaml",
-				"testdata/multiple/configB/production.yaml",
-				"testdata/multiple/configB/production-zone2.yaml"},
-		},
-		{
-			ConfigDir: "./testdata/multiple/configA:./testdata/multiple/configB:./random/",
-			Result: []string{
-				"testdata/multiple/configB/base.yaml",
-				"testdata/multiple/configB/production.yaml",
-				"testdata/multiple/configB/production-zone2.yaml"},
-		},
-		{
-			ConfigDir: "./testdata/multiple/configA:",
-			Result: []string{
-				"testdata/multiple/configA/base.yaml",
-				"testdata/multiple/configA/production.yaml",
-				"testdata/multiple/configA/production-zone2.yaml"},
-		},
-	}
-
-	for _, tt := range tests {
-		require := require.New(t)
-
-		os.Setenv(configDirKey, tt.ConfigDir)
-		files, err := FilterCandidates("production-zone2.yaml")
-		require.NoError(err)
-		require.Equal(tt.Result, files, "config files mismatch for %s", tt.ConfigDir)
-	}
-}
-
-func TestLoadSingleConfigDir(t *testing.T) {
+func TestResolveExtends(t *testing.T) {
 	require := require.New(t)
 
-	defer stubEnv(configDirKey, "testdata/single")()
-
-	config := &configuration{}
-	err := Load("test.yaml", config)
-	require.NoError(err, "failed to load config from %v", os.Getenv(configDirKey))
-
-	require.Equal(&configuration{
-		ListenAddress: "127.0.0.1:8080",
-		BufferSpace:   9000,
-		Servers:       []string{"127.0.0.1:01", "127.0.0.1:02"},
-		Secret:        "shh",
-	}, config, "configs mismatch for %s", os.Getenv(configDirKey))
-}
-
-func loadMultipleConfigDir(require *require.Assertions, dir string) *configuration {
-	defer stubEnv(configDirKey, dir)()
-
-	config := &configuration{}
-	err := Load("production-zone2.yaml", config)
-	require.NoError(err, "failed to load config from %v", os.Getenv(configDirKey))
-	return config
-}
-
-func TestLoadMultipleConfigDir(t *testing.T) {
 	tests := []struct {
-		ConfigDir     string
-		Configuration configuration
+		fpath    string
+		extends  map[string]string
+		expected []string
+		err      error
 	}{
 		{
-			ConfigDir: "testdata/multiple/configA:testdata/multiple/configB",
-			Configuration: configuration{
-				ListenAddress: "127.0.0.1:2",
-				BufferSpace:   2000,
-				Servers:       []string{"127.0.0.1:02"}, // each file contains single config attribute
-				Nodes: map[string]string{ // map in each config file will be merged
-					"configBProdZone2": "nodeB",
-				},
-			},
+			fpath:    "/configs/c1",
+			extends:  map[string]string{},
+			expected: []string{"/configs/c1"},
 		},
 		{
-			ConfigDir: "testdata/multiple/configB:testdata/multiple/configA", // each file contains single config attribute
-			Configuration: configuration{
-				ListenAddress: "127.0.0.1:1",
-				BufferSpace:   1000,
-				Servers:       []string{"127.0.0.1:01"},
-				Nodes: map[string]string{
-					"configAProdZone2": "nodeA",
-				},
-			},
+			fpath:    "/configs/c1",
+			extends:  map[string]string{"/configs/c1": "/configs/c2"},
+			expected: []string{"/configs/c2", "/configs/c1"},
 		},
 		{
-			ConfigDir: "testdata/multiple/configA:testdata/multiple/configB:testdata/multiple/configC", // each file contains single config attribute
-			Configuration: configuration{
-				ListenAddress: "127.0.0.1:3",
-				BufferSpace:   3000,
-				Servers:       []string{"127.0.0.1:03"},
-				Nodes: map[string]string{
-					"configCProdZone2": "nodeC",
-				},
-			},
+			fpath:    "/configs/c1",
+			extends:  map[string]string{"/configs/c1": "c2"},
+			expected: []string{"/configs/c2", "/configs/c1"},
 		},
 		{
-			ConfigDir: "testdata/multiple/configB:testdata/multiple/configC:testdata/multiple/configA", // each file contains single config attribute
-			Configuration: configuration{
-				ListenAddress: "127.0.0.1:1",
-				BufferSpace:   1000,
-				Servers:       []string{"127.0.0.1:01"},
-				Nodes: map[string]string{
-					"configAProdZone2": "nodeA",
-				},
-			},
+			fpath:    "/configs/c1",
+			extends:  map[string]string{"/configs/c1": "c2", "/configs/c2": "c1"},
+			expected: nil,
+			err:      ErrCycleRef,
 		},
 		{
-			ConfigDir: "testdata/multiple/configA:testdata/configFullD", // one file contains single config attribute and one file contains whole config attributes
-			Configuration: configuration{
-				ListenAddress: "configFullDProdZone2:03",
-				BufferSpace:   3000,
-				Servers:       []string{"configFullDProdZone2:03", "configFullDProdZone2:04"},
-			},
-		},
-		{
-			ConfigDir: "testdata/configFullD:testdata/multiple/configA", // one file contains single config attribute and one file contains whole config attributes
-			Configuration: configuration{
-				ListenAddress: "127.0.0.1:1",
-				BufferSpace:   1000,
-				Servers:       []string{"127.0.0.1:01"},
-				Nodes: map[string]string{
-					"configAProdZone2": "nodeA",
-				},
-			},
+			fpath:    "/configs/c1",
+			extends:  map[string]string{"/configs/c1": "/etc/c2", "/etc/c2": "c3"},
+			expected: []string{"/etc/c3", "/etc/c2", "/configs/c1"},
 		},
 	}
 
 	for _, tt := range tests {
-		require := require.New(t)
-
-		config := loadMultipleConfigDir(require, tt.ConfigDir)
-		require.Equal(&tt.Configuration, config, "configs mismatch for %s", tt.ConfigDir)
-	}
-}
-
-func TestLoadMultipleConfigDirPriorityFullConflict(t *testing.T) {
-	tests := []struct {
-		ConfigDir     string
-		Configuration configuration
-	}{
-		{
-			ConfigDir: "testdata/configFullD:testdata/configFullE",
-			Configuration: configuration{
-				ListenAddress: "configFullEProdZone2:03",
-				BufferSpace:   6000,
-				Servers:       []string{"configFullEProdZone2:03", "configFullEProdZone2:04"},
-			},
-		},
-		{
-			ConfigDir: "testdata/configFullE:testdata/configFullD",
-			Configuration: configuration{
-				ListenAddress: "configFullDProdZone2:03",
-				BufferSpace:   3000,
-				Servers:       []string{"configFullDProdZone2:03", "configFullDProdZone2:04"},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		require := require.New(t)
-
-		config := loadMultipleConfigDir(require, tt.ConfigDir)
-		require.Equal(&tt.Configuration, config, "configs mismatch for %s", tt.ConfigDir)
-	}
-}
-
-func TestLoadMultipleConfigDirPriorityRelativeExtends(t *testing.T) {
-	tests := []struct {
-		ConfigDir     string
-		Configuration configuration
-	}{
-		{
-			ConfigDir: "testdata/multiple/configF:testdata/multiple/configG",
-			Configuration: configuration{
-				ListenAddress: "127.0.0.1:1",
-				BufferSpace:   1000,
-				Servers:       []string{"127.0.0.1:05"},
-				Nodes: map[string]string{
-					"configGProdZone2": "nodeG",
-				},
-			},
-		},
-		{
-			ConfigDir: "testdata/multiple/configG:testdata/multiple/configF",
-			Configuration: configuration{
-				ListenAddress: "127.0.0.1:1",
-				BufferSpace:   1000,
-				Servers:       []string{"127.0.0.1:04"},
-				Nodes: map[string]string{
-					"configFProdZone2": "nodeF",
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		require := require.New(t)
-
-		config := loadMultipleConfigDir(require, tt.ConfigDir)
-		require.Equal(&tt.Configuration, config, "configs mismatch for %s", tt.ConfigDir)
+		fn := func(filename string) (string, error) {
+			target, found := tt.extends[filename]
+			if !found {
+				return "", nil
+			}
+			return target, nil
+		}
+		filenames, err := resolveExtends(tt.fpath, fn)
+		require.Equal(tt.err, err)
+		require.Equal(tt.expected, filenames)
 	}
 }


### PR DESCRIPTION
We no longer have complex loading logic for configuration files, and support absolute path extends in the yaml.

This also includes a breaking change: `UBER_CONFIG_DIR` is no longer supported.