### PR TITLE
Support prometheus

### DIFF
--- a/lib/middleware/middleware.go
+++ b/lib/middleware/middleware.go
@@ -95,7 +95,7 @@ func StatusCounter(stats tally.Scope) func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			recordw := &recordStatusWriter{w, false, http.StatusOK}
 			next.ServeHTTP(recordw, r)
-			tagEndpoint(stats, r).Counter(strconv.Itoa(recordw.code)).Inc(1)
+			tagEndpoint(stats, r).Counter("http_" + strconv.Itoa(recordw.code)).Inc(1)
 		})
 	}
 }

--- a/lib/middleware/middleware_test.go
+++ b/lib/middleware/middleware_test.go
@@ -145,7 +145,7 @@ func TestStatusCounter(t *testing.T) {
 
 			require.Equal(1, len(stats.Snapshot().Counters()))
 			for _, v := range stats.Snapshot().Counters() {
-				require.Equal(test.expectedStatus, v.Name())
+				require.Equal("http_" + test.expectedStatus, v.Name())
 				require.Equal(int64(5), v.Value())
 				require.Equal(map[string]string{
 					"endpoint": "foo",

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -15,9 +15,10 @@ package metrics
 
 // Config defines metrics configuration.
 type Config struct {
-	Backend string       `yaml:"backend"`
-	Statsd  StatsdConfig `yaml:"statsd"`
-	M3      M3Config     `yaml:"m3"`
+	Backend    string           `yaml:"backend"`
+	Statsd     StatsdConfig     `yaml:"statsd"`
+	M3         M3Config         `yaml:"m3"`
+	Prometheus PrometheusConfig `yaml:"prometheus"`
 }
 
 // StatsdConfig defines statsd configuration.
@@ -31,4 +32,11 @@ type M3Config struct {
 	HostPort string `yaml:"host_port"`
 	Service  string `yaml:"service"`
 	Env      string `yaml:"env"`
+}
+
+// PrometheusConfig defines prometheus configuration.
+type PrometheusConfig struct {
+	ListenAddress string `yaml:"listen_address"`
+	// HandlerPath if not define use default /metrics.
+	HandlerPath string `yaml:"handler_path"`
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -29,6 +29,7 @@ func init() {
 	register("statsd", newStatsdScope)
 	register("disabled", newDisabledScope)
 	register("m3", newM3Scope)
+	register("prometheus", newPrometheusScope)
 }
 
 var _scopeFactories = make(map[string]scopeFactory)

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/uber-go/tally"
+	promreporter "github.com/uber-go/tally/prometheus"
+)
+
+func newPrometheusScope(config Config, cluster string) (tally.Scope, io.Closer, error) {
+	if config.Prometheus.ListenAddress == "" {
+		return nil, nil, fmt.Errorf("listen_address required for prometheus")
+	}
+
+	prometheusConfig := promreporter.Configuration{
+		HandlerPath:   config.Prometheus.HandlerPath,
+		ListenAddress: config.Prometheus.ListenAddress,
+	}
+	r, err := prometheusConfig.NewReporter(promreporter.ConfigurationOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	s, c := tally.NewRootScope(tally.ScopeOptions{
+		CachedReporter: r,
+	}, time.Second)
+	return s, c, nil
+}


### PR DESCRIPTION
add 'http_' as prefix of metrics name. for there is a restriction in prometheus that metrics name should start with letter.
and you can set backend to 'promethues' to active prometheus metrics.
```
metrics:
  backend: prometheus
  m3:
    service: kraken-agent
    host_port: 10740
  statsd:
    host_port: 0.0.0.0:10740
    prefix: kraken-agent
  prometheus:
    listen_address: 0.0.0.0:10740
```