### PR TITLE
fix: kubernetes example

### DIFF
--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -10,7 +10,7 @@ configurable.
 ## 2. Pulling from Docker Hub Library
 
 A simple registry storage backend is provided for read-only access to Docker registry. A library 
-image can be pulled from Kraken agent by specifying `localhost:30081` in the image name in pod
+image can be pulled from Kraken agent by specifying `127.0.0.1:30081` in the image name in pod
 spec. For example spec, see [example](demo.json).
 
 Note, this backend is used only for all `library/.*` repositories. `library` is the default

--- a/examples/k8s/demo.json
+++ b/examples/k8s/demo.json
@@ -21,7 +21,7 @@
                 "containers": [
                     {
                         "name": "main",
-                        "image": "localhost:30081/library/busybox:latest",
+                        "image": "127.0.0.1:30081/library/busybox:latest",
                         "command": [
                             "/bin/sh", "-c",
                             "while true; do sleep 10; done"


### PR DESCRIPTION
Based on my testing, using locahost will run afoul of how Kubernetes sets up the iptables rules and the traffic will get blackholed. Using the actual IP works.