### PR TITLE
Add log event for requesting pieces

### DIFF
--- a/lib/torrent/networkevent/events.go
+++ b/lib/torrent/networkevent/events.go
@@ -32,6 +32,7 @@ const (
 	AddActiveConn    Name = "add_active_conn"
 	DropActiveConn   Name = "drop_active_conn"
 	BlacklistConn    Name = "blacklist_conn"
+	RequestPiece     Name = "request_piece"
 	ReceivePiece     Name = "receive_piece"
 	TorrentComplete  Name = "torrent_complete"
 	TorrentCancelled Name = "torrent_cancelled"
@@ -105,7 +106,15 @@ func BlacklistConnEvent(h core.InfoHash, self core.PeerID, peer core.PeerID, dur
 	return e
 }
 
-// ReceivePieceEvent returns an event for a piece received from peer.
+// RequestPieceEvent returns an event for a piece request sent to a peer.
+func RequestPieceEvent(h core.InfoHash, self core.PeerID, peer core.PeerID, piece int) *Event {
+	e := baseEvent(RequestPiece, h, self)
+	e.Peer = peer.String()
+	e.Piece = piece
+	return e
+}
+
+// ReceivePieceEvent returns an event for a piece received from a peer.
 func ReceivePieceEvent(h core.InfoHash, self core.PeerID, peer core.PeerID, piece int) *Event {
 	e := baseEvent(ReceivePiece, h, self)
 	e.Peer = peer.String()

--- a/lib/torrent/scheduler/dispatch/dispatcher.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher.go
@@ -390,8 +390,10 @@ func (d *Dispatcher) maybeSendPieceRequests(p *peer, candidates *bitset.BitSet) 
 			d.pieceRequestManager.MarkUnsent(p.id, i)
 			return false, err
 		}
-		p.pstats.incrementPieceRequestsSent()
-	}
+		d.netevents.Produce(
+			networkevent.RequestPieceEvent(d.torrent.InfoHash(), d.localPeerID, p.id, i))
+			p.pstats.incrementPieceRequestsSent()
+		}
 	return true, nil
 }
 

--- a/lib/torrent/scheduler/scheduler_test.go
+++ b/lib/torrent/scheduler/scheduler_test.go
@@ -348,6 +348,7 @@ func TestNetworkEvents(t *testing.T) {
 	leecherExpected := []*networkevent.Event{
 		networkevent.AddTorrentEvent(h, lid, bitsetutil.FromBools(false), config.ConnState.MaxOpenConnectionsPerTorrent),
 		networkevent.AddActiveConnEvent(h, lid, sid),
+		networkevent.RequestPieceEvent(h, lid, sid, 0),
 		networkevent.ReceivePieceEvent(h, lid, sid, 0),
 		networkevent.TorrentCompleteEvent(h, lid),
 		networkevent.DropActiveConnEvent(h, lid, sid),


### PR DESCRIPTION
Currently, we only log when a piece is received. Logging the requests will
help diagnose performance issues related to piece request scheduling.

This could also be done on the receiving end, but logging on the sending
side makes it semantically more clear alongside the receive piece event.