### PR TITLE
Fix go1.12 incompatible tls test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 
 go:
   - 1.11.4
+  - 1.12.x
 
 services:
   - docker

--- a/utils/httputil/tls_test.go
+++ b/utils/httputil/tls_test.go
@@ -211,7 +211,7 @@ func TestTLSClientBadAuth(t *testing.T) {
 	badtls, err := badConfig.BuildClient()
 	require.NoError(err)
 
-	_, err = Get("https://"+addr+"/", SendTLS(badtls))
+	_, err = Get("https://"+addr+"/", SendTLS(badtls), DisableHTTPFallback())
 	require.True(IsNetworkError(err))
 }
 


### PR DESCRIPTION
Fix https://github.com/uber/kraken/issues/87

In go1.11 and go1.12, the responses returned when http request is sent to https server are different in the fallback mode: 1.11 returns a network error whereas 1.12 returns 400 BadRequest. This change broke one of the unit tests.

In production, however, the two errors are treated the same (failure).