### PR TITLE
Support pagination for tagserver

### DIFF
--- a/lib/backend/gcsbackend/gcs.go
+++ b/lib/backend/gcsbackend/gcs.go
@@ -17,6 +17,7 @@ import (
 	"io"
 
 	"cloud.google.com/go/storage"
+	"github.com/uber/kraken/lib/backend"
 	"google.golang.org/api/iterator"
 )
 
@@ -26,4 +27,5 @@ type GCS interface {
 	Download(objectName string, w io.Writer) (int64, error)
 	Upload(objectName string, r io.Reader) (int64, error)
 	GetObjectIterator(prefix string) iterator.Pageable
+	NextPage(pager *iterator.Pager) (*backend.ListResult, error)
 }

--- a/mocks/lib/backend/gcsbackend/gcs.go
+++ b/mocks/lib/backend/gcsbackend/gcs.go
@@ -7,6 +7,7 @@ package mockgcsbackend
 import (
 	storage "cloud.google.com/go/storage"
 	gomock "github.com/golang/mock/gomock"
+	backend "github.com/uber/kraken/lib/backend"
 	iterator "google.golang.org/api/iterator"
 	io "io"
 	reflect "reflect"
@@ -62,6 +63,21 @@ func (m *MockGCS) GetObjectIterator(arg0 string) iterator.Pageable {
 func (mr *MockGCSMockRecorder) GetObjectIterator(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectIterator", reflect.TypeOf((*MockGCS)(nil).GetObjectIterator), arg0)
+}
+
+// NextPage mocks base method
+func (m *MockGCS) NextPage(arg0 *iterator.Pager) (*backend.ListResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NextPage", arg0)
+	ret0, _ := ret[0].(*backend.ListResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NextPage indicates an expected call of NextPage
+func (mr *MockGCSMockRecorder) NextPage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextPage", reflect.TypeOf((*MockGCS)(nil).NextPage), arg0)
 }
 
 // ObjectAttrs mocks base method


### PR DESCRIPTION
+ Support pagination in list and listRespositories handler
+ Fix bug in gcsbackend pagination
+ Response for list with pagination
type ListResponse struct {
       Links struct {
               Next string `json:"next"`
               Self string `json:"self"`
       }
       Size   int      `json:"size"`
       Result []string `json:"result"`
}

{
  "Links": {
    "next": "/list/?limit=3&offset=ClEvdGVzdC1idWNrZXQva3Jha2VuL2RlZmF1bHQvZG9ja2VyL3JlZ2lzdHJ5L3YyL2Jsb2JzL3NoYTI1Ni9hbC9hbHBpbmU6bGF0ZXN0L2RhdGE%3D",
    "self": "/list/?limit=3&offset=CoQBL3Rlc3QtYnVja2V0L2tyYWtlbi9kZWZhdWx0L2RvY2tlci9yZWdpc3RyeS92Mi9ibG9icy9zaGEyNTYvNTcvNTczMzRjNTA5NTlmMjZjZTFlZTAyNWQwOGYxMzZjMjI5MmMxMjhmODRlN2IyMjlkMWIwZGE1ZGFjODllOTg2Ni9kYXRh"
  },
  "size": 3,
  "result": [
    "/test-bucket/kraken/default/docker/registry/v2/blobs/sha256/92/921b31ab772b38172fd9f942a40fae6db24decbd6706f67836260d47a72baab5/data",
    "/test-bucket/kraken/default/docker/registry/v2/blobs/sha256/97/97a042bf09f1bf78c8cf3dcebef94614f2b95fa2f988a5c07314031bc2570c7a/data",
    "/test-bucket/kraken/default/docker/registry/v2/blobs/sha256/al/alpine:latest/data"
  ]
}