### PR TITLE
WIP Fixing flaky dependency downloading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ services:
 
 install:
   - go get -v || (sleep 30 && go get -v) # Install dependencies listed in the go.mod and go.sum files (twice if flaky network).
-  - go get github.com/axw/gocov/gocov # Install gocov package.
   - go get -v -d google.golang.org/grpc # Install protobuf package.
   - go get -v -d -t github.com/golang/protobuf/...
   - curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,7 @@ services:
   - docker
 
 install:
-  - go get -v || (sleep 30 && go get -v) # Install dependencies listed in the go.mod and go.sum files (twice if flaky network).
-  - go get -v -d google.golang.org/grpc # Install protobuf package.
-  - go get -v -d -t github.com/golang/protobuf/...
-  - curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip
-  - unzip /tmp/protoc.zip -d "$HOME"/protoc
-  - mkdir -p "$HOME"/src && ln -s "$HOME"/protoc "$HOME"/src/protobuf
+  - for i in $(seq 1 5); do (go get -v && break) || sleep 30; done # Install dependencies listed in the go.mod and go.sum files.
 
 env:
   - PATH=$HOME/protoc/bin:$PATH GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ services:
   - docker
 
 install:
-  # gocov
-  - go get github.com/axw/gocov/gocov
-  # protobuf
-  - go get -v -d google.golang.org/grpc
+  - go get -v || (sleep 30 && go get -v) # Install dependencies listed in the go.mod and go.sum files (twice if flaky network).
+  - go get github.com/axw/gocov/gocov # Install gocov package.
+  - go get -v -d google.golang.org/grpc # Install protobuf package.
   - go get -v -d -t github.com/golang/protobuf/...
   - curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip
   - unzip /tmp/protoc.zip -d "$HOME"/protoc

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9or
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:Fv9bK1Q+ly/ROk4aJsVMeuIwPel4bEnD8EPiI91nZMg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
-github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aws/aws-sdk-go v1.17.6 h1:6vyz02W06Ik1Wps7vL00pb+ODHvihrY/7J/ko/RkctU=
 github.com/aws/aws-sdk-go v1.17.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=


### PR DESCRIPTION
It looks like theres something incompatible between travis and the golang.org/x servers, leading to lots of failed dependency downloads. This should mitigate a lot of the issues travis has been having by adding a simple `sleep + retry` to the dep downloads.