### PR TITLE
Bump testfs to debian:9

### DIFF
--- a/docker/testfs/Dockerfile
+++ b/docker/testfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8
+FROM debian:9
 
 RUN apt-get update && apt-get install -y curl
 


### PR DESCRIPTION
jessie-updates were removed from the debian mirror network:

https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html

For whatever reason, testfs was still on debian:8, so this diff bumps
it to debian:9 which should work.