### PR TITLE
Add ability to set registry backend http timeout

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -193,6 +193,7 @@ Example origin config that uses multiple backends:
 >    backend:
 >      registry_blob:
 >        address: index.docker.io
+>        timeout: 60s
 >        security:
 >          basic:
 >            username: ""

--- a/lib/backend/registrybackend/blobclient.go
+++ b/lib/backend/registrybackend/blobclient.go
@@ -60,7 +60,7 @@ type BlobClient struct {
 
 // NewBlobClient creates a new BlobClient.
 func NewBlobClient(config Config) (*BlobClient, error) {
-	return &BlobClient{config}, nil
+	return &BlobClient{config: config.applyDefaults()}, nil
 }
 
 // Stat sends a HEAD request to registry for a blob and returns the blob size.
@@ -120,7 +120,9 @@ func (c *BlobClient) downloadHelper(namespace, name, query string, dst io.Writer
 	resp, err := httputil.Get(
 		URL,
 		opt,
-		httputil.SendAcceptedCodes(http.StatusOK))
+		httputil.SendAcceptedCodes(http.StatusOK),
+		httputil.SendTimeout(c.config.Timeout),
+	)
 	if err != nil {
 		if httputil.IsNotFound(err) {
 			return backenderrors.ErrBlobNotFound

--- a/lib/backend/registrybackend/config.go
+++ b/lib/backend/registrybackend/config.go
@@ -13,10 +13,23 @@
 // limitations under the License.
 package registrybackend
 
-import "github.com/uber/kraken/lib/backend/registrybackend/security"
+import (
+	"time"
 
-// Config defines the registry address and security options.
+	"github.com/uber/kraken/lib/backend/registrybackend/security"
+)
+
+// Config defines the registry address, timeout and security options.
 type Config struct {
 	Address  string          `yaml:"address"`
+	Timeout  time.Duration   `yaml:"timeout"`
 	Security security.Config `yaml:"security"`
+}
+
+// Set default configuration
+func (c Config) applyDefaults() Config {
+	if c.Timeout == 0 {
+		c.Timeout = 60 * time.Second
+	}
+	return c
 }


### PR DESCRIPTION
When pulling large layers from a registry backend, pull fails if the duration exceed 60 seconds for a particular layer. This commit introduces a new `timeout` configuration keyword to increase that value.

This probably fixes #208.