### PR TITLE
Simple helm chart added

### DIFF
--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,5 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+.git

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,13 @@
+name: kraken
+description: P2P Docker registry capable of distributing TBs of data in seconds
+version: 0.1.1
+kubeVersion: ">=1.10.0"
+keywords:
+  - http
+  - docker
+  - registry
+  - p2p
+home: https://github.com/uber/kraken/helm
+maintainers:
+  - name: Antoine Pourchet
+    email: antoine.pourchet@gmail.com

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/* vim: set filetype=mustache: */}}
+
+
+{{- define "trackers" -}}
+tracker:
+  hosts:
+    static:
+{{- range $i, $e := until (int .Values.num_trackers) }}
+      - kraken-tracker-{{$i}}:80
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "origins" -}}
+origin:
+  hosts:
+    static:
+{{- range $i, $e := until (int .Values.num_origins) }}
+      - kraken-origin-{{$i}}:80
+{{- end -}}
+{{- end -}}
+
+{{- define "origin-cluster" -}}
+cluster:
+  static:
+{{- range $i, $e := until (int .Values.num_origins) }}
+    - kraken-origin-{{$i}}:80
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "build-index" -}}
+build_index:
+  hosts:
+    static:
+{{- range $i, $e := until (int .Values.num_build_index) }}
+      - kraken-build-index-{{$i}}:80
+{{- end -}}
+{{- end -}}
+
+{{- define "build-index-cluster" -}}
+cluster:
+  hosts:
+    static:
+{{- range $i, $e := until (int .Values.num_build_index) }}
+      - kraken-build-index-{{$i}}:80
+{{- end -}}
+{{- end -}}
+
+
+
+{{- define "library-namespace" -}}
+- namespace: library/.*
+  backend:
+    registry_blob:
+      address: index.docker.io
+      security:
+        basic:
+          username: ""
+          password: ""
+{{- end -}}
+
+{{- define "tls" -}}
+tls:
+  client:
+    disabled: true
+  server:
+    disabled: true
+{{- end -}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -4,10 +4,7 @@
 {{- define "trackers" -}}
 tracker:
   hosts:
-    static:
-{{- range $i, $e := until (int .Values.num_trackers) }}
-      - kraken-tracker-{{$i}}:80
-{{- end -}}
+    dns: kraken-tracker:80
 {{- end -}}
 
 
@@ -15,18 +12,12 @@ tracker:
 {{- define "origins" -}}
 origin:
   hosts:
-    static:
-{{- range $i, $e := until (int .Values.num_origins) }}
-      - kraken-origin-{{$i}}:80
-{{- end -}}
+    dns: kraken-origin:80
 {{- end -}}
 
 {{- define "origin-cluster" -}}
 cluster:
-  static:
-{{- range $i, $e := until (int .Values.num_origins) }}
-    - kraken-origin-{{$i}}:80
-{{- end -}}
+  dns: kraken-origin:80
 {{- end -}}
 
 
@@ -34,19 +25,13 @@ cluster:
 {{- define "build-index" -}}
 build_index:
   hosts:
-    static:
-{{- range $i, $e := until (int .Values.num_build_index) }}
-      - kraken-build-index-{{$i}}:80
-{{- end -}}
+    dns: kraken-build-index:80
 {{- end -}}
 
 {{- define "build-index-cluster" -}}
 cluster:
   hosts:
-    static:
-{{- range $i, $e := until (int .Values.num_build_index) }}
-      - kraken-build-index-{{$i}}:80
-{{- end -}}
+    dns: kraken-build-index:80
 {{- end -}}
 
 

--- a/helm/templates/agents.yaml
+++ b/helm/templates/agents.yaml
@@ -46,4 +46,4 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 8081
-    nodePort: {{ .Values.agent_registry_port }}
+    nodePort: {{ .Values.kraken.registry_port }}

--- a/helm/templates/agents.yaml
+++ b/helm/templates/agents.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: gcr.io/uber-container-tools/kraken-agent:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-agent:{{ .Values.kraken.tag }}
         command:
         - /usr/bin/kraken-agent
         - --config=/etc/config/agent.yaml

--- a/helm/templates/agents.yaml
+++ b/helm/templates/agents.yaml
@@ -1,31 +1,29 @@
-{{- range $i, $e := until (int .Values.num_trackers) }}
----
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-agent
   labels:
     kraken: 'true'
 spec:
-  replicas: 1
   selector:
     matchLabels:
-      kraken-app: tracker-{{$i}}
+      kraken-app: agent
   template:
     metadata:
       labels:
         kraken: 'true'
-        kraken-app: tracker-{{$i}}
+        kraken-app: agent
+        kraken-peer: 'true'
     spec:
       containers:
-      - name: redis
-        image: redis:5.0
       - name: main
-        image: gcr.io/uber-container-tools/kraken-tracker:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-agent:v0.1.1
         command:
-        - /usr/bin/kraken-tracker
-        - --config=/etc/config/tracker.yaml
-        - --port=80
+        - /usr/bin/kraken-agent
+        - --config=/etc/config/agent.yaml
+        - --agent-server-port=80
+        - --peer-port=8080
+        - --agent-registry-port=8081
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -37,14 +35,15 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-agent-registry
   labels:
     kraken: 'true'
 spec:
+  type: NodePort
   selector:
-    kraken-app: tracker-{{$i}}
+    kraken-app: agent
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 80
-{{- end -}}
+    targetPort: 8081
+    nodePort: {{ .Values.agent_registry_port }}

--- a/helm/templates/agents.yaml
+++ b/helm/templates/agents.yaml
@@ -35,7 +35,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-agent-registry
+  name: kraken-agent
   labels:
     kraken: 'true'
 spec:

--- a/helm/templates/build-index.yaml
+++ b/helm/templates/build-index.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     kraken: 'true'
 spec:
-  replicas: {{ .Values.num_build_index }}
+  replicas: {{ .Values.build_index.replicas }}
   selector:
     matchLabels:
       kraken-app: build-index
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: gcr.io/uber-container-tools/kraken-build-index:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-build-index:{{ .Values.kraken.tag }}
         command:
         - /bin/bash
         - -c

--- a/helm/templates/build-index.yaml
+++ b/helm/templates/build-index.yaml
@@ -1,29 +1,27 @@
-{{- range $i, $e := until (int .Values.num_trackers) }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kraken-build-index-{{$i}}
+  name: kraken-build-index
   labels:
     kraken: 'true'
 spec:
-  replicas: 1
+  replicas: {{ .Values.num_build_index }}
   selector:
     matchLabels:
-      kraken-app: build-index-{{$i}}
+      kraken-app: build-index
   template:
     metadata:
       labels:
         kraken: 'true'
-        kraken-app: build-index-{{$i}}
+        kraken-app: build-index
     spec:
       containers:
       - name: main
         image: gcr.io/uber-container-tools/kraken-build-index:v0.1.1
         command:
-        - /usr/bin/kraken-build-index
-        - --config=/etc/config/build-index.yaml
-        - --port=80
+        - /bin/bash
+        - -c
+        - "sleep 30 && /usr/bin/kraken-build-index --config=/etc/config/build-index.yaml --port=80"
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -35,14 +33,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-build-index-{{$i}}
+  name: kraken-build-index
   labels:
     kraken: 'true'
 spec:
+  clusterIP: None
   selector:
-    kraken-app: build-index-{{$i}}
+    kraken-app: build-index
   ports:
   - protocol: TCP
     port: 80
     targetPort: 80
-{{- end -}}

--- a/helm/templates/build-index.yaml
+++ b/helm/templates/build-index.yaml
@@ -3,28 +3,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-build-index-{{$i}}
   labels:
     kraken: 'true'
 spec:
   replicas: 1
   selector:
     matchLabels:
-      kraken-app: tracker-{{$i}}
+      kraken-app: build-index-{{$i}}
   template:
     metadata:
       labels:
         kraken: 'true'
-        kraken-app: tracker-{{$i}}
+        kraken-app: build-index-{{$i}}
     spec:
       containers:
-      - name: redis
-        image: redis:5.0
       - name: main
-        image: gcr.io/uber-container-tools/kraken-tracker:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-build-index:v0.1.1
         command:
-        - /usr/bin/kraken-tracker
-        - --config=/etc/config/tracker.yaml
+        - /usr/bin/kraken-build-index
+        - --config=/etc/config/build-index.yaml
         - --port=80
         volumeMounts:
         - name: config
@@ -37,12 +35,12 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-build-index-{{$i}}
   labels:
     kraken: 'true'
 spec:
   selector:
-    kraken-app: tracker-{{$i}}
+    kraken-app: build-index-{{$i}}
   ports:
   - protocol: TCP
     port: 80

--- a/helm/templates/config.yaml
+++ b/helm/templates/config.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kraken
+data:
+  agent.yaml: |
+    extends: /etc/kraken/config/agent/base.yaml
+    {{- include "tls" . | nindent 4 }}
+    {{- include "trackers" . | nindent 4 }}
+    {{- include "build-index" . | nindent 4 }}
+
+  tracker.yaml: |
+    extends: /etc/kraken/config/tracker/base.yaml
+    {{- include "tls" . | nindent 4 }}
+    {{- include "origins" . | nindent 4 }}
+
+    peerstore:
+      redis:
+        addr: 127.0.0.1:6379
+
+    trackerserver:
+      announce_interval: 3s
+
+    nginx:
+      cache_dir: /tmp/kraken-tracker-nginx/
+
+  origin.yaml: |
+    extends: /etc/kraken/config/origin/base.yaml
+    {{- include "tls" . | nindent 4 }}
+    {{- include "origin-cluster" . | nindent 4 }}
+
+    backends:
+      {{- include "library-namespace" . | nindent 6 }}
+      - namespace: .*
+        backend:
+          testfs:
+            addr: kraken-testfs:80
+            root: blobs
+            name_path: identity
+
+    hashring:
+      max_replica: 2
+
+    writeback:
+      retry_interval: 100ms
+      poll_retries_interval: 250ms
+
+  build-index.yaml: |
+    extends: /etc/kraken/config/build-index/base.yaml
+    {{- include "tls" . | nindent 4 }}
+    {{- include "build-index-cluster" . | nindent 4 }}
+    {{- include "origins" . | nindent 4 }}
+
+    backends:
+      {{- include "library-namespace" . | nindent 6 }}
+      - namespace: .*
+        backend:
+          testfs:
+            addr: kraken-testfs:80
+            root: tags
+            name_path: docker_tag
+
+    remotes: {}
+
+    tag_replication:
+      retry_interval: 100ms
+      poll_retries_interval: 250ms
+
+    tag_types:
+      - namespace: .*
+        type: docker
+        root: tags
+
+    tag_store:
+      write_through: false
+
+    writeback:
+      retry_interval: 100ms
+      poll_retries_interval: 250ms
+
+    nginx:
+      cache_dir: /tmp/kraken-build-index-nginx/
+
+  proxy.yaml: |
+    extends: /etc/kraken/config/proxy/base.yaml
+    {{- include "tls" . | nindent 4 }}
+    {{- include "build-index" . | nindent 4 }}
+    {{- include "origins" . | nindent 4 }}
+
+    nginx:
+      cache_dir: /tmp/kraken-proxy-nginx/

--- a/helm/templates/config.yaml
+++ b/helm/templates/config.yaml
@@ -9,42 +9,6 @@ data:
     {{- include "trackers" . | nindent 4 }}
     {{- include "build-index" . | nindent 4 }}
 
-  tracker.yaml: |
-    extends: /etc/kraken/config/tracker/base.yaml
-    {{- include "tls" . | nindent 4 }}
-    {{- include "origins" . | nindent 4 }}
-
-    peerstore:
-      redis:
-        addr: 127.0.0.1:6379
-
-    trackerserver:
-      announce_interval: 3s
-
-    nginx:
-      cache_dir: /tmp/kraken-tracker-nginx/
-
-  origin.yaml: |
-    extends: /etc/kraken/config/origin/base.yaml
-    {{- include "tls" . | nindent 4 }}
-    {{- include "origin-cluster" . | nindent 4 }}
-
-    backends:
-      {{- include "library-namespace" . | nindent 6 }}
-      - namespace: .*
-        backend:
-          testfs:
-            addr: kraken-testfs:80
-            root: blobs
-            name_path: identity
-
-    hashring:
-      max_replica: 2
-
-    writeback:
-      retry_interval: 100ms
-      poll_retries_interval: 250ms
-
   build-index.yaml: |
     extends: /etc/kraken/config/build-index/base.yaml
     {{- include "tls" . | nindent 4 }}
@@ -52,7 +16,14 @@ data:
     {{- include "origins" . | nindent 4 }}
 
     backends:
-      {{- include "library-namespace" . | nindent 6 }}
+      - namespace: library/.*
+        backend:
+          registry_tag:
+            address: index.docker.io
+            security:
+              basic:
+                username: ""
+                password: ""
       - namespace: .*
         backend:
           testfs:
@@ -81,6 +52,27 @@ data:
     nginx:
       cache_dir: /tmp/kraken-build-index-nginx/
 
+  origin.yaml: |
+    extends: /etc/kraken/config/origin/base.yaml
+    {{- include "tls" . | nindent 4 }}
+    {{- include "origin-cluster" . | nindent 4 }}
+
+    backends:
+      {{- include "library-namespace" . | nindent 6 }}
+      - namespace: .*
+        backend:
+          testfs:
+            addr: kraken-testfs:80
+            root: blobs
+            name_path: identity
+
+    hashring:
+      max_replica: 2
+
+    writeback:
+      retry_interval: 100ms
+      poll_retries_interval: 250ms
+
   proxy.yaml: |
     extends: /etc/kraken/config/proxy/base.yaml
     {{- include "tls" . | nindent 4 }}
@@ -89,3 +81,18 @@ data:
 
     nginx:
       cache_dir: /tmp/kraken-proxy-nginx/
+
+  tracker.yaml: |
+    extends: /etc/kraken/config/tracker/base.yaml
+    {{- include "tls" . | nindent 4 }}
+    {{- include "origins" . | nindent 4 }}
+
+    peerstore:
+      redis:
+        addr: 127.0.0.1:6379
+
+    trackerserver:
+      announce_interval: 3s
+
+    nginx:
+      cache_dir: /tmp/kraken-tracker-nginx/

--- a/helm/templates/origins.yaml
+++ b/helm/templates/origins.yaml
@@ -3,29 +3,30 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-origin-{{$i}}
   labels:
     kraken: 'true'
 spec:
   replicas: 1
   selector:
     matchLabels:
-      kraken-app: tracker-{{$i}}
+      kraken-app: origin-{{$i}}
   template:
     metadata:
       labels:
         kraken: 'true'
-        kraken-app: tracker-{{$i}}
+        kraken-app: origin-{{$i}}
+        kraken-peer: 'true'
     spec:
       containers:
-      - name: redis
-        image: redis:5.0
       - name: main
-        image: gcr.io/uber-container-tools/kraken-tracker:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-origin:v0.1.1
         command:
-        - /usr/bin/kraken-tracker
-        - --config=/etc/config/tracker.yaml
-        - --port=80
+        - /usr/bin/kraken-origin
+        - --config=/etc/config/origin.yaml
+        - --blobserver-hostname=kraken-origin-0
+        - --blobserver-port=80
+        - --peer-port=8080
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -37,12 +38,12 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-origin-{{$i}}
   labels:
     kraken: 'true'
 spec:
   selector:
-    kraken-app: tracker-{{$i}}
+    kraken-app: origin-{{$i}}
   ports:
   - protocol: TCP
     port: 80

--- a/helm/templates/origins.yaml
+++ b/helm/templates/origins.yaml
@@ -1,32 +1,28 @@
-{{- range $i, $e := until (int .Values.num_trackers) }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kraken-origin-{{$i}}
+  name: kraken-origin
   labels:
     kraken: 'true'
 spec:
-  replicas: 1
+  replicas: {{ .Values.num_origins }}
   selector:
     matchLabels:
-      kraken-app: origin-{{$i}}
+      kraken-app: origin
   template:
     metadata:
       labels:
         kraken: 'true'
-        kraken-app: origin-{{$i}}
+        kraken-app: origin
         kraken-peer: 'true'
     spec:
       containers:
       - name: main
         image: gcr.io/uber-container-tools/kraken-origin:v0.1.1
         command:
-        - /usr/bin/kraken-origin
-        - --config=/etc/config/origin.yaml
-        - --blobserver-hostname=kraken-origin-0
-        - --blobserver-port=80
-        - --peer-port=8080
+        - /bin/bash
+        - -c
+        - "sleep 30 && /usr/bin/kraken-origin --config=/etc/config/origin.yaml --blobserver-hostname=kraken-origin-0 --blobserver-port=80 --peer-port=8080"
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -38,14 +34,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-origin-{{$i}}
+  name: kraken-origin
   labels:
     kraken: 'true'
 spec:
+  clusterIP: None
   selector:
-    kraken-app: origin-{{$i}}
+    kraken-app: origin
   ports:
   - protocol: TCP
     port: 80
     targetPort: 80
-{{- end -}}

--- a/helm/templates/origins.yaml
+++ b/helm/templates/origins.yaml
@@ -22,7 +22,7 @@ spec:
         command:
         - /bin/bash
         - -c
-        - "sleep 30 && /usr/bin/kraken-origin --config=/etc/config/origin.yaml --blobserver-hostname=kraken-origin-0 --blobserver-port=80 --peer-port=8080"
+        - "sleep 30 && /usr/bin/kraken-origin --config=/etc/config/origin.yaml --blobserver-port=80 --peer-port=8080"
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/helm/templates/origins.yaml
+++ b/helm/templates/origins.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     kraken: 'true'
 spec:
-  replicas: {{ .Values.num_origins }}
+  replicas: {{ .Values.origin.replicas }}
   selector:
     matchLabels:
       kraken-app: origin
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: gcr.io/uber-container-tools/kraken-origin:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-origin:{{ .Values.kraken.tag }}
         command:
         - /bin/bash
         - -c

--- a/helm/templates/proxy.yaml
+++ b/helm/templates/proxy.yaml
@@ -1,30 +1,27 @@
-{{- range $i, $e := until (int .Values.num_trackers) }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-proxy
   labels:
     kraken: 'true'
 spec:
-  replicas: 1
+  replicas: {{ .Values.num_proxies }}
   selector:
     matchLabels:
-      kraken-app: tracker-{{$i}}
+      kraken-app: proxy
   template:
     metadata:
       labels:
         kraken: 'true'
-        kraken-app: tracker-{{$i}}
+        kraken-app: proxy
     spec:
       containers:
-      - name: redis
-        image: redis:5.0
       - name: main
-        image: gcr.io/uber-container-tools/kraken-tracker:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-proxy:v0.1.1
         command:
-        - /usr/bin/kraken-tracker
-        - --config=/etc/config/tracker.yaml
+        - /usr/bin/kraken-proxy
+        - --config=/etc/config/proxy.yaml
         - --port=80
         volumeMounts:
         - name: config
@@ -37,14 +34,13 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-proxy
   labels:
     kraken: 'true'
 spec:
   selector:
-    kraken-app: tracker-{{$i}}
+    kraken-app: proxy
   ports:
   - protocol: TCP
     port: 80
     targetPort: 80
-{{- end -}}

--- a/helm/templates/proxy.yaml
+++ b/helm/templates/proxy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     kraken: 'true'
 spec:
-  replicas: {{ .Values.num_proxies }}
+  replicas: {{ .Values.proxy.replicas }}
   selector:
     matchLabels:
       kraken-app: proxy
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: gcr.io/uber-container-tools/kraken-proxy:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-proxy:{{ .Values.kraken.tag }}
         command:
         - /usr/bin/kraken-proxy
         - --config=/etc/config/proxy.yaml

--- a/helm/templates/testfs.yaml
+++ b/helm/templates/testfs.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kraken-testfs
+  labels:
+    kraken: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      kraken-app: testfs
+  template:
+    metadata:
+      labels:
+        kraken: 'true'
+        kraken-app: testfs
+    spec:
+      containers:
+      - name: main
+        image: gcr.io/uber-container-tools/kraken-testfs:v0.1.1
+        command:
+        - /usr/bin/kraken-testfs
+        - --port=80
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: kraken-testfs
+  labels:
+    kraken: 'true'
+spec:
+  selector:
+    kraken-app: testfs
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80

--- a/helm/templates/testfs.yaml
+++ b/helm/templates/testfs.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: gcr.io/uber-container-tools/kraken-testfs:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-testfs:{{ .Values.kraken.tag }}
         command:
         - /usr/bin/kraken-testfs
         - --port=80

--- a/helm/templates/trackers.yaml
+++ b/helm/templates/trackers.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     kraken: 'true'
 spec:
-  replicas: {{ .Values.num_trackers }}
+  replicas: {{ .Values.tracker.replicas }}
   selector:
     matchLabels:
       kraken-app: tracker
@@ -19,7 +19,7 @@ spec:
       - name: redis
         image: redis:5.0
       - name: main
-        image: gcr.io/uber-container-tools/kraken-tracker:v0.1.1
+        image: gcr.io/uber-container-tools/kraken-tracker:{{ .Values.kraken.tag }}
         command:
         - /bin/bash
         - -c

--- a/helm/templates/trackers.yaml
+++ b/helm/templates/trackers.yaml
@@ -1,21 +1,19 @@
-{{- range $i, $e := until (int .Values.num_trackers) }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-tracker
   labels:
     kraken: 'true'
 spec:
-  replicas: 1
+  replicas: {{ .Values.num_trackers }}
   selector:
     matchLabels:
-      kraken-app: tracker-{{$i}}
+      kraken-app: tracker
   template:
     metadata:
       labels:
         kraken: 'true'
-        kraken-app: tracker-{{$i}}
+        kraken-app: tracker
     spec:
       containers:
       - name: redis
@@ -23,9 +21,9 @@ spec:
       - name: main
         image: gcr.io/uber-container-tools/kraken-tracker:v0.1.1
         command:
-        - /usr/bin/kraken-tracker
-        - --config=/etc/config/tracker.yaml
-        - --port=80
+        - /bin/bash
+        - -c
+        - "sleep 30 && /usr/bin/kraken-tracker --config=/etc/config/tracker.yaml --port=80"
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -37,14 +35,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: kraken-tracker-{{$i}}
+  name: kraken-tracker
   labels:
     kraken: 'true'
 spec:
+  clusterIP: None
   selector:
-    kraken-app: tracker-{{$i}}
+    kraken-app: tracker
   ports:
   - protocol: TCP
     port: 80
     targetPort: 80
-{{- end -}}

--- a/helm/templates/trackers.yaml
+++ b/helm/templates/trackers.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kraken-tracker-0
+  labels:
+    kraken: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      kraken-app: tracker-0
+  template:
+    metadata:
+      labels:
+        kraken: 'true'
+        kraken-app: tracker-0
+    spec:
+      containers:
+      - name: redis
+        image: redis:5.0
+      - name: main
+        image: gcr.io/uber-container-tools/kraken-tracker:v0.1.1
+        command:
+        - /usr/bin/kraken-tracker
+        - --config=/etc/config/tracker.yaml
+        - --port=80
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+      volumes:
+      - name: config
+        configMap:
+          name: kraken
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: kraken-tracker-0
+spec:
+  selector:
+    kraken-app: tracker-0
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,15 @@
-num_trackers: 3
-num_build_index: 3
-num_origins: 3
-num_proxies: 1
+kraken:
+  tag: v0.1.1
+  registry_port: 30081
 
-agent_registry_port: 30081
+tracker:
+  replicas: 3
+
+build_index:
+  replicas: 3
+
+origin:
+  replicas: 3
+
+proxy:
+  replicas: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,3 +1,6 @@
-num_trackers: 3
-num_build_index: 3
-num_origins: 3
+num_trackers: 1
+num_build_index: 1
+num_origins: 1
+num_proxies: 1
+
+agent_registry_port: 30081

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,6 @@
-num_trackers: 1
-num_build_index: 1
-num_origins: 1
+num_trackers: 3
+num_build_index: 3
+num_origins: 3
 num_proxies: 1
 
 agent_registry_port: 30081

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,3 @@
+num_trackers: 3
+num_build_index: 3
+num_origins: 3


### PR DESCRIPTION
End result of helm install looks like this:
```
$ kubectl get pods
NAME                                 READY   STATUS    RESTARTS   AGE
demo-6568968d44-2bfwc                1/1     Running   0          6m
kraken-agent-x2555                   1/1     Running   3          5m
kraken-build-index-b9767cd7b-8624l   1/1     Running   0          5m
kraken-build-index-b9767cd7b-gxwxl   1/1     Running   0          5m
kraken-build-index-b9767cd7b-tvtps   1/1     Running   0          5m
kraken-origin-6cccd79f6-4bxgl        1/1     Running   0          5m
kraken-origin-6cccd79f6-lhwh4        1/1     Running   1          5m
kraken-origin-6cccd79f6-qg46w        1/1     Running   0          5m
kraken-proxy-6695ddfc9-gclhq         1/1     Running   0          5m
kraken-testfs-79db8688dc-5kg2n       1/1     Running   0          5m
kraken-tracker-6cb8b9d7fd-9h5ff      2/2     Running   0          5m
kraken-tracker-6cb8b9d7fd-9kxdl      2/2     Running   0          5m
kraken-tracker-6cb8b9d7fd-wb9fh      2/2     Running   0          5m

$ kubectl get services
NAME                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
kraken-agent-registry   NodePort    10.97.253.118   <none>        80:30081/TCP   5m
kraken-build-index      ClusterIP   None            <none>        80/TCP         5m
kraken-origin           ClusterIP   None            <none>        80/TCP         5m
kraken-proxy            ClusterIP   10.99.104.243   <none>        80/TCP         5m
kraken-testfs           ClusterIP   10.99.227.32    <none>        80/TCP         5m
kraken-tracker          ClusterIP   None            <none>        80/TCP         5m
```