### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ services:
 env:
   - PATH=$HOME/protoc/bin:$PATH
 
+before_script:
+- "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
+
 script:
   - make unit-test integration
+  - fossa
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment.