### PR TITLE
Make S3 continuation token nil instead of empty string

### DIFF
--- a/lib/backend/s3backend/client_test.go
+++ b/lib/backend/s3backend/client_test.go
@@ -186,7 +186,6 @@ func TestClientList(t *testing.T) {
 			Bucket:            aws.String("test-bucket"),
 			MaxKeys:           aws.Int64(250),
 			Prefix:            aws.String("root/test"),
-			ContinuationToken: aws.String(""),
 		},
 		gomock.Any(),
 	).DoAndReturn(func(
@@ -230,7 +229,6 @@ func TestClientListPaginated(t *testing.T) {
 			Bucket:            aws.String("test-bucket"),
 			MaxKeys:           aws.Int64(2),
 			Prefix:            aws.String("root/test"),
-			ContinuationToken: aws.String(""),
 		},
 		gomock.Any(),
 	).DoAndReturn(func(


### PR DESCRIPTION
Found an error in the S3 paginated code when testing against a real S3 bucket. When listing from a bucket without a continuation token, the `ContinuationToken` parameter must be `nil` and not a pointer an empty string.

@rmalpani-uber 