### PR TITLE
Introduce PortReservation utility to integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ tools/bin/trackerload/trackerload
 
 *.xml
 *.pyc
-env
+venv
 
 # Golang coverage files
 *.out

--- a/Makefile
+++ b/Makefile
@@ -106,28 +106,30 @@ unit-test: vendor
 docker_stop:
 	-docker ps -a --format '{{.Names}}' | grep kraken | while read n; do docker rm -f $$n; done
 
+env:
+	virtualenv --python=$(shell which python2) --setuptools env
+	source env/bin/activate
+	pip install -r requirements-tests.txt
+
 .PHONY: integration
 FILE?=
 NAME?=test_
 USERNAME:=$(shell id -u -n)
 USERID:=$(shell id -u)
-integration: vendor $(LINUX_BINS) docker_stop tools/bin/puller/puller
+integration: env vendor $(LINUX_BINS) docker_stop tools/bin/puller/puller
 	docker build $(BUILD_QUIET) -t kraken-agent:$(PACKAGE_VERSION) -f docker/agent/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-build-index:$(PACKAGE_VERSION) -f docker/build-index/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-origin:$(PACKAGE_VERSION) -f docker/origin/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-proxy:$(PACKAGE_VERSION) -f docker/proxy/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-testfs:$(PACKAGE_VERSION) -f docker/testfs/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-tracker:$(PACKAGE_VERSION) -f docker/tracker/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
-	if [ ! -d env ]; then virtualenv --setuptools env; fi
-	source env/bin/activate
-	env/bin/pip install -r requirements-tests.txt
-	PACKAGE_VERSION=$(PACKAGE_VERSION) env/bin/py.test --timeout=120 -v -k $(NAME) test/python/$(FILE)
+	PACKAGE_VERSION=$(PACKAGE_VERSION) py.test --timeout=120 -v -k $(NAME) test/python/$(FILE)
 
 .PHONY: runtest
 NAME?=test_
-runtest: docker_stop
+runtest: env docker_stop
 	source env/bin/activate
-	env/bin/py.test --timeout=120 -v -k $(NAME) test/python
+	py.test --timeout=120 -v -k $(NAME) test/python
 
 .PHONY: devcluster
 devcluster: vendor $(LINUX_BINS) docker_stop images

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ docker_stop:
 venv: requirements-tests.txt
 	virtualenv --python=$(shell which python2) --setuptools venv
 	source venv/bin/activate
-	pip install -r requirements-tests.txt
+	venv/bin/pip install -r requirements-tests.txt
 
 .PHONY: integration
 FILE?=
@@ -123,13 +123,13 @@ integration: venv vendor $(LINUX_BINS) docker_stop tools/bin/puller/puller
 	docker build $(BUILD_QUIET) -t kraken-proxy:$(PACKAGE_VERSION) -f docker/proxy/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-testfs:$(PACKAGE_VERSION) -f docker/testfs/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-tracker:$(PACKAGE_VERSION) -f docker/tracker/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
-	PACKAGE_VERSION=$(PACKAGE_VERSION) py.test --timeout=120 -v -k $(NAME) test/python/$(FILE)
+	PACKAGE_VERSION=$(PACKAGE_VERSION) venv/bin/py.test --timeout=120 -v -k $(NAME) test/python/$(FILE)
 
 .PHONY: runtest
 NAME?=test_
 runtest: venv docker_stop
 	source venv/bin/activate
-	py.test --timeout=120 -v -k $(NAME) test/python
+	venv/bin/py.test --timeout=120 -v -k $(NAME) test/python
 
 .PHONY: devcluster
 devcluster: vendor $(LINUX_BINS) docker_stop images

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,9 @@ unit-test: vendor
 docker_stop:
 	-docker ps -a --format '{{.Names}}' | grep kraken | while read n; do docker rm -f $$n; done
 
-env:
-	virtualenv --python=$(shell which python2) --setuptools env
-	source env/bin/activate
+venv: requirements-tests.txt
+	virtualenv --python=$(shell which python2) --setuptools venv
+	source venv/bin/activate
 	pip install -r requirements-tests.txt
 
 .PHONY: integration
@@ -116,7 +116,7 @@ FILE?=
 NAME?=test_
 USERNAME:=$(shell id -u -n)
 USERID:=$(shell id -u)
-integration: env vendor $(LINUX_BINS) docker_stop tools/bin/puller/puller
+integration: venv vendor $(LINUX_BINS) docker_stop tools/bin/puller/puller
 	docker build $(BUILD_QUIET) -t kraken-agent:$(PACKAGE_VERSION) -f docker/agent/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-build-index:$(PACKAGE_VERSION) -f docker/build-index/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
 	docker build $(BUILD_QUIET) -t kraken-origin:$(PACKAGE_VERSION) -f docker/origin/Dockerfile --build-arg USERID=$(USERID) --build-arg USERNAME=$(USERNAME) ./
@@ -127,8 +127,8 @@ integration: env vendor $(LINUX_BINS) docker_stop tools/bin/puller/puller
 
 .PHONY: runtest
 NAME?=test_
-runtest: env docker_stop
-	source env/bin/activate
+runtest: venv docker_stop
+	source venv/bin/activate
 	py.test --timeout=120 -v -k $(NAME) test/python
 
 .PHONY: devcluster

--- a/test/python/test_replication.py
+++ b/test/python/test_replication.py
@@ -20,7 +20,7 @@ import pytest
 from conftest import TEST_IMAGE
 
 
-def test_docker_image_replication(one_way_replicas):
+def test_docker_image_replication_success(one_way_replicas):
     one_way_replicas.src.proxy.push(TEST_IMAGE)
 
     # Wait for replication to finish.

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -14,7 +14,47 @@
 from __future__ import absolute_import
 
 import os
+from socket import socket
 from threading import Thread
+
+
+def find_free_port():
+    s = socket()
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class PortReservation(object):
+    """
+    PortReservation is a utility for finding and reserving an open port. Normally,
+    find_free_port is sufficient for components which find an available port and
+    immediately start their container. However, the more consecutive find_free_port
+    calls are made without actually binding to the "free" ports, the higher chance
+    that successive find_free_port calls will return a port twice.
+
+    PortReservation solves this problem by binding a socket to the port until
+    the port is ready to be used, at which point the client can call release
+    to close the socket and assume ownership of the port.
+
+    Obviously this is not bullet-proof and there is a race between releasing
+    the PortReservation and the client binding to the port.
+    """
+
+    def __init__(self):
+        self._sock = socket()
+        self._sock.bind(('', 0))
+        self._open = True
+        self._port = self._sock.getsockname()[1]
+
+    def get(self):
+        return self._port
+
+    def release(self):
+        if self._open:
+            self._sock.close()
+            self._open = False
 
 
 def concurrently_apply(f, inputs):
@@ -47,16 +87,19 @@ def format_insecure_curl(url):
         url,
     ])
 
+
 def tls_opts():
     return {
         'verify': False, ## Set verify=False to disable server cert verification for test only.
     }
+
 
 def tls_opts_with_client_certs():
     return {
         'cert': ('test/tls/client/client.crt', 'test/tls/client/client_decrypted.key'),
         'verify': False, ## Set verify=False to disable server cert verification for test only.
     }
+
 
 def dev_tag(image_name):
     tag = os.getenv("PACKAGE_VERSION", "latest")


### PR DESCRIPTION
Attempts to prevent some integration tests flakiness I've been observing
wrt build-index and origin clusters crashing due to port conflicts. See
PortReservation comment for context.

Also adds `env` as a Makefile target to grease up some friction I had
trying to `make runtest`.