### PR TITLE
OpenedByRemote should be false for local

### DIFF
--- a/lib/torrent/scheduler/conn/handshaker.go
+++ b/lib/torrent/scheduler/conn/handshaker.go
@@ -323,7 +323,7 @@ func (h *Handshaker) fullHandshake(
 	if hs.peerID != peerID {
 		return nil, errors.New("unexpected peer id")
 	}
-	c, err := h.newConn(nc, peerID, info, true)
+	c, err := h.newConn(nc, peerID, info, false)
 	if err != nil {
 		return nil, fmt.Errorf("new conn: %s", err)
 	}


### PR DESCRIPTION
when connection opened by local peer, the flag 'openedByRemote' in Conn should be false.
see log
`2019-05-24T11:03:56.639Z    INFO    scheduler/events.go:219 Added outgoing conn with 0% downloaded  {"conn": "Conn(peer=c5399c8209e12a1df3e2bf8271661cc7ec9d44d8,                              hash=68aecd38087eb91de8a9a356ea9b8d6808f700f7, opened_by_remote=true)"}`
it will make people confused.