### PR TITLE
Run function for bypassing config loading

### DIFF
--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -74,15 +74,6 @@ func ParseFlags() *Flags {
 
 // Run runs the agent.
 func Run(flags *Flags) {
-	if flags.PeerPort == 0 {
-		panic("must specify non-zero peer port")
-	}
-	if flags.AgentServerPort == 0 {
-		panic("must specify non-zero agent server port")
-	}
-	if flags.AgentRegistryPort == 0 {
-		panic("must specify non-zero agent registry port")
-	}
 	var config Config
 	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
 		panic(err)
@@ -92,6 +83,21 @@ func Run(flags *Flags) {
 		if err := configutil.Load(flags.SecretsFile, &config); err != nil {
 			panic(err)
 		}
+	}
+	RunWithConfig(flags, config)
+}
+
+// RunWithConfig runs the agent, but ignores config/secrets flags and directly
+// uses the provided config struct.
+func RunWithConfig(flags *Flags, config Config) {
+	if flags.PeerPort == 0 {
+		panic("must specify non-zero peer port")
+	}
+	if flags.AgentServerPort == 0 {
+		panic("must specify non-zero agent server port")
+	}
+	if flags.AgentRegistryPort == 0 {
+		panic("must specify non-zero agent registry port")
 	}
 
 	zlog := log.ConfigureLogger(config.ZapLogging)

--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -61,10 +61,6 @@ func ParseFlags() *Flags {
 
 // Run runs the build-index.
 func Run(flags *Flags) {
-	if flags.Port == 0 {
-		panic("must specify non-zero port")
-	}
-
 	var config Config
 	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
 		panic(err)
@@ -74,6 +70,16 @@ func Run(flags *Flags) {
 			panic(err)
 		}
 	}
+	RunWithConfig(flags, config)
+}
+
+// RunWithConfig runs the build-index, but ignores config/secrets flags and directly
+// uses the provided config struct.
+func RunWithConfig(flags *Flags, config Config) {
+	if flags.Port == 0 {
+		panic("must specify non-zero port")
+	}
+
 	log.ConfigureLogger(config.ZapLogging)
 
 	stats, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -83,6 +83,21 @@ func ParseFlags() *Flags {
 
 // Run runs the origin.
 func Run(flags *Flags) {
+	var config Config
+	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
+		panic(err)
+	}
+	if flags.SecretsFile != "" {
+		if err := configutil.Load(flags.SecretsFile, &config); err != nil {
+			panic(err)
+		}
+	}
+	RunWithConfig(flags, config)
+}
+
+// RunWithConfig runs the origin, but ignores config/secrets flags and directly
+// uses the provided config struct.
+func RunWithConfig(flags *Flags, config Config) {
 	if flags.PeerPort == 0 {
 		panic("must specify non-zero peer port")
 	}
@@ -101,16 +116,6 @@ func Run(flags *Flags) {
 		hostname = flags.BlobServerHostName
 	}
 	log.Infof("Configuring origin with hostname '%s'", hostname)
-
-	var config Config
-	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
-		panic(err)
-	}
-	if flags.SecretsFile != "" {
-		if err := configutil.Load(flags.SecretsFile, &config); err != nil {
-			panic(err)
-		}
-	}
 
 	zlog := log.ConfigureLogger(config.ZapLogging)
 	defer zlog.Sync()

--- a/proxy/cmd/cmd.go
+++ b/proxy/cmd/cmd.go
@@ -62,10 +62,6 @@ func ParseFlags() *Flags {
 
 // Run runs the proxy.
 func Run(flags *Flags) {
-	if len(flags.Ports) == 0 {
-		panic("must specify a port")
-	}
-
 	var config Config
 	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
 		panic(err)
@@ -75,12 +71,17 @@ func Run(flags *Flags) {
 			panic(err)
 		}
 	}
+	RunWithConfig(flags, config)
+}
+
+// RunWithConfig runs the proxy, but ignores config/secrets flags and directly
+// uses the provided config struct.
+func RunWithConfig(flags *Flags, config Config) {
+	if len(flags.Ports) == 0 {
+		panic("must specify a port")
+	}
 
 	log.ConfigureLogger(config.ZapLogging)
-
-	if len(flags.Ports) == 0 {
-		log.Fatal("Must specify at least one -port")
-	}
 
 	stats, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
 	if err != nil {

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -65,6 +65,12 @@ func Run(flags *Flags) {
 			panic(err)
 		}
 	}
+	RunWithConfig(flags, config)
+}
+
+// RunWithConfig runs the tracker, but ignores config/secrets flags and directly
+// uses the provided config struct.
+func RunWithConfig(flags *Flags, config Config) {
 	log.ConfigureLogger(config.ZapLogging)
 
 	stats, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)


### PR DESCRIPTION
Depends on https://github.com/uber/kraken/pull/228

Adds a function to each cmd package for bypassing config loading.
This allows closed-source consumers of the cmd packages to use their
own config loading.