### PR TITLE
Limit proxy next upstream attempts to 3

### DIFF
--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -39,6 +39,7 @@ server {
   location / {
     proxy_pass http://registry-backend;
     proxy_next_upstream error timeout http_404 http_500;
+    proxy_next_upstream_tries 3;
   }
 }
 `


### PR DESCRIPTION
The current proxy configuration for Kraken agent causes a client that
receives HTTP 404 to retry the "next upstream" server:
proxy_next_upstream error timeout http_404 http_500;

This can be an issue for clients that rely on getting a 404 as a part of
their logic, seen by Docker clients on Mac. It appears that Docker
clients try to access the image URL with a "/manifests/latest" suffix
before they try the correct URL. Getting a 404 is ok, however, a
repeated 404 from multiple Kraken backend servers can turn into a 502
Gateway Error by an intermediate proxy tier.

The fix is to limit the number of "next upstream" attempts to 3.
Rationale is that if a request had failed on three servers, it is most
probably going to "fail" the same way by others.