### PR TITLE
Scope tag replication failure metrics by destination

### DIFF
--- a/lib/persistedretry/interfaces.go
+++ b/lib/persistedretry/interfaces.go
@@ -20,6 +20,10 @@ type Task interface {
 	GetLastAttempt() time.Time
 	GetFailures() int
 	Ready() bool
+
+	// Tags returns tags describing the context of the task, which can be
+	// included on metrics to group related instances of a task.
+	Tags() map[string]string
 }
 
 // Store provides persisted storage for tasks.

--- a/lib/persistedretry/manager.go
+++ b/lib/persistedretry/manager.go
@@ -251,7 +251,7 @@ func (m *manager) exec(t Task) error {
 		log.With(
 			"task", t,
 			"failures", t.GetFailures()).Errorf("Task failed: %s", err)
-		m.stats.Counter("task_failures").Inc(1)
+		m.stats.Tagged(t.Tags()).Counter("task_failures").Inc(1)
 		return nil
 	}
 	if err := m.store.Remove(t); err != nil {

--- a/lib/persistedretry/manager_test.go
+++ b/lib/persistedretry/manager_test.go
@@ -152,6 +152,7 @@ func TestManagerAddTaskFail(t *testing.T) {
 		mocks.executor.EXPECT().Exec(task).Return(errors.New("task failed")),
 		mocks.store.EXPECT().MarkFailed(task).Return(nil),
 		task.EXPECT().GetFailures().Return(1),
+		task.EXPECT().Tags().Return(nil),
 	)
 
 	m, err := mocks.new()

--- a/lib/persistedretry/tagreplication/task.go
+++ b/lib/persistedretry/tagreplication/task.go
@@ -69,3 +69,10 @@ func (t *Task) GetFailures() int {
 func (t *Task) Ready() bool {
 	return time.Since(t.CreatedAt) >= t.Delay
 }
+
+// Tags returns the replication destination.
+func (t *Task) Tags() map[string]string {
+	return map[string]string{
+		"dest": t.Destination,
+	}
+}

--- a/lib/persistedretry/writeback/task.go
+++ b/lib/persistedretry/writeback/task.go
@@ -61,3 +61,8 @@ func (t *Task) GetFailures() int {
 func (t *Task) Ready() bool {
 	return time.Since(t.CreatedAt) >= t.Delay
 }
+
+// Tags is unused.
+func (t *Task) Tags() map[string]string {
+	return nil
+}

--- a/mocks/lib/persistedretry/task.go
+++ b/mocks/lib/persistedretry/task.go
@@ -74,3 +74,17 @@ func (mr *MockTaskMockRecorder) Ready() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockTask)(nil).Ready))
 }
+
+// Tags mocks base method
+func (m *MockTask) Tags() map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Tags")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// Tags indicates an expected call of Tags
+func (mr *MockTaskMockRecorder) Tags() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tags", reflect.TypeOf((*MockTask)(nil).Tags))
+}


### PR DESCRIPTION
Currently, our monitoring against tag replication failures is very confusing because failures to replicate are almost always caused by the destination being broken, not the source. Thus, when a cluster breaks, all other clusters start to alert on tag replication failures. The operator is then forced to deduce which destination is broken through process of elimination.

With this change, we can scope alerts by destination and create more sane monitoring.