### PR TITLE
Only start conn once in active state

### DIFF
--- a/lib/torrent/scheduler/conn/conn.go
+++ b/lib/torrent/scheduler/conn/conn.go
@@ -118,9 +118,16 @@ func newConn(
 		logger:         logger,
 	}
 
-	c.start()
-
 	return c, nil
+}
+
+// Start starts message processing on c. Note, once c has been started, it may
+// close itself if it encounters an error reading/writing to the underlying
+// socket.
+func (c *Conn) Start() {
+	c.wg.Add(2)
+	go c.readLoop()
+	go c.writeLoop()
 }
 
 // PeerID returns the remote peer id.
@@ -181,12 +188,6 @@ func (c *Conn) Close() {
 // IsClosed returns true if the c is closed.
 func (c *Conn) IsClosed() bool {
 	return c.closed.Load()
-}
-
-func (c *Conn) start() {
-	c.wg.Add(2)
-	go c.readLoop()
-	go c.writeLoop()
 }
 
 func (c *Conn) readPayload(length int32) ([]byte, error) {

--- a/lib/torrent/scheduler/conn/conn.go
+++ b/lib/torrent/scheduler/conn/conn.go
@@ -67,6 +67,8 @@ type Conn struct {
 	// Marks whether the connection was opened by the remote peer, or the local peer.
 	openedByRemote bool
 
+	startOnce sync.Once
+
 	sender   chan *Message
 	receiver chan *Message
 
@@ -125,9 +127,11 @@ func newConn(
 // close itself if it encounters an error reading/writing to the underlying
 // socket.
 func (c *Conn) Start() {
-	c.wg.Add(2)
-	go c.readLoop()
-	go c.writeLoop()
+	c.startOnce.Do(func() {
+		c.wg.Add(2)
+		go c.readLoop()
+		go c.writeLoop()
+	})
 }
 
 // PeerID returns the remote peer id.

--- a/lib/torrent/scheduler/conn/conn_test.go
+++ b/lib/torrent/scheduler/conn/conn_test.go
@@ -26,8 +26,6 @@ func TestConnClose(t *testing.T) {
 	c, cleanup := Fixture()
 	defer cleanup()
 
-	c.Start()
-
 	require.False(c.IsClosed())
 
 	var wg sync.WaitGroup

--- a/lib/torrent/scheduler/conn/conn_test.go
+++ b/lib/torrent/scheduler/conn/conn_test.go
@@ -26,6 +26,8 @@ func TestConnClose(t *testing.T) {
 	c, cleanup := Fixture()
 	defer cleanup()
 
+	c.Start()
+
 	require.False(c.IsClosed())
 
 	var wg sync.WaitGroup

--- a/lib/torrent/scheduler/conn/fixtures.go
+++ b/lib/torrent/scheduler/conn/fixtures.go
@@ -59,12 +59,14 @@ func PipeFixture(
 	if err != nil {
 		panic(err)
 	}
+	local.Start()
 
 	remote, err = HandshakerFixture(config).newConn(
 		noopDeadline{nc2}, core.PeerIDFixture(), info, true)
 	if err != nil {
 		panic(err)
 	}
+	remote.Start()
 
 	return local, remote, cleanup.Run
 }

--- a/lib/torrent/scheduler/state.go
+++ b/lib/torrent/scheduler/state.go
@@ -112,6 +112,7 @@ func (s *state) addOutgoingConn(c *conn.Conn, b *bitset.BitSet, info *storage.To
 	if err := s.conns.MovePendingToActive(c); err != nil {
 		return fmt.Errorf("move pending to active: %s", err)
 	}
+	c.Start()
 	ctrl, ok := s.torrentControls[info.InfoHash()]
 	if !ok {
 		return errors.New("torrent controls must be created before sending handshake")
@@ -131,6 +132,7 @@ func (s *state) addIncomingConn(
 	if err := s.conns.MovePendingToActive(c); err != nil {
 		return fmt.Errorf("move pending to active: %s", err)
 	}
+	c.Start()
 	ctrl, ok := s.torrentControls[info.InfoHash()]
 	if !ok {
 		t, err := s.sched.torrentArchive.GetTorrent(namespace, info.Digest())


### PR DESCRIPTION
We discovered an issue where a conn could get stuck in a pending state if
it the remote peer closed the conn (sent EOF) before the local peer moved
the conn into an active state, because `connClosedEvent` assumes that the
conn is already in an active state.

By not starting the conn until it is in active state, this diff eliminates the possibility
that it will close itself while still in a pending state.

Note, an underlying closed socket != a closed `conn.Conn`. `conn.Conn` is
"closed" only when `Close()` is explicitly called.

Unfortunately, it is near impossible to test for this race condition given the
distributed nature of scheduler.