### PR TITLE
Enable gzip only for origin, proxy and agent

### DIFF
--- a/nginx/config/base.go
+++ b/nginx/config/base.go
@@ -124,8 +124,8 @@ http {
   # Gzip Settings
   ##
 
-  gzip on;
-  gzip_disable "msie6";
+  # gzip on;
+  # gzip_disable "msie6";
 
   # gzip_vary on;
   # gzip_proxied any;

--- a/nginx/config/base.go
+++ b/nginx/config/base.go
@@ -124,14 +124,15 @@ http {
   # Gzip Settings
   ##
 
-  # gzip on;
+  gzip off;
+  gzip_disable "msie6";
+
   # gzip_vary on;
   # gzip_proxied any;
   # gzip_comp_level 6;
   # gzip_buffers 16 8k;
   # gzip_http_version 1.1;
 
-  gzip_disable "msie6";
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
   ##

--- a/nginx/config/base.go
+++ b/nginx/config/base.go
@@ -125,14 +125,13 @@ http {
   ##
 
   # gzip on;
-  # gzip_disable "msie6";
-
   # gzip_vary on;
   # gzip_proxied any;
   # gzip_comp_level 6;
   # gzip_buffers 16 8k;
   # gzip_http_version 1.1;
 
+  gzip_disable "msie6";
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
   ##

--- a/nginx/config/origin.go
+++ b/nginx/config/origin.go
@@ -25,6 +25,9 @@ server {
   access_log {{.log_dir}}/nginx-access.log;
   error_log {{.log_dir}}/nginx-error.log;
 
+  gzip on;
+  gzip_types text/plain test/csv application/json;
+
   location / {
     proxy_pass http://{{.server}};
   }

--- a/nginx/config/proxy.go
+++ b/nginx/config/proxy.go
@@ -34,6 +34,9 @@ server {
   access_log {{$.log_dir}}/nginx-access.log json;
   error_log {{$.log_dir}}/nginx-error.log;
 
+  gzip on;
+  gzip_types text/plain test/csv application/json;
+
   # Committing large blobs might take a while.
   proxy_read_timeout 3m;
 


### PR DESCRIPTION
gzip should be disabled by default. It should be enabled only for agent, origin and proxy where large blobs are served.