### PR TITLE
Add self-hosted S3 support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -217,6 +217,17 @@ Example origin config that uses multiple backends:
 >       root_directory: /test-bucket/kraken/default/
 >       name_path: sharded_docker_blob
 >       username: kraken-user
+> - namespace: minio-images/.*
+>   backend:
+>     s3:
+>       region: us-east-1
+>       bucket: self-hosted-bucket
+>       root_directory: /kraken/default/
+>       name_path: sharded_docker_blob
+>       username: minio-user
+>       endpoint: http://172.17.0.1:9000
+>       disable_ssl: true
+>       force_path_style: true
 >   bandwidth:
 >     enable: true
 > - namespace: gcs-images/.*
@@ -234,6 +245,11 @@ Example origin config that uses multiple backends:
 >    kraken-user:
 >      s3:
 >        aws: kraken-user
+>        aws_access_key_id: <keyid>
+>        aws_secret_access_key: <key>
+>    minio-user:
+>      s3:
+>        aws: minio-user
 >        aws_access_key_id: <keyid>
 >        aws_secret_access_key: <key>
 >  gcs:

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -112,7 +112,13 @@ func NewClient(
 	creds := credentials.NewStaticCredentials(
 		auth.S3.AccessKeyID, auth.S3.AccessSecretKey, auth.S3.SessionToken)
 
-	api := s3.New(session.New(), aws.NewConfig().WithRegion(config.Region).WithCredentials(creds))
+	awsConfig := aws.NewConfig().WithRegion(config.Region).WithCredentials(creds)
+
+	if config.Endpoint != "" {
+		awsConfig = awsConfig.WithEndpoint(config.Endpoint)
+	}
+
+	api := s3.New(session.New(), awsConfig)
 
 	downloader := s3manager.NewDownloaderWithClient(api, func(d *s3manager.Downloader) {
 		d.PartSize = config.DownloadPartSize

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -118,6 +118,10 @@ func NewClient(
 		awsConfig = awsConfig.WithEndpoint(config.Endpoint)
 	}
 
+	if config.S3ForcePathStyle {
+		awsConfig = awsConfig.WithS3ForcePathStyle(config.S3ForcePathStyle)
+	}
+
 	api := s3.New(session.New(), awsConfig)
 
 	downloader := s3manager.NewDownloaderWithClient(api, func(d *s3manager.Downloader) {

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -118,6 +118,10 @@ func NewClient(
 		awsConfig = awsConfig.WithEndpoint(config.Endpoint)
 	}
 
+	if config.DisableSSL {
+		awsConfig = awsConfig.WithDisableSSL(config.DisableSSL)
+	}
+
 	if config.S3ForcePathStyle {
 		awsConfig = awsConfig.WithS3ForcePathStyle(config.S3ForcePathStyle)
 	}

--- a/lib/backend/s3backend/config.go
+++ b/lib/backend/s3backend/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Region           string `yaml:"region"`           // AWS S3 region
 	Bucket           string `yaml:"bucket"`           // S3 bucket
 	Endpoint         string `yaml:"endpoint"`         // S3 endpoint
+	S3ForcePathStyle bool   `yaml:"force_path_style"` // use path style instead of DNS style
 
 	RootDirectory    string `yaml:"root_directory"`     // S3 root directory for docker images
 	UploadPartSize   int64  `yaml:"upload_part_size"`   // part size s3 manager uses for upload

--- a/lib/backend/s3backend/config.go
+++ b/lib/backend/s3backend/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Region           string `yaml:"region"`           // AWS S3 region
 	Bucket           string `yaml:"bucket"`           // S3 bucket
 	Endpoint         string `yaml:"endpoint"`         // S3 endpoint
+	DisableSSL       bool   `yaml:"disable_ssl"`      // use clear HTTP when talking to endpoint
 	S3ForcePathStyle bool   `yaml:"force_path_style"` // use path style instead of DNS style
 
 	RootDirectory    string `yaml:"root_directory"`     // S3 root directory for docker images

--- a/lib/backend/s3backend/config.go
+++ b/lib/backend/s3backend/config.go
@@ -22,9 +22,10 @@ import (
 // Config defines s3 connection specific
 // parameters and authetication credentials
 type Config struct {
-	Username string `yaml:"username"` // IAM username for selecting credentials.
-	Region   string `yaml:"region"`   // AWS S3 region
-	Bucket   string `yaml:"bucket"`   // S3 bucket
+	Username         string `yaml:"username"`         // IAM username for selecting credentials.
+	Region           string `yaml:"region"`           // AWS S3 region
+	Bucket           string `yaml:"bucket"`           // S3 bucket
+	Endpoint         string `yaml:"endpoint"`         // S3 endpoint
 
 	RootDirectory    string `yaml:"root_directory"`     // S3 root directory for docker images
 	UploadPartSize   int64  `yaml:"upload_part_size"`   // part size s3 manager uses for upload


### PR DESCRIPTION
This PR introduce the ability to use a self-hosted S3-compatible backend like [minio](https://min.io/)

It uses AWS S3 backend and authentication configuration, and added 3 options :

 * `endpoint` : HTTP endpoint to use (eg. `http://minio.example.local:9000`)
 * `disable_ssl` : In case you want to see the traffic between kraken and the S3 backend
 * `force_path_style` : In case your bucket name contains dots (see [doc](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro))

To test that PR using minio, you could use :

```
# start minio
docker run \
	--detach \
	--name kraken-minio \
	--publish 9000:9000 \
	--env MINIO_ACCESS_KEY=minio_user \
	--env MINIO_SECRET_KEY=minio_pass \
	minio/minio server /data

# create bucket using official AWS CLI
AWS_DEFAULT_REGION=us-east-1 AWS_ACCESS_KEY_ID=minio_user AWS_SECRET_ACCESS_KEY=minio_pass \
	aws --endpoint-url http://172.17.0.1:9000 s3 mb s3://kraken-data
```