### PR TITLE
Options for passing metrics / logger to Run

### DIFF
--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -34,6 +34,9 @@ import (
 	"github.com/uber/kraken/origin/blobclient"
 	"github.com/uber/kraken/utils/configutil"
 	"github.com/uber/kraken/utils/log"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 // Flags defines build-index CLI flags.
@@ -59,34 +62,72 @@ func ParseFlags() *Flags {
 	return &flags
 }
 
-// Run runs the build-index.
-func Run(flags *Flags) {
-	var config Config
-	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
-		panic(err)
-	}
-	if flags.SecretsFile != "" {
-		if err := configutil.Load(flags.SecretsFile, &config); err != nil {
-			panic(err)
-		}
-	}
-	RunWithConfig(flags, config)
+type options struct {
+	config  *Config
+	metrics tally.Scope
+	logger  *zap.Logger
 }
 
-// RunWithConfig runs the build-index, but ignores config/secrets flags and directly
-// uses the provided config struct.
-func RunWithConfig(flags *Flags, config Config) {
+// Option defines an optional Run parameter.
+type Option func(*options)
+
+// WithConfig ignores config/secrets flags and directly uses the provided config
+// struct.
+func WithConfig(c Config) Option {
+	return func(o *options) { o.config = &c }
+}
+
+// WithMetrics ignores metrics config and directly uses the provided tally scope.
+func WithMetrics(s tally.Scope) Option {
+	return func(o *options) { o.metrics = s }
+}
+
+// WithLogger ignores logging config and directly uses the provided logger.
+func WithLogger(l *zap.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// Run runs the build-index.
+func Run(flags *Flags, opts ...Option) {
 	if flags.Port == 0 {
 		panic("must specify non-zero port")
 	}
 
-	log.ConfigureLogger(config.ZapLogging)
-
-	stats, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
-	if err != nil {
-		log.Fatalf("Failed to init metrics: %s", err)
+	var overrides options
+	for _, o := range opts {
+		o(&overrides)
 	}
-	defer closer.Close()
+
+	var config Config
+	if overrides.config != nil {
+		config = *overrides.config
+	} else {
+		if err := configutil.Load(flags.ConfigFile, &config); err != nil {
+			panic(err)
+		}
+		if flags.SecretsFile != "" {
+			if err := configutil.Load(flags.SecretsFile, &config); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	if overrides.logger != nil {
+		log.SetGlobalLogger(overrides.logger.Sugar())
+	} else {
+		zlog := log.ConfigureLogger(config.ZapLogging)
+		defer zlog.Sync()
+	}
+
+	stats := overrides.metrics
+	if stats == nil {
+		s, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
+		if err != nil {
+			log.Fatalf("Failed to init metrics: %s", err)
+		}
+		stats = s
+		defer closer.Close()
+	}
 
 	go metrics.EmitVersion(stats)
 

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	go.uber.org/atomic v1.4.0
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v0.0.0-20190327195448-badef736563f
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/api v0.7.0

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -44,6 +44,8 @@ import (
 
 	"github.com/andres-erbsen/clock"
 	"github.com/pressly/chi"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 // Flags defines origin CLI flags.
@@ -81,29 +83,77 @@ func ParseFlags() *Flags {
 	return &flags
 }
 
-// Run runs the origin.
-func Run(flags *Flags) {
-	var config Config
-	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
-		panic(err)
-	}
-	if flags.SecretsFile != "" {
-		if err := configutil.Load(flags.SecretsFile, &config); err != nil {
-			panic(err)
-		}
-	}
-	RunWithConfig(flags, config)
+type options struct {
+	config  *Config
+	metrics tally.Scope
+	logger  *zap.Logger
 }
 
-// RunWithConfig runs the origin, but ignores config/secrets flags and directly
-// uses the provided config struct.
-func RunWithConfig(flags *Flags, config Config) {
+// Option defines an optional Run parameter.
+type Option func(*options)
+
+// WithConfig ignores config/secrets flags and directly uses the provided config
+// struct.
+func WithConfig(c Config) Option {
+	return func(o *options) { o.config = &c }
+}
+
+// WithMetrics ignores metrics config and directly uses the provided tally scope.
+func WithMetrics(s tally.Scope) Option {
+	return func(o *options) { o.metrics = s }
+}
+
+// WithLogger ignores logging config and directly uses the provided logger.
+func WithLogger(l *zap.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// Run runs the origin.
+func Run(flags *Flags, opts ...Option) {
 	if flags.PeerPort == 0 {
 		panic("must specify non-zero peer port")
 	}
 	if flags.BlobServerPort == 0 {
 		panic("must specify non-zero blob server port")
 	}
+
+	var overrides options
+	for _, o := range opts {
+		o(&overrides)
+	}
+
+	var config Config
+	if overrides.config != nil {
+		config = *overrides.config
+	} else {
+		if err := configutil.Load(flags.ConfigFile, &config); err != nil {
+			panic(err)
+		}
+		if flags.SecretsFile != "" {
+			if err := configutil.Load(flags.SecretsFile, &config); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	if overrides.logger != nil {
+		log.SetGlobalLogger(overrides.logger.Sugar())
+	} else {
+		zlog := log.ConfigureLogger(config.ZapLogging)
+		defer zlog.Sync()
+	}
+
+	stats := overrides.metrics
+	if stats == nil {
+		s, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
+		if err != nil {
+			log.Fatalf("Failed to init metrics: %s", err)
+		}
+		stats = s
+		defer closer.Close()
+	}
+
+	go metrics.EmitVersion(stats)
 
 	var hostname string
 	if flags.BlobServerHostName == "" {
@@ -116,17 +166,6 @@ func RunWithConfig(flags *Flags, config Config) {
 		hostname = flags.BlobServerHostName
 	}
 	log.Infof("Configuring origin with hostname '%s'", hostname)
-
-	zlog := log.ConfigureLogger(config.ZapLogging)
-	defer zlog.Sync()
-
-	stats, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
-	if err != nil {
-		log.Fatalf("Failed to init metrics: %s", err)
-	}
-	defer closer.Close()
-
-	go metrics.EmitVersion(stats)
 
 	if flags.PeerIP == "" {
 		localIP, err := netutil.GetLocalIP()

--- a/proxy/cmd/cmd.go
+++ b/proxy/cmd/cmd.go
@@ -32,6 +32,9 @@ import (
 	"github.com/uber/kraken/utils/configutil"
 	"github.com/uber/kraken/utils/flagutil"
 	"github.com/uber/kraken/utils/log"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 // Flags defines proxy CLI flags.
@@ -60,34 +63,72 @@ func ParseFlags() *Flags {
 	return &flags
 }
 
-// Run runs the proxy.
-func Run(flags *Flags) {
-	var config Config
-	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
-		panic(err)
-	}
-	if flags.SecretsFile != "" {
-		if err := configutil.Load(flags.SecretsFile, &config); err != nil {
-			panic(err)
-		}
-	}
-	RunWithConfig(flags, config)
+type options struct {
+	config  *Config
+	metrics tally.Scope
+	logger  *zap.Logger
 }
 
-// RunWithConfig runs the proxy, but ignores config/secrets flags and directly
-// uses the provided config struct.
-func RunWithConfig(flags *Flags, config Config) {
+// Option defines an optional Run parameter.
+type Option func(*options)
+
+// WithConfig ignores config/secrets flags and directly uses the provided config
+// struct.
+func WithConfig(c Config) Option {
+	return func(o *options) { o.config = &c }
+}
+
+// WithMetrics ignores metrics config and directly uses the provided tally scope.
+func WithMetrics(s tally.Scope) Option {
+	return func(o *options) { o.metrics = s }
+}
+
+// WithLogger ignores logging config and directly uses the provided logger.
+func WithLogger(l *zap.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// Run runs the proxy.
+func Run(flags *Flags, opts ...Option) {
 	if len(flags.Ports) == 0 {
 		panic("must specify a port")
 	}
 
-	log.ConfigureLogger(config.ZapLogging)
-
-	stats, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
-	if err != nil {
-		log.Fatalf("Failed to init metrics: %s", err)
+	var overrides options
+	for _, o := range opts {
+		o(&overrides)
 	}
-	defer closer.Close()
+
+	var config Config
+	if overrides.config != nil {
+		config = *overrides.config
+	} else {
+		if err := configutil.Load(flags.ConfigFile, &config); err != nil {
+			panic(err)
+		}
+		if flags.SecretsFile != "" {
+			if err := configutil.Load(flags.SecretsFile, &config); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	if overrides.logger != nil {
+		log.SetGlobalLogger(overrides.logger.Sugar())
+	} else {
+		zlog := log.ConfigureLogger(config.ZapLogging)
+		defer zlog.Sync()
+	}
+
+	stats := overrides.metrics
+	if stats == nil {
+		s, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
+		if err != nil {
+			log.Fatalf("Failed to init metrics: %s", err)
+		}
+		stats = s
+		defer closer.Close()
+	}
 
 	go metrics.EmitVersion(stats)
 

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -29,6 +29,8 @@ import (
 	"github.com/uber/kraken/utils/log"
 
 	"github.com/andres-erbsen/clock"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 // Flags define tracker CLI flags.
@@ -54,30 +56,68 @@ func ParseFlags() *Flags {
 	return &flags
 }
 
-// Run runs the tracker.
-func Run(flags *Flags) {
-	var config Config
-	if err := configutil.Load(flags.ConfigFile, &config); err != nil {
-		panic(err)
-	}
-	if flags.SecretsFile != "" {
-		if err := configutil.Load(flags.SecretsFile, &config); err != nil {
-			panic(err)
-		}
-	}
-	RunWithConfig(flags, config)
+type options struct {
+	config  *Config
+	metrics tally.Scope
+	logger  *zap.Logger
 }
 
-// RunWithConfig runs the tracker, but ignores config/secrets flags and directly
-// uses the provided config struct.
-func RunWithConfig(flags *Flags, config Config) {
-	log.ConfigureLogger(config.ZapLogging)
+// Option defines an optional Run parameter.
+type Option func(*options)
 
-	stats, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
-	if err != nil {
-		log.Fatalf("Failed to init metrics: %s", err)
+// WithConfig ignores config/secrets flags and directly uses the provided config
+// struct.
+func WithConfig(c Config) Option {
+	return func(o *options) { o.config = &c }
+}
+
+// WithMetrics ignores metrics config and directly uses the provided tally scope.
+func WithMetrics(s tally.Scope) Option {
+	return func(o *options) { o.metrics = s }
+}
+
+// WithLogger ignores logging config and directly uses the provided logger.
+func WithLogger(l *zap.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// Run runs the tracker.
+func Run(flags *Flags, opts ...Option) {
+	var overrides options
+	for _, o := range opts {
+		o(&overrides)
 	}
-	defer closer.Close()
+
+	var config Config
+	if overrides.config != nil {
+		config = *overrides.config
+	} else {
+		if err := configutil.Load(flags.ConfigFile, &config); err != nil {
+			panic(err)
+		}
+		if flags.SecretsFile != "" {
+			if err := configutil.Load(flags.SecretsFile, &config); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	if overrides.logger != nil {
+		log.SetGlobalLogger(overrides.logger.Sugar())
+	} else {
+		zlog := log.ConfigureLogger(config.ZapLogging)
+		defer zlog.Sync()
+	}
+
+	stats := overrides.metrics
+	if stats == nil {
+		s, closer, err := metrics.New(config.Metrics, flags.KrakenCluster)
+		if err != nil {
+			log.Fatalf("Failed to init metrics: %s", err)
+		}
+		stats = s
+		defer closer.Close()
+	}
 
 	go metrics.EmitVersion(stats)
 

--- a/utils/log/log.go
+++ b/utils/log/log.go
@@ -50,6 +50,11 @@ func ConfigureLogger(zapConfig zap.Config) *zap.SugaredLogger {
 	return _default
 }
 
+// SetGlobalLogger sets the global logger.
+func SetGlobalLogger(l *zap.SugaredLogger) {
+	_default = l
+}
+
 // Default returns the default global logger.
 func Default() *zap.SugaredLogger {
 	return _default


### PR DESCRIPTION
Allows internal kraken users (cough cough uber) to inject
their own logger / metrics into each component. This is useful
if you're compiling non-kraken code into the same binary, which
need a logger and metrics (as most do).