### PR TITLE
Add allowed cidrs in agent configuration

### DIFF
--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -183,6 +183,7 @@ func Run(flags *Flags) {
 	}
 
 	log.Fatal(nginx.Run(config.Nginx, map[string]interface{}{
+		"allowed_cidrs": config.AllowedCidrs,
 		"port": flags.AgentRegistryPort,
 		"registry_server": nginx.GetServer(
 			config.Registry.Docker.HTTP.Net, config.Registry.Docker.HTTP.Addr),

--- a/agent/cmd/config.go
+++ b/agent/cmd/config.go
@@ -43,4 +43,5 @@ type Config struct {
 	RegistryBackup  string                         `yaml:"registry_backup"`
 	Nginx           nginx.Config                   `yaml:"nginx"`
 	TLS             httputil.TLSConfig             `yaml:"tls"`
+	AllowedCidrs    []string                       `yaml:"allowed_cidrs"`
 }

--- a/config/agent/base.yaml
+++ b/config/agent/base.yaml
@@ -58,6 +58,11 @@ registry:
 
 peer_id_factory: addr_hash
 
+# Allow agent to only serve localhost and Docker default bridge requests.
+allowed_cidrs:
+  - 127.0.0.1
+  - 172.17.0.1
+
 nginx:
   name: kraken-agent
   cache_dir: /var/cache/kraken/kraken-agent/nginx/

--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -23,9 +23,9 @@ upstream registry-backend {
 server {
   listen {{.port}};
 
-  # Allow agent to only serve localhost and Docker default bridge requests.
-  allow 127.0.0.1;
-  allow 172.17.0.1;
+  {{range .allowed_cidrs}}
+    allow {{.}};
+  {{end}}
   deny all;
 
   {{.client_verification}}


### PR DESCRIPTION
Allow to configure which CIDR is allowed to use the kraken agent.