### PR TITLE
Log good and duplicate pieces received separately

### DIFF
--- a/lib/torrent/scheduler/dispatch/peer.go
+++ b/lib/torrent/scheduler/dispatch/peer.go
@@ -92,10 +92,14 @@ func (p *peer) touchLastPieceSent() {
 // peerStats wraps stats collected for a given peer.
 type peerStats struct {
 	mu                    sync.Mutex
-	pieceRequestsSent     int // pieces we requested from the peer
-	pieceRequestsReceived int // pieces the peer requested from us
-	piecesSent            int // pieces we sent to the peer
-	piecesReceived        int // pieces we received from the peer
+	pieceRequestsSent       int // Pieces we requested from the peer.
+	pieceRequestsReceived   int // Pieces the peer requested from us.
+	piecesSent              int // Pieces we sent to the peer.
+
+	// Pieces we received from the peer that we didn't already have.
+	goodPiecesReceived int
+	// Pieces we received from the peer that we already had.
+	duplicatePiecesReceived int
 }
 
 func (s *peerStats) getPieceRequestsSent() int {
@@ -140,16 +144,30 @@ func (s *peerStats) incrementPiecesSent() {
 	s.piecesSent++
 }
 
-func (s *peerStats) getPiecesReceived() int {
+func (s *peerStats) getGoodPiecesReceived() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.piecesReceived
+	return s.goodPiecesReceived
 }
 
-func (s *peerStats) incrementPiecesReceived() {
+func (s *peerStats) incrementGoodPiecesReceived() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.piecesReceived++
+	s.goodPiecesReceived++
+}
+
+func (s *peerStats) getDuplicatePiecesReceived() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.duplicatePiecesReceived
+}
+
+func (s *peerStats) incrementDuplicatePiecesReceived() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.duplicatePiecesReceived++
 }

--- a/lib/torrent/scheduler/torrentlog/logger.go
+++ b/lib/torrent/scheduler/torrentlog/logger.go
@@ -194,16 +194,18 @@ func (l *Logger) Sync() {
 
 // SeederSummary contains information about piece requests to and pieces received from a peer.
 type SeederSummary struct {
-	PeerID         core.PeerID
-	RequestsSent   int
-	PiecesReceived int
+	PeerID                  core.PeerID
+	RequestsSent            int
+	GoodPiecesReceived      int
+	DuplicatePiecesReceived int
 }
 
 // MarshalLogObject marshals a SeederSummary for logging.
 func (s SeederSummary) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("peer_id", s.PeerID.String())
 	enc.AddInt("requests_sent", s.RequestsSent)
-	enc.AddInt("pieces_received", s.PiecesReceived)
+	enc.AddInt("good_pieces_received", s.GoodPiecesReceived)
+	enc.AddInt("duplicate_pieces_received", s.DuplicatePiecesReceived)
 	return nil
 }
 


### PR DESCRIPTION
Currently, we don't have visibility into how many duplicate piece payloads that peers are receiving. Based on some testbed experiments, it seems that this may be the cause of unexpectedly low goodput in downloads. Logging these would help to confirm that sending duplicate pieces is the problem.