### PR TITLE
Added tracker Monitor 

### DIFF
--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -131,6 +131,7 @@ func Run(flags *Flags) {
 	if err != nil {
 		log.Fatalf("Error building tracker upstream: %s", err)
 	}
+	go trackers.Monitor(nil)
 
 	tls, err := config.TLS.BuildClient()
 	if err != nil {


### PR DESCRIPTION
Fix for #195 
Added tracker.Monitor in agent to periodically resolves for hostname similar to how origin refreshes its hashring https://github.com/uber/kraken/blob/master/origin/cmd/cmd.go#L199

**Test:** Delete all tracker pods and bring them back up, expected agent to refresh tracker hashring and successfully pull images