### PR TITLE
lib/backend/registrybackend/security: Disable automated HTTP fallback

### DIFF
--- a/lib/backend/registrybackend/blobclient_test.go
+++ b/lib/backend/registrybackend/blobclient_test.go
@@ -55,7 +55,7 @@ func TestBlobDownloadBlobSuccess(t *testing.T) {
 	addr, stop := testutil.StartServer(r)
 	defer stop()
 
-	config := Config{Address: addr}
+	config := newTestConfig(addr)
 	client, err := NewBlobClient(config)
 	require.NoError(err)
 
@@ -85,7 +85,7 @@ func TestBlobDownloadManifestSuccess(t *testing.T) {
 	addr, stop := testutil.StartServer(r)
 	defer stop()
 
-	config := Config{Address: addr}
+	config := newTestConfig(addr)
 	client, err := NewBlobClient(config)
 	require.NoError(err)
 
@@ -115,7 +115,7 @@ func TestBlobDownloadFileNotFound(t *testing.T) {
 	addr, stop := testutil.StartServer(r)
 	defer stop()
 
-	config := Config{Address: addr}
+	config := newTestConfig(addr)
 	client, err := NewBlobClient(config)
 	require.NoError(err)
 

--- a/lib/backend/registrybackend/config_test.go
+++ b/lib/backend/registrybackend/config_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registrybackend
+
+import "github.com/uber/kraken/lib/backend/registrybackend/security"
+
+func newTestConfig(addr string) Config {
+	return Config{
+		Address: addr,
+		Security: security.Config{
+			EnableHTTPFallback: true,
+		},
+	}
+}

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -82,7 +82,7 @@ func (c *TagClient) Stat(namespace, name string) (*core.BlobInfo, error) {
 	}
 	repo, tag := tokens[0], tokens[1]
 
-	opt, err := c.authenticator.Authenticate(repo)
+	opts, err := c.authenticator.Authenticate(repo)
 	if err != nil {
 		return nil, fmt.Errorf("get security opt: %s", err)
 	}
@@ -90,9 +90,12 @@ func (c *TagClient) Stat(namespace, name string) (*core.BlobInfo, error) {
 	URL := fmt.Sprintf(_tagquery, c.config.Address, repo, tag)
 	resp, err := httputil.Head(
 		URL,
-		opt,
-		httputil.SendHeaders(map[string]string{"Accept": _v2ManifestType}),
-		httputil.SendAcceptedCodes(http.StatusOK, http.StatusNotFound))
+		append(
+			opts,
+			httputil.SendHeaders(map[string]string{"Accept": _v2ManifestType}),
+			httputil.SendAcceptedCodes(http.StatusOK, http.StatusNotFound),
+		)...,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("check blob exists: %s", err)
 	}
@@ -115,7 +118,7 @@ func (c *TagClient) Download(namespace, name string, dst io.Writer) error {
 	}
 	repo, tag := tokens[0], tokens[1]
 
-	opt, err := c.authenticator.Authenticate(repo)
+	opts, err := c.authenticator.Authenticate(repo)
 	if err != nil {
 		return fmt.Errorf("get security opt: %s", err)
 	}
@@ -123,9 +126,12 @@ func (c *TagClient) Download(namespace, name string, dst io.Writer) error {
 	URL := fmt.Sprintf(_tagquery, c.config.Address, repo, tag)
 	resp, err := httputil.Get(
 		URL,
-		opt,
-		httputil.SendHeaders(map[string]string{"Accept": _v2ManifestType}),
-		httputil.SendAcceptedCodes(http.StatusOK, http.StatusNotFound))
+		append(
+			opts,
+			httputil.SendHeaders(map[string]string{"Accept": _v2ManifestType}),
+			httputil.SendAcceptedCodes(http.StatusOK, http.StatusNotFound),
+		)...,
+	)
 	if err != nil {
 		return fmt.Errorf("check blob exists: %s", err)
 	}

--- a/lib/backend/registrybackend/tagclient_test.go
+++ b/lib/backend/registrybackend/tagclient_test.go
@@ -57,7 +57,7 @@ func TestTagDownloadSuccess(t *testing.T) {
 	addr, stop := testutil.StartServer(r)
 	defer stop()
 
-	config := Config{Address: addr}
+	config := newTestConfig(addr)
 	client, err := NewTagClient(config)
 	require.NoError(err)
 
@@ -87,7 +87,7 @@ func TestTagDownloadFileNotFound(t *testing.T) {
 	addr, stop := testutil.StartServer(r)
 	defer stop()
 
-	config := Config{Address: addr}
+	config := newTestConfig(addr)
 	client, err := NewTagClient(config)
 	require.NoError(err)
 


### PR DESCRIPTION
This PR changes the registry backend so that it does NOT [automatically fall back to unencrypted HTTP](/uber/kraken/blob/master/utils/httputil/httputil.go#L291-L305) whenever an HTTPS call fails (possibly due to network error or timeout). Communication with backend registries often includes authentication credentials in the requests, so falling back to HTTP is typically undesirable.

Users who wish to preserve the prior behavior can explicitly enable HTTP fallback by setting `enableHTTPFallback: true` in the registry backend's security configuration.