### PR TITLE
Add optional exponential backoff to httpbackend download

### DIFF
--- a/utils/httputil/backoff.go
+++ b/utils/httputil/backoff.go
@@ -36,8 +36,8 @@ func (c *ExponentialBackOffConfig) applyDefaults() {
 
 // Build creates a new ExponentialBackOff using c's settings (if enabled).
 func (c ExponentialBackOffConfig) Build() backoff.BackOff {
-	c.applyDefaults()
 	if c.Enabled {
+		c.applyDefaults()
 		b := &backoff.ExponentialBackOff{
 			InitialInterval:     c.InitialInterval,
 			RandomizationFactor: c.RandomizationFactor,

--- a/utils/httputil/backoff.go
+++ b/utils/httputil/backoff.go
@@ -1,0 +1,51 @@
+package httputil
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+// ExponentialBackOffConfig maps backoff settings into YAML config format.
+type ExponentialBackOffConfig struct {
+	Enabled             bool          `yaml:"enabled"`
+	InitialInterval     time.Duration `yaml:"initial_interval"`
+	RandomizationFactor float64       `yaml:"randomization_factor"`
+	Multiplier          float64       `yaml:"multiplier"`
+	MaxInterval         time.Duration `yaml:"max_interval"`
+	MaxRetries          uint64        `yaml:"max_retries"`
+}
+
+func (c *ExponentialBackOffConfig) applyDefaults() {
+	if c.InitialInterval == 0 {
+		c.InitialInterval = 2 * time.Second
+	}
+	if c.RandomizationFactor == 0 {
+		c.RandomizationFactor = 0.05
+	}
+	if c.Multiplier == 0 {
+		c.Multiplier = 2
+	}
+	if c.MaxInterval == 0 {
+		c.MaxInterval = 30 * time.Second
+	}
+	if c.MaxRetries == 0 {
+		c.MaxRetries = 5
+	}
+}
+
+// Build creates a new ExponentialBackOff using c's settings (if enabled).
+func (c ExponentialBackOffConfig) Build() backoff.BackOff {
+	c.applyDefaults()
+	if c.Enabled {
+		b := &backoff.ExponentialBackOff{
+			InitialInterval:     c.InitialInterval,
+			RandomizationFactor: c.RandomizationFactor,
+			Multiplier:          c.Multiplier,
+			MaxInterval:         c.MaxInterval,
+			Clock:               backoff.SystemClock,
+		}
+		return backoff.WithMaxRetries(b, c.MaxRetries)
+	}
+	return &backoff.StopBackOff{}
+}


### PR DESCRIPTION
Makes the httpbackend more resilient to transient upstream errors.

Normally we should expect whatever client is downstream of the kraken-agent
to retry transient errors, however our monitoring is affected by the number
of download errors and can be somewhat noisy when an http file server
is acting up. Therefore this change tolerates up to 62 seconds of unavailability,
which is hopefully enough to smooth over random spikes.