### PR TITLE
Add skipped announces back to queue

### DIFF
--- a/lib/torrent/scheduler/dispatch/dispatcher.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher.go
@@ -45,6 +45,7 @@ var (
 // Events defines Dispatcher events.
 type Events interface {
 	DispatcherComplete(*Dispatcher)
+	PeerRemoved(core.PeerID, core.InfoHash)
 }
 
 // Messages defines a subset of conn.Conn methods which Dispatcher requires to
@@ -453,6 +454,7 @@ func (d *Dispatcher) feed(p *peer) {
 		}
 	}
 	d.removePeer(p)
+	d.events.PeerRemoved(p.id, d.torrent.InfoHash())
 }
 
 func (d *Dispatcher) dispatch(p *peer, msg *conn.Message) error {

--- a/lib/torrent/scheduler/dispatch/dispatcher_test.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher_test.go
@@ -102,6 +102,8 @@ type noopEvents struct{}
 
 func (e noopEvents) DispatcherComplete(*Dispatcher) {}
 
+func (e noopEvents) PeerRemoved(core.PeerID, core.InfoHash) {}
+
 func testDispatcher(config Config, clk clock.Clock, t storage.Torrent) *Dispatcher {
 	d, err := newDispatcher(
 		config,

--- a/lib/torrent/scheduler/events.go
+++ b/lib/torrent/scheduler/events.go
@@ -242,7 +242,8 @@ func (e announceTickEvent) apply(s *state) {
 			skipped = append(skipped, h)
 			continue
 		}
-		go s.sched.announce(ctrl.dispatcher.Digest(), ctrl.dispatcher.InfoHash(), ctrl.dispatcher.Complete())
+		go s.sched.announce(
+			ctrl.dispatcher.Digest(), ctrl.dispatcher.InfoHash(), ctrl.dispatcher.Complete())
 		break
 	}
 	// Re-enqueue any torrents we pulled off and ignored, else we would never

--- a/lib/torrent/scheduler/events.go
+++ b/lib/torrent/scheduler/events.go
@@ -225,21 +225,31 @@ type announceTickEvent struct{}
 // apply pulls the next dispatcher from the announce queue and asynchronously
 // makes an announce request to the tracker.
 func (e announceTickEvent) apply(s *state) {
-	h, ok := s.announceQueue.Next()
-	if !ok {
-		s.log().Debug("No torrents in announce queue")
-		return
+	var skipped []core.InfoHash
+	for {
+		h, ok := s.announceQueue.Next()
+		if !ok {
+			s.log().Debug("No torrents in announce queue")
+			break
+		}
+		ctrl, ok := s.torrentControls[h]
+		if !ok {
+			s.log("hash", h).Error("Pulled unknown torrent off announce queue")
+			continue
+		}
+		if ctrl.dispatcher.NumPeers() >= s.conns.MaxConnsPerTorrent() {
+			s.log("hash", h).Info("Skipping announce for fully saturated torrent")
+			skipped = append(skipped, h)
+			continue
+		}
+		go s.sched.announce(ctrl.dispatcher.Digest(), ctrl.dispatcher.InfoHash(), ctrl.dispatcher.Complete())
+		break
 	}
-	ctrl, ok := s.torrentControls[h]
-	if !ok {
-		s.log("hash", h).Error("Pulled unknown torrent off announce queue")
-		return
+	// Re-enqueue any torrents we pulled off and ignored, else we would never
+	// announce them again.
+	for _, h := range skipped {
+		s.announceQueue.Ready(h)
 	}
-	if ctrl.dispatcher.NumPeers() >= s.conns.MaxConnsPerTorrent() {
-		s.log("hash", h).Info("Skipping announce for fully saturated torrent")
-		return
-	}
-	go s.sched.announce(ctrl.dispatcher.Digest(), ctrl.dispatcher.InfoHash(), ctrl.dispatcher.Complete())
 }
 
 // announceResultEvent occurs when a successfully announced response was received


### PR DESCRIPTION
If a torrent is at capacity, we skip announcing that torrent. However, we were not re-adding
that torrent back to the announce queue, so it wouldn't announce again until it was completed.
In practice, if a torrent is at capacity it will very likely be completed, so this bug went by
unnoticed for a long time.

Now, we skip all torrents that are at capacity until we reach a torrent we want to announce.
Then we re-enqueue all the skipped torrents.