### PR TITLE
Simplify announce tick event test

### DIFF
--- a/lib/torrent/scheduler/dispatch/dispatcher.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher.go
@@ -45,7 +45,6 @@ var (
 // Events defines Dispatcher events.
 type Events interface {
 	DispatcherComplete(*Dispatcher)
-	PeerRemoved(core.PeerID, core.InfoHash)
 }
 
 // Messages defines a subset of conn.Conn methods which Dispatcher requires to
@@ -444,7 +443,6 @@ func (d *Dispatcher) feed(p *peer) {
 		}
 	}
 	d.removePeer(p)
-	d.events.PeerRemoved(p.id, d.torrent.InfoHash())
 }
 
 func (d *Dispatcher) dispatch(p *peer, msg *conn.Message) error {

--- a/lib/torrent/scheduler/dispatch/dispatcher_test.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher_test.go
@@ -102,8 +102,6 @@ type noopEvents struct{}
 
 func (e noopEvents) DispatcherComplete(*Dispatcher) {}
 
-func (e noopEvents) PeerRemoved(core.PeerID, core.InfoHash) {}
-
 func testDispatcher(config Config, clk clock.Clock, t storage.Torrent) *Dispatcher {
 	d, err := newDispatcher(
 		config,

--- a/lib/torrent/scheduler/events.go
+++ b/lib/torrent/scheduler/events.go
@@ -112,10 +112,6 @@ func (l *liftedEventLoop) DispatcherComplete(d *dispatch.Dispatcher) {
 	l.send(dispatcherCompleteEvent{d})
 }
 
-func (l *liftedEventLoop) PeerRemoved(peerID core.PeerID, h core.InfoHash) {
-	l.send(peerRemovedEvent{peerID, h})
-}
-
 func (l *liftedEventLoop) AnnounceTick() {
 	l.send(announceTickEvent{})
 }
@@ -376,15 +372,6 @@ func (e dispatcherCompleteEvent) apply(s *state) {
 	// Immediately announce completed torrents.
 	go s.sched.announce(ctrl.dispatcher.Digest(), ctrl.dispatcher.InfoHash(), true)
 }
-
-// peerRemovedEvent occurs when a dispatcher removes a peer with a closed
-// connection. Currently is a no-op.
-type peerRemovedEvent struct {
-	peerID   core.PeerID
-	infoHash core.InfoHash
-}
-
-func (e peerRemovedEvent) apply(s *state) {}
 
 // preemptionTickEvent occurs periodically to preempt unneeded conns and remove
 // idle torrentControls.


### PR DESCRIPTION
Now that announce does not rely on `dispatcher.NumPeers()` to determine
if a torrent is saturated (see #173), there is no nondeterministic behavior in announce
tick event and thus the the event test can be simplified.