### PR TITLE
Add pagination support to backend

### DIFF
--- a/build-index/tagserver/server.go
+++ b/build-index/tagserver/server.go
@@ -244,7 +244,7 @@ func (s *Server) listHandler(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return handler.Errorf("backend manager: %s", err)
 	}
-	names, err := client.List(prefix)
+	names, _, err := client.List(prefix, &backend.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func (s *Server) listRepositoryHandler(w http.ResponseWriter, r *http.Request) e
 	if err != nil {
 		return handler.Errorf("backend manager: %s", err)
 	}
-	names, err := client.List(path.Join(repo, "_manifests/tags"))
+	names, _, err := client.List(path.Join(repo, "_manifests/tags"), &backend.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/build-index/tagserver/server.go
+++ b/build-index/tagserver/server.go
@@ -244,7 +244,7 @@ func (s *Server) listHandler(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return handler.Errorf("backend manager: %s", err)
 	}
-	result, err := client.List(prefix, backend.ListOptions{})
+	result, err := client.List(prefix)
 	if err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func (s *Server) listRepositoryHandler(w http.ResponseWriter, r *http.Request) e
 	if err != nil {
 		return handler.Errorf("backend manager: %s", err)
 	}
-	result, err := client.List(path.Join(repo, "_manifests/tags"), backend.ListOptions{})
+	result, err := client.List(path.Join(repo, "_manifests/tags"))
 	if err != nil {
 		return err
 	}

--- a/build-index/tagserver/server.go
+++ b/build-index/tagserver/server.go
@@ -244,11 +244,11 @@ func (s *Server) listHandler(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return handler.Errorf("backend manager: %s", err)
 	}
-	names, _, err := client.List(prefix, &backend.ListOptions{})
+	result, err := client.List(prefix, backend.ListOptions{})
 	if err != nil {
 		return err
 	}
-	if err := json.NewEncoder(w).Encode(&names); err != nil {
+	if err := json.NewEncoder(w).Encode(&result.Names); err != nil {
 		return handler.Errorf("json encode: %s", err)
 	}
 	return nil
@@ -265,12 +265,12 @@ func (s *Server) listRepositoryHandler(w http.ResponseWriter, r *http.Request) e
 	if err != nil {
 		return handler.Errorf("backend manager: %s", err)
 	}
-	names, _, err := client.List(path.Join(repo, "_manifests/tags"), &backend.ListOptions{})
+	result, err := client.List(path.Join(repo, "_manifests/tags"), backend.ListOptions{})
 	if err != nil {
 		return err
 	}
 	var tags []string
-	for _, name := range names {
+	for _, name := range result.Names {
 		// Strip repo prefix.
 		parts := strings.Split(name, ":")
 		if len(parts) != 2 {

--- a/build-index/tagserver/server_test.go
+++ b/build-index/tagserver/server_test.go
@@ -369,7 +369,7 @@ func TestListRepository(t *testing.T) {
 		names = append(names, repo+":"+tag)
 	}
 
-	mocks.backendClient.EXPECT().List(repo+"/_manifests/tags", backend.ListOptions{}).Return(&backend.ListResult{
+	mocks.backendClient.EXPECT().List(repo+"/_manifests/tags").Return(&backend.ListResult{
 		Names: names,
 	}, nil)
 
@@ -392,7 +392,7 @@ func TestList(t *testing.T) {
 	prefix := "namespace-foo/repo-bar/_manifests/tags"
 	names := []string{"latest", "0000", "0001"}
 
-	mocks.backendClient.EXPECT().List(prefix, backend.ListOptions{}).Return(&backend.ListResult{
+	mocks.backendClient.EXPECT().List(prefix).Return(&backend.ListResult{
 		Names: names,
 	}, nil)
 
@@ -414,7 +414,7 @@ func TestListEmptyPrefix(t *testing.T) {
 
 	names := []string{"a", "b", "c"}
 
-	mocks.backendClient.EXPECT().List("", backend.ListOptions{}).Return(&backend.ListResult{
+	mocks.backendClient.EXPECT().List("").Return(&backend.ListResult{
 		Names: names,
 	}, nil)
 

--- a/build-index/tagserver/server_test.go
+++ b/build-index/tagserver/server_test.go
@@ -369,7 +369,7 @@ func TestListRepository(t *testing.T) {
 		names = append(names, repo+":"+tag)
 	}
 
-	mocks.backendClient.EXPECT().List(repo+"/_manifests/tags").Return(names, nil)
+	mocks.backendClient.EXPECT().List(repo+"/_manifests/tags", &backend.ListOptions{}).Return(names, "", nil)
 
 	result, err := client.ListRepository(repo)
 	require.NoError(err)
@@ -390,7 +390,7 @@ func TestList(t *testing.T) {
 	prefix := "namespace-foo/repo-bar/_manifests/tags"
 	names := []string{"latest", "0000", "0001"}
 
-	mocks.backendClient.EXPECT().List(prefix).Return(names, nil)
+	mocks.backendClient.EXPECT().List(prefix, &backend.ListOptions{}).Return(names, "", nil)
 
 	result, err := client.List(prefix)
 	require.NoError(err)
@@ -410,7 +410,7 @@ func TestListEmptyPrefix(t *testing.T) {
 
 	names := []string{"a", "b", "c"}
 
-	mocks.backendClient.EXPECT().List("").Return(names, nil)
+	mocks.backendClient.EXPECT().List("", &backend.ListOptions{}).Return(names, "", nil)
 
 	result, err := client.List("")
 	require.NoError(err)

--- a/build-index/tagserver/server_test.go
+++ b/build-index/tagserver/server_test.go
@@ -369,7 +369,9 @@ func TestListRepository(t *testing.T) {
 		names = append(names, repo+":"+tag)
 	}
 
-	mocks.backendClient.EXPECT().List(repo+"/_manifests/tags", &backend.ListOptions{}).Return(names, "", nil)
+	mocks.backendClient.EXPECT().List(repo+"/_manifests/tags", backend.ListOptions{}).Return(&backend.ListResult{
+		Names: names,
+	}, nil)
 
 	result, err := client.ListRepository(repo)
 	require.NoError(err)
@@ -390,7 +392,9 @@ func TestList(t *testing.T) {
 	prefix := "namespace-foo/repo-bar/_manifests/tags"
 	names := []string{"latest", "0000", "0001"}
 
-	mocks.backendClient.EXPECT().List(prefix, &backend.ListOptions{}).Return(names, "", nil)
+	mocks.backendClient.EXPECT().List(prefix, backend.ListOptions{}).Return(&backend.ListResult{
+		Names: names,
+	}, nil)
 
 	result, err := client.List(prefix)
 	require.NoError(err)
@@ -410,7 +414,9 @@ func TestListEmptyPrefix(t *testing.T) {
 
 	names := []string{"a", "b", "c"}
 
-	mocks.backendClient.EXPECT().List("", &backend.ListOptions{}).Return(names, "", nil)
+	mocks.backendClient.EXPECT().List("", backend.ListOptions{}).Return(&backend.ListResult{
+		Names: names,
+	}, nil)
 
 	result, err := client.List("")
 	require.NoError(err)

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -62,5 +62,5 @@ type Client interface {
 	Download(namespace, name string, dst io.Writer) error
 
 	// List lists entries whose names start with prefix.
-	List(prefix string, options *ListOptions) ([]string, string, error)
+	List(prefix string, options ListOptions) (*ListResult, error)
 }

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -62,5 +62,5 @@ type Client interface {
 	Download(namespace, name string, dst io.Writer) error
 
 	// List lists entries whose names start with prefix.
-	List(prefix string, options ListOptions) (*ListResult, error)
+	List(prefix string, opts ...ListOption) (*ListResult, error)
 }

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -62,5 +62,5 @@ type Client interface {
 	Download(namespace, name string, dst io.Writer) error
 
 	// List lists entries whose names start with prefix.
-	List(prefix string) ([]string, error)
+	List(prefix string, options *ListOptions) ([]string, string, error)
 }

--- a/lib/backend/gcsbackend/client.go
+++ b/lib/backend/gcsbackend/client.go
@@ -169,7 +169,7 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List lists names that start with prefix.
-func (c *Client) List(prefix string) ([]string, error) {
+func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
 	var names []string
 
 	absPrefix := path.Join(c.pather.BasePath(), prefix)
@@ -178,10 +178,10 @@ func (c *Client) List(prefix string) ([]string, error) {
 	objectsPage := iterator.NewPager(pageIterator, c.config.ListMaxKeys, "")
 	_, err := objectsPage.NextPage(&names)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return names, nil
+	return names, "", nil
 }
 
 // isObjectNotFound is helper function for identify non-existing object error.

--- a/lib/backend/gcsbackend/client.go
+++ b/lib/backend/gcsbackend/client.go
@@ -170,6 +170,10 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 
 // List lists names that start with prefix.
 func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
+	if options != nil && options.Paginated {
+		return nil, "", errors.New("pagination not supported")
+	}
+
 	var names []string
 
 	absPrefix := path.Join(c.pather.BasePath(), prefix)

--- a/lib/backend/gcsbackend/client.go
+++ b/lib/backend/gcsbackend/client.go
@@ -169,9 +169,9 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List lists names that start with prefix.
-func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
-	if options != nil && options.Paginated {
-		return nil, "", errors.New("pagination not supported")
+func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+	if options.Paginated {
+		return nil, errors.New("pagination not supported")
 	}
 
 	var names []string
@@ -182,10 +182,12 @@ func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, st
 	objectsPage := iterator.NewPager(pageIterator, c.config.ListMaxKeys, "")
 	_, err := objectsPage.NextPage(&names)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return names, "", nil
+	return &backend.ListResult{
+		Names: names,
+	}, nil
 }
 
 // isObjectNotFound is helper function for identify non-existing object error.

--- a/lib/backend/gcsbackend/client.go
+++ b/lib/backend/gcsbackend/client.go
@@ -169,7 +169,12 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List lists names that start with prefix.
-func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
+	options := backend.DefaultListOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	if options.Paginated {
 		return nil, errors.New("pagination not supported")
 	}

--- a/lib/backend/gcsbackend/client_test.go
+++ b/lib/backend/gcsbackend/client_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/uber/kraken/core"
-	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/mocks/lib/backend/gcsbackend"
 	"github.com/uber/kraken/utils/mockutil"
 	"github.com/uber/kraken/utils/randutil"
@@ -182,7 +181,7 @@ func TestClientList(t *testing.T) {
 		"/root/test",
 	).Return(Alphabets())
 
-	result, err := client.List("test", backend.ListOptions{})
+	result, err := client.List("test")
 	require.NoError(err)
 	require.Equal([]string{"test/0", "test/1", "test/2", "test/3", "test/4"}, result.Names)
 }

--- a/lib/backend/gcsbackend/client_test.go
+++ b/lib/backend/gcsbackend/client_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/uber/kraken/core"
+	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/mocks/lib/backend/gcsbackend"
 	"github.com/uber/kraken/utils/mockutil"
 	"github.com/uber/kraken/utils/randutil"
@@ -181,7 +182,7 @@ func TestClientList(t *testing.T) {
 		"/root/test",
 	).Return(Alphabets())
 
-	names, err := client.List("test")
+	names, _, err := client.List("test", &backend.ListOptions{})
 	require.NoError(err)
 	require.Equal([]string{"test/0", "test/1", "test/2", "test/3", "test/4"}, names)
 }

--- a/lib/backend/gcsbackend/client_test.go
+++ b/lib/backend/gcsbackend/client_test.go
@@ -182,7 +182,7 @@ func TestClientList(t *testing.T) {
 		"/root/test",
 	).Return(Alphabets())
 
-	names, _, err := client.List("test", &backend.ListOptions{})
+	result, err := client.List("test", backend.ListOptions{})
 	require.NoError(err)
-	require.Equal([]string{"test/0", "test/1", "test/2", "test/3", "test/4"}, names)
+	require.Equal([]string{"test/0", "test/1", "test/2", "test/3", "test/4"}, result.Names)
 }

--- a/lib/backend/hdfsbackend/client.go
+++ b/lib/backend/hdfsbackend/client.go
@@ -168,6 +168,10 @@ func (c *Client) sendAll(done <-chan struct{}, dirs []string, listJobs chan<- st
 
 // List lists names which start with prefix.
 func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
+	if options != nil && options.Paginated {
+		return nil, "", errors.New("pagination not supported")
+	}
+
 	root := path.Join(c.pather.BasePath(), prefix)
 
 	listJobs := make(chan string)

--- a/lib/backend/hdfsbackend/client.go
+++ b/lib/backend/hdfsbackend/client.go
@@ -167,7 +167,12 @@ func (c *Client) sendAll(done <-chan struct{}, dirs []string, listJobs chan<- st
 }
 
 // List lists names which start with prefix.
-func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
+	options := backend.DefaultListOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	if options.Paginated {
 		return nil, errors.New("pagination not supported")
 	}

--- a/lib/backend/hdfsbackend/client.go
+++ b/lib/backend/hdfsbackend/client.go
@@ -167,9 +167,9 @@ func (c *Client) sendAll(done <-chan struct{}, dirs []string, listJobs chan<- st
 }
 
 // List lists names which start with prefix.
-func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
-	if options != nil && options.Paginated {
-		return nil, "", errors.New("pagination not supported")
+func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+	if options.Paginated {
+		return nil, errors.New("pagination not supported")
 	}
 
 	root := path.Join(c.pather.BasePath(), prefix)
@@ -214,7 +214,7 @@ func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, st
 			if httputil.IsNotFound(res.err) {
 				continue
 			}
-			return nil, "", res.err
+			return nil, res.err
 		}
 		var dirs []string
 		for _, fs := range res.list {
@@ -262,5 +262,7 @@ func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, st
 		}
 	}
 
-	return files, "", nil
+	return &backend.ListResult{
+		Names: files,
+	},  nil
 }

--- a/lib/backend/hdfsbackend/client.go
+++ b/lib/backend/hdfsbackend/client.go
@@ -167,7 +167,7 @@ func (c *Client) sendAll(done <-chan struct{}, dirs []string, listJobs chan<- st
 }
 
 // List lists names which start with prefix.
-func (c *Client) List(prefix string) ([]string, error) {
+func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
 	root := path.Join(c.pather.BasePath(), prefix)
 
 	listJobs := make(chan string)
@@ -210,7 +210,7 @@ func (c *Client) List(prefix string) ([]string, error) {
 			if httputil.IsNotFound(res.err) {
 				continue
 			}
-			return nil, res.err
+			return nil, "", res.err
 		}
 		var dirs []string
 		for _, fs := range res.list {
@@ -258,5 +258,5 @@ func (c *Client) List(prefix string) ([]string, error) {
 		}
 	}
 
-	return files, nil
+	return files, "", nil
 }

--- a/lib/backend/hdfsbackend/client_test.go
+++ b/lib/backend/hdfsbackend/client_test.go
@@ -175,9 +175,9 @@ func TestClientList(t *testing.T) {
 
 			mocks.webhdfs.EXPECT().ListFileStatus("/root/empty").Return(nil, nil).MaxTimes(1)
 
-			names, _, err := client.List(test.prefix, &backend.ListOptions{})
+			result, err := client.List(test.prefix, backend.ListOptions{})
 			require.NoError(err)
-			require.Equal(test.expected, names)
+			require.Equal(test.expected, result.Names)
 		})
 	}
 }
@@ -216,6 +216,6 @@ func TestClientListErrorDoesNotLeakGoroutines(t *testing.T) {
 
 	initDirectoryTree(mocks, "/root", 10, 3) // 1000 nodes.
 
-	_, _, err := client.List("", &backend.ListOptions{})
+	_, err := client.List("", backend.ListOptions{})
 	require.Error(err)
 }

--- a/lib/backend/hdfsbackend/client_test.go
+++ b/lib/backend/hdfsbackend/client_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/uber/kraken/core"
+	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/lib/backend/hdfsbackend/webhdfs"
 	"github.com/uber/kraken/mocks/lib/backend/hdfsbackend/webhdfs"
 	"github.com/uber/kraken/utils/mockutil"
@@ -174,7 +175,7 @@ func TestClientList(t *testing.T) {
 
 			mocks.webhdfs.EXPECT().ListFileStatus("/root/empty").Return(nil, nil).MaxTimes(1)
 
-			names, err := client.List(test.prefix)
+			names, _, err := client.List(test.prefix, &backend.ListOptions{})
 			require.NoError(err)
 			require.Equal(test.expected, names)
 		})
@@ -215,6 +216,6 @@ func TestClientListErrorDoesNotLeakGoroutines(t *testing.T) {
 
 	initDirectoryTree(mocks, "/root", 10, 3) // 1000 nodes.
 
-	_, err := client.List("")
+	_, _, err := client.List("", &backend.ListOptions{})
 	require.Error(err)
 }

--- a/lib/backend/hdfsbackend/client_test.go
+++ b/lib/backend/hdfsbackend/client_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/uber/kraken/core"
-	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/lib/backend/hdfsbackend/webhdfs"
 	"github.com/uber/kraken/mocks/lib/backend/hdfsbackend/webhdfs"
 	"github.com/uber/kraken/utils/mockutil"
@@ -175,7 +174,7 @@ func TestClientList(t *testing.T) {
 
 			mocks.webhdfs.EXPECT().ListFileStatus("/root/empty").Return(nil, nil).MaxTimes(1)
 
-			result, err := client.List(test.prefix, backend.ListOptions{})
+			result, err := client.List(test.prefix)
 			require.NoError(err)
 			require.Equal(test.expected, result.Names)
 		})
@@ -216,6 +215,6 @@ func TestClientListErrorDoesNotLeakGoroutines(t *testing.T) {
 
 	initDirectoryTree(mocks, "/root", 10, 3) // 1000 nodes.
 
-	_, err := client.List("", backend.ListOptions{})
+	_, err := client.List("")
 	require.Error(err)
 }

--- a/lib/backend/httpbackend/http.go
+++ b/lib/backend/httpbackend/http.go
@@ -115,6 +115,6 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported.
-func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }

--- a/lib/backend/httpbackend/http.go
+++ b/lib/backend/httpbackend/http.go
@@ -115,6 +115,6 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported.
-func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
-	return nil, "", errors.New("not supported")
+func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+	return nil, errors.New("not supported")
 }

--- a/lib/backend/httpbackend/http.go
+++ b/lib/backend/httpbackend/http.go
@@ -115,6 +115,6 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported.
-func (c *Client) List(prefix string) ([]string, error) {
-	return nil, errors.New("not supported")
+func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
+	return nil, "", errors.New("not supported")
 }

--- a/lib/backend/noop.go
+++ b/lib/backend/noop.go
@@ -45,6 +45,6 @@ func (c NoopClient) Download(namespace, name string, dst io.Writer) error {
 }
 
 // List always returns nil.
-func (c NoopClient) List(prefix string, options *ListOptions) ([]string, string, error) {
-	return nil, "", nil
+func (c NoopClient) List(prefix string, options ListOptions) (*ListResult, error) {
+	return nil, nil
 }

--- a/lib/backend/noop.go
+++ b/lib/backend/noop.go
@@ -45,6 +45,6 @@ func (c NoopClient) Download(namespace, name string, dst io.Writer) error {
 }
 
 // List always returns nil.
-func (c NoopClient) List(prefix string, options ListOptions) (*ListResult, error) {
+func (c NoopClient) List(prefix string, opts ...ListOption) (*ListResult, error) {
 	return nil, nil
 }

--- a/lib/backend/noop.go
+++ b/lib/backend/noop.go
@@ -45,6 +45,6 @@ func (c NoopClient) Download(namespace, name string, dst io.Writer) error {
 }
 
 // List always returns nil.
-func (c NoopClient) List(prefix string) ([]string, error) {
-	return nil, nil
+func (c NoopClient) List(prefix string, options *ListOptions) ([]string, string, error) {
+	return nil, "", nil
 }

--- a/lib/backend/options.go
+++ b/lib/backend/options.go
@@ -20,3 +20,38 @@ type ListOptions struct {
 	MaxKeys int64
 	ContinuationToken string
 }
+
+// DefaultListOptions defines the defaults for list operations.
+func DefaultListOptions() *ListOptions {
+	return &ListOptions{
+		Paginated: false,
+		MaxKeys: 1000,
+		ContinuationToken: "",
+	}
+}
+
+// ListOption is used to configure list calls via variadic functional options.
+type ListOption func(*ListOptions)
+
+// ListWithPagination configures the list command to use pagination.
+func ListWithPagination() ListOption {
+	return func(opt *ListOptions) {
+		opt.Paginated = true
+	}
+}
+
+// ListWithMaxKeys configures the list command to return a max
+// number of keys if pagination is enabled.
+func ListWithMaxKeys(max int64) ListOption {
+	return func(opt *ListOptions) {
+		opt.MaxKeys = max
+	}
+}
+
+// ListWithContinuationToken configures the list command return
+// results starting at the continuation token if pagination is enabled.
+func ListWithContinuationToken(token string) ListOption {
+	return func(opt *ListOptions) {
+		opt.ContinuationToken = token
+	}
+}

--- a/lib/backend/options.go
+++ b/lib/backend/options.go
@@ -25,7 +25,7 @@ type ListOptions struct {
 func DefaultListOptions() *ListOptions {
 	return &ListOptions{
 		Paginated: false,
-		MaxKeys: 1000,
+		MaxKeys: int64(DefaultListMaxKeys),
 		ContinuationToken: "",
 	}
 }

--- a/lib/backend/options.go
+++ b/lib/backend/options.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 package backend
 
-// ListOptions defines a the options which can be specified
+// ListOptions defines the options which can be specified
 // when listing names. It is used to enable pagination in list requests.
 type ListOptions struct {
 	Paginated bool

--- a/lib/backend/options.go
+++ b/lib/backend/options.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package backend
+
+// ListOptions defines a the options which can be specified
+// when listing names. It is used to enable pagination in list requests.
+type ListOptions struct {
+	Paginated bool
+	MaxKeys int64
+	ContinuationToken string
+}

--- a/lib/backend/registrybackend/blobclient.go
+++ b/lib/backend/registrybackend/blobclient.go
@@ -141,6 +141,6 @@ func (c *BlobClient) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported for blobs.
-func (c *BlobClient) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
-	return nil, "", errors.New("not supported")
+func (c *BlobClient) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+	return nil, errors.New("not supported")
 }

--- a/lib/backend/registrybackend/blobclient.go
+++ b/lib/backend/registrybackend/blobclient.go
@@ -141,6 +141,6 @@ func (c *BlobClient) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported for blobs.
-func (c *BlobClient) List(prefix string) ([]string, error) {
-	return nil, errors.New("not supported")
+func (c *BlobClient) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
+	return nil, "", errors.New("not supported")
 }

--- a/lib/backend/registrybackend/blobclient.go
+++ b/lib/backend/registrybackend/blobclient.go
@@ -141,6 +141,6 @@ func (c *BlobClient) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported for blobs.
-func (c *BlobClient) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+func (c *BlobClient) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -141,6 +141,6 @@ func (c *TagClient) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported as users can list directly from registry.
-func (c *TagClient) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+func (c *TagClient) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -141,6 +141,6 @@ func (c *TagClient) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported as users can list directly from registry.
-func (c *TagClient) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
-	return nil, "", errors.New("not supported")
+func (c *TagClient) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+	return nil, errors.New("not supported")
 }

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -141,6 +141,6 @@ func (c *TagClient) Upload(namespace, name string, src io.Reader) error {
 }
 
 // List is not supported as users can list directly from registry.
-func (c *TagClient) List(prefix string) ([]string, error) {
-	return nil, errors.New("not supported")
+func (c *TagClient) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
+	return nil, "", errors.New("not supported")
 }

--- a/lib/backend/results.go
+++ b/lib/backend/results.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package backend
+
+// ListResult defines the response from a client list operation.
+// The names of the entries found will always be populated, and the
+// continuation token will only be populated if pagination was enabled
+// and there are remaining entries to list.
+type ListResult struct {
+	Names             []string
+	ContinuationToken string
+}

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -213,7 +213,7 @@ func isNotFound(err error) bool {
 }
 
 // List lists names with start with prefix.
-func (c *Client) List(prefix string) ([]string, error) {
+func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
 	// For whatever reason, the S3 list API does not accept an absolute path
 	// for prefix. Thus, the root is stripped from the input and added manually
 	// to each output key.
@@ -240,7 +240,7 @@ func (c *Client) List(prefix string) ([]string, error) {
 		return true
 	})
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return names, nil
+	return names, "", nil
 }

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -213,10 +213,15 @@ func isNotFound(err error) bool {
 }
 
 // List lists names with start with prefix.
-func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	// For whatever reason, the S3 list API does not accept an absolute path
 	// for prefix. Thus, the root is stripped from the input and added manually
 	// to each output key.
+	options := backend.DefaultListOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	var names []string
 
 	addObjectsToNames := func(objects []*s3.Object) {

--- a/lib/backend/s3backend/client_test.go
+++ b/lib/backend/s3backend/client_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/uber/kraken/core"
+	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/mocks/lib/backend/s3backend"
 	"github.com/uber/kraken/utils/mockutil"
 	"github.com/uber/kraken/utils/randutil"
@@ -208,7 +209,7 @@ func TestClientList(t *testing.T) {
 		return nil
 	})
 
-	names, err := client.List("test")
+	names, _, err := client.List("test", &backend.ListOptions{})
 	require.NoError(err)
 	require.Equal([]string{"test/a", "test/b", "test/c", "test/d"}, names)
 }

--- a/lib/backend/s3backend/client_test.go
+++ b/lib/backend/s3backend/client_test.go
@@ -209,7 +209,7 @@ func TestClientList(t *testing.T) {
 		return nil
 	})
 
-	result, err := client.List("test", backend.ListOptions{})
+	result, err := client.List("test")
 	require.NoError(err)
 	require.Equal([]string{"test/a", "test/b", "test/c", "test/d"}, result.Names)
 }
@@ -264,19 +264,19 @@ func TestClientListPaginated(t *testing.T) {
 		}, nil
 	})
 
-	result, err := client.List("test", backend.ListOptions{
-		Paginated: true,
-		MaxKeys: 2,
-	})
+	result, err := client.List("test",
+		backend.ListWithPagination(),
+		backend.ListWithMaxKeys(2),
+	)
 	require.NoError(err)
 	require.Equal([]string{"test/a", "test/b"}, result.Names)
 	require.Equal("test-continuation-token", result.ContinuationToken)
 
-	result, err = client.List("test", backend.ListOptions{
-		Paginated: true,
-		MaxKeys: 2,
-		ContinuationToken: result.ContinuationToken,
-	})
+	result, err = client.List("test",
+		backend.ListWithPagination(),
+		backend.ListWithMaxKeys(2),
+		backend.ListWithContinuationToken(result.ContinuationToken),
+	)
 	require.NoError(err)
 	require.Equal([]string{"test/c", "test/d"}, result.Names)
 	require.Equal("", result.ContinuationToken)

--- a/lib/backend/s3backend/client_test.go
+++ b/lib/backend/s3backend/client_test.go
@@ -209,9 +209,9 @@ func TestClientList(t *testing.T) {
 		return nil
 	})
 
-	names, _, err := client.List("test", &backend.ListOptions{})
+	result, err := client.List("test", backend.ListOptions{})
 	require.NoError(err)
-	require.Equal([]string{"test/a", "test/b", "test/c", "test/d"}, names)
+	require.Equal([]string{"test/a", "test/b", "test/c", "test/d"}, result.Names)
 }
 
 func TestClientListPaginated(t *testing.T) {
@@ -264,20 +264,20 @@ func TestClientListPaginated(t *testing.T) {
 		}, nil
 	})
 
-	names, continuationToken, err := client.List("test", &backend.ListOptions{
+	result, err := client.List("test", backend.ListOptions{
 		Paginated: true,
 		MaxKeys: 2,
 	})
 	require.NoError(err)
-	require.Equal([]string{"test/a", "test/b"}, names)
-	require.Equal("test-continuation-token", continuationToken)
+	require.Equal([]string{"test/a", "test/b"}, result.Names)
+	require.Equal("test-continuation-token", result.ContinuationToken)
 
-	names, continuationToken, err = client.List("test", &backend.ListOptions{
+	result, err = client.List("test", backend.ListOptions{
 		Paginated: true,
 		MaxKeys: 2,
-		ContinuationToken: continuationToken,
+		ContinuationToken: result.ContinuationToken,
 	})
 	require.NoError(err)
-	require.Equal([]string{"test/c", "test/d"}, names)
-	require.Equal("", continuationToken)
+	require.Equal([]string{"test/c", "test/d"}, result.Names)
+	require.Equal("", result.ContinuationToken)
 }

--- a/lib/backend/s3backend/s3.go
+++ b/lib/backend/s3backend/s3.go
@@ -35,6 +35,8 @@ type S3 interface {
 		options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 
 	ListObjectsPages(input *s3.ListObjectsInput, fn func(*s3.ListObjectsOutput, bool) bool) error
+
+	ListObjectsV2(input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error)
 }
 
 type join struct {

--- a/lib/backend/testfs/client.go
+++ b/lib/backend/testfs/client.go
@@ -133,6 +133,10 @@ func (c *Client) Download(namespace, name string, dst io.Writer) error {
 
 // List lists names starting with prefix.
 func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
+	if options != nil && options.Paginated {
+		return nil, "", errors.New("pagination not supported")
+	}
+
 	resp, err := httputil.Get(
 		fmt.Sprintf("http://%s/list/%s", c.config.Addr, path.Join(c.pather.BasePath(), prefix)))
 	if err != nil {

--- a/lib/backend/testfs/client.go
+++ b/lib/backend/testfs/client.go
@@ -132,7 +132,12 @@ func (c *Client) Download(namespace, name string, dst io.Writer) error {
 }
 
 // List lists names starting with prefix.
-func (c *Client) List(prefix string, options backend.ListOptions) (*backend.ListResult, error) {
+func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
+	options := backend.DefaultListOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	if options.Paginated {
 		return nil, errors.New("pagination not supported")
 	}

--- a/lib/backend/testfs/client.go
+++ b/lib/backend/testfs/client.go
@@ -132,24 +132,24 @@ func (c *Client) Download(namespace, name string, dst io.Writer) error {
 }
 
 // List lists names starting with prefix.
-func (c *Client) List(prefix string) ([]string, error) {
+func (c *Client) List(prefix string, options *backend.ListOptions) ([]string, string, error) {
 	resp, err := httputil.Get(
 		fmt.Sprintf("http://%s/list/%s", c.config.Addr, path.Join(c.pather.BasePath(), prefix)))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer resp.Body.Close()
 	var paths []string
 	if err := json.NewDecoder(resp.Body).Decode(&paths); err != nil {
-		return nil, fmt.Errorf("json: %s", err)
+		return nil, "", fmt.Errorf("json: %s", err)
 	}
 	var names []string
 	for _, p := range paths {
 		name, err := c.pather.NameFromBlobPath(p)
 		if err != nil {
-			return nil, fmt.Errorf("invalid path %s: %s", p, err)
+			return nil, "", fmt.Errorf("invalid path %s: %s", p, err)
 		}
 		names = append(names, name)
 	}
-	return names, nil
+	return names, "", nil
 }

--- a/lib/backend/testfs/server_test.go
+++ b/lib/backend/testfs/server_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/uber/kraken/core"
-	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/lib/backend/namepath"
 	"github.com/uber/kraken/utils/testutil"
@@ -106,7 +105,7 @@ func TestServerList(t *testing.T) {
 			require.NoError(c.Upload(ns, "a/b/d.txt", bytes.NewBufferString("bar")))
 			require.NoError(c.Upload(ns, "x/y/z.txt", bytes.NewBufferString("baz")))
 
-			result, err := c.List(test.prefix, backend.ListOptions{})
+			result, err := c.List(test.prefix)
 			require.NoError(err)
 			require.ElementsMatch(test.expected, result.Names)
 		})
@@ -131,7 +130,7 @@ func TestDockerTagList(t *testing.T) {
 		require.NoError(c.Upload(ns, tag, bytes.NewBufferString(core.DigestFixture().String())))
 	}
 
-	result, err := c.List("", backend.ListOptions{})
+	result, err := c.List("")
 	require.NoError(err)
 	require.ElementsMatch(tags, result.Names)
 }

--- a/lib/backend/testfs/server_test.go
+++ b/lib/backend/testfs/server_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/uber/kraken/core"
+	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/lib/backend/namepath"
 	"github.com/uber/kraken/utils/testutil"
@@ -105,7 +106,7 @@ func TestServerList(t *testing.T) {
 			require.NoError(c.Upload(ns, "a/b/d.txt", bytes.NewBufferString("bar")))
 			require.NoError(c.Upload(ns, "x/y/z.txt", bytes.NewBufferString("baz")))
 
-			names, err := c.List(test.prefix)
+			names, _, err := c.List(test.prefix, &backend.ListOptions{})
 			require.NoError(err)
 			require.ElementsMatch(test.expected, names)
 		})
@@ -130,7 +131,7 @@ func TestDockerTagList(t *testing.T) {
 		require.NoError(c.Upload(ns, tag, bytes.NewBufferString(core.DigestFixture().String())))
 	}
 
-	names, err := c.List("")
+	names, _, err := c.List("", &backend.ListOptions{})
 	require.NoError(err)
 	require.ElementsMatch(tags, names)
 }

--- a/lib/backend/testfs/server_test.go
+++ b/lib/backend/testfs/server_test.go
@@ -106,9 +106,9 @@ func TestServerList(t *testing.T) {
 			require.NoError(c.Upload(ns, "a/b/d.txt", bytes.NewBufferString("bar")))
 			require.NoError(c.Upload(ns, "x/y/z.txt", bytes.NewBufferString("baz")))
 
-			names, _, err := c.List(test.prefix, &backend.ListOptions{})
+			result, err := c.List(test.prefix, backend.ListOptions{})
 			require.NoError(err)
-			require.ElementsMatch(test.expected, names)
+			require.ElementsMatch(test.expected, result.Names)
 		})
 	}
 }
@@ -131,7 +131,7 @@ func TestDockerTagList(t *testing.T) {
 		require.NoError(c.Upload(ns, tag, bytes.NewBufferString(core.DigestFixture().String())))
 	}
 
-	names, _, err := c.List("", &backend.ListOptions{})
+	result, err := c.List("", backend.ListOptions{})
 	require.NoError(err)
-	require.ElementsMatch(tags, names)
+	require.ElementsMatch(tags, result.Names)
 }

--- a/mocks/lib/backend/client.go
+++ b/mocks/lib/backend/client.go
@@ -50,13 +50,12 @@ func (mr *MockClientMockRecorder) Download(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // List mocks base method
-func (m *MockClient) List(arg0 string, arg1 *backend.ListOptions) ([]string, string, error) {
+func (m *MockClient) List(arg0 string, arg1 backend.ListOptions) (*backend.ListResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(*backend.ListResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // List indicates an expected call of List

--- a/mocks/lib/backend/client.go
+++ b/mocks/lib/backend/client.go
@@ -50,18 +50,23 @@ func (mr *MockClientMockRecorder) Download(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // List mocks base method
-func (m *MockClient) List(arg0 string, arg1 backend.ListOptions) (*backend.ListResult, error) {
+func (m *MockClient) List(arg0 string, arg1 ...backend.ListOption) (*backend.ListResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0, arg1)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "List", varargs...)
 	ret0, _ := ret[0].(*backend.ListResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List
-func (mr *MockClientMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) List(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), arg0, arg1)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
 // Stat mocks base method

--- a/mocks/lib/backend/client.go
+++ b/mocks/lib/backend/client.go
@@ -7,6 +7,7 @@ package mockbackend
 import (
 	gomock "github.com/golang/mock/gomock"
 	core "github.com/uber/kraken/core"
+	backend "github.com/uber/kraken/lib/backend"
 	io "io"
 	reflect "reflect"
 )
@@ -49,18 +50,19 @@ func (mr *MockClientMockRecorder) Download(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // List mocks base method
-func (m *MockClient) List(arg0 string) ([]string, error) {
+func (m *MockClient) List(arg0 string, arg1 *backend.ListOptions) ([]string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // List indicates an expected call of List
-func (mr *MockClientMockRecorder) List(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), arg0, arg1)
 }
 
 // Stat mocks base method

--- a/mocks/lib/backend/s3backend/s3.go
+++ b/mocks/lib/backend/s3backend/s3.go
@@ -84,6 +84,21 @@ func (mr *MockS3MockRecorder) ListObjectsPages(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsPages", reflect.TypeOf((*MockS3)(nil).ListObjectsPages), arg0, arg1)
 }
 
+// ListObjectsV2 mocks base method
+func (m *MockS3) ListObjectsV2(arg0 *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListObjectsV2", arg0)
+	ret0, _ := ret[0].(*s3.ListObjectsV2Output)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListObjectsV2 indicates an expected call of ListObjectsV2
+func (mr *MockS3MockRecorder) ListObjectsV2(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsV2", reflect.TypeOf((*MockS3)(nil).ListObjectsV2), arg0)
+}
+
 // Upload mocks base method
 func (m *MockS3) Upload(arg0 *s3manager.UploadInput, arg1 ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Closes #22 

The backend's `Client` interface's `List` method is modified to add an addition parameter `ListOptions`. These parameters control pagination and potentially more settings in the future. `List` also returns an additional value, which is the continuation token. This will be an empty string if there is no more entries to list.

The `s3backend` has been modified to return a page of results and the continuation token if pagination was enabled. If pagination is not enabled the behavior of the backend does not change. Other backends will return an error if pagination is attempted to be used on them. The behavior of these backends has not been modified if pagination is not enabled.

Currently nothing has been modified to take advantage of s3's pagination support.