### PR TITLE
Add option to disable blob hash verification

### DIFF
--- a/lib/store/ca_store.go
+++ b/lib/store/ca_store.go
@@ -135,8 +135,10 @@ func (s *CAStore) WriteCacheFile(name string, write func(w FileReadWriter) error
 	return nil
 }
 
+// verify verifies that name is a valid SHA256 digest, and checks if the given
+// blob content matches the digset unless explicitly skipped.
 func (s *CAStore) verify(r io.Reader, name string) error {
-	// Verify that expected name is valid.
+	// Verify that expected name is a valid SHA256 digest.
 	expected, err := core.NewSHA256DigestFromHex(name)
 	if err != nil {
 		return fmt.Errorf("new digest from file name: %s", err)

--- a/lib/store/ca_store.go
+++ b/lib/store/ca_store.go
@@ -31,6 +31,8 @@ import (
 
 // CAStore allows uploading / caching content-addressable files.
 type CAStore struct {
+	config CAStoreConfig
+
 	*uploadStore
 	*cacheStore
 	cleanup *cleanupManager
@@ -66,7 +68,7 @@ func NewCAStore(config CAStoreConfig, stats tally.Scope) (*CAStore, error) {
 	cleanup.addJob("upload", config.UploadCleanup, uploadStore.newFileOp())
 	cleanup.addJob("cache", config.CacheCleanup, cacheStore.newFileOp())
 
-	return &CAStore{uploadStore, cacheStore, cleanup}, nil
+	return &CAStore{config, uploadStore, cacheStore, cleanup}, nil
 }
 
 // Close terminates any goroutines started by s.

--- a/lib/store/ca_store.go
+++ b/lib/store/ca_store.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"net/http"
 	"os"
 	"path"
 
@@ -88,7 +87,7 @@ func (s *CAStore) MoveUploadFileToCache(uploadName, cacheName string) error {
 		return fmt.Errorf("get file reader %s: %s", uploadName, err)
 	}
 	defer f.Close()
-	if err := s.verify(w, cacheName); err != nil {
+	if err := s.verify(f, cacheName); err != nil {
 		return fmt.Errorf("verify digest: %s", err)
 	}
 
@@ -147,12 +146,10 @@ func (s *CAStore) verify(r io.Reader, name string) error {
 		digester := core.NewDigester()
 		computed, err := digester.FromReader(r)
 		if err != nil {
-			return handler.Errorf("calculate digest: %s", err)
+			return fmt.Errorf("calculate digest: %s", err)
 		}
 		if computed != expected {
-			return handler.
-				Errorf("computed digest %s doesn't match expected value %s", computed, expected).
-				Status(http.StatusBadRequest)
+			return fmt.Errorf("computed digest %s doesn't match expected value %s", computed, expected)
 		}
 	}
 	return nil

--- a/lib/store/ca_store_test.go
+++ b/lib/store/ca_store_test.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/uber/kraken/core"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"github.com/uber/kraken/core"
 )
 
 func TestCAStoreInitVolumes(t *testing.T) {
@@ -145,11 +145,18 @@ func TestCAStoreCreateUploadFileAndMoveToCache(t *testing.T) {
 	require.NoError(err)
 
 	src := core.DigestFixture().Hex()
-	dst := core.DigestFixture().Hex()
 
 	require.NoError(s.CreateUploadFile(src, 100))
 	_, err = os.Stat(path.Join(config.UploadDir, src))
 	require.NoError(err)
+
+	f, err := s.uploadStore.newFileOp().GetFileReader(src)
+	require.NoError(err)
+	defer f.Close()
+	digester := core.NewDigester()
+	digest, err := digester.FromReader(f)
+	require.NoError(err)
+	dst := digest.Hex()
 
 	err = s.MoveUploadFileToCache(src, dst)
 	require.NoError(err)

--- a/lib/store/config.go
+++ b/lib/store/config.go
@@ -29,6 +29,8 @@ type CAStoreConfig struct {
 	Capacity      int           `yaml:"capacity"`
 	UploadCleanup CleanupConfig `yaml:"upload_cleanup"`
 	CacheCleanup  CleanupConfig `yaml:"cache_cleanup"`
+
+	SkipHashVerification bool `yaml:"skip_hash_verification"`
 }
 
 func (c CAStoreConfig) applyDefaults() CAStoreConfig {

--- a/lib/store/fixtures.go
+++ b/lib/store/fixtures.go
@@ -40,8 +40,9 @@ func CAStoreConfigFixture() (CAStoreConfig, func()) {
 	cache := tempdir(cleanup, "cache")
 
 	return CAStoreConfig{
-		UploadDir: upload,
-		CacheDir:  cache,
+		UploadDir:            upload,
+		CacheDir:             cache,
+		SkipHashVerification: false,
 	}, cleanup.Run
 }
 

--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -526,9 +526,9 @@ func (s *Server) commitTransferHandler(w http.ResponseWriter, r *http.Request) e
 	if err != nil {
 		return err
 	}
-	if err := s.uploader.verify(d, uid); err != nil {
-		return err
-	}
+	// if err := s.uploader.verify(d, uid); err != nil {
+	// 	return err
+	// }
 	if err := s.uploader.commit(d, uid); err != nil {
 		return err
 	}
@@ -611,9 +611,9 @@ func (s *Server) commitClusterUploadHandler(w http.ResponseWriter, r *http.Reque
 		return err
 	}
 
-	if err := s.uploader.verify(d, uid); err != nil {
-		return err
-	}
+	// if err := s.uploader.verify(d, uid); err != nil {
+	// 	return err
+	// }
 	if err := s.uploader.commit(d, uid); err != nil {
 		return s.handleUploadConflict(err, namespace, d)
 	}
@@ -660,9 +660,9 @@ func (s *Server) duplicateCommitClusterUploadHandler(w http.ResponseWriter, r *h
 	}
 	delay := dr.Delay
 
-	if err := s.uploader.verify(d, uid); err != nil {
-		return err
-	}
+	// if err := s.uploader.verify(d, uid); err != nil {
+	// 	return err
+	// }
 	if err := s.uploader.commit(d, uid); err != nil {
 		return err
 	}

--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -526,9 +526,6 @@ func (s *Server) commitTransferHandler(w http.ResponseWriter, r *http.Request) e
 	if err != nil {
 		return err
 	}
-	// if err := s.uploader.verify(d, uid); err != nil {
-	// 	return err
-	// }
 	if err := s.uploader.commit(d, uid); err != nil {
 		return err
 	}
@@ -611,9 +608,6 @@ func (s *Server) commitClusterUploadHandler(w http.ResponseWriter, r *http.Reque
 		return err
 	}
 
-	// if err := s.uploader.verify(d, uid); err != nil {
-	// 	return err
-	// }
 	if err := s.uploader.commit(d, uid); err != nil {
 		return s.handleUploadConflict(err, namespace, d)
 	}
@@ -660,9 +654,6 @@ func (s *Server) duplicateCommitClusterUploadHandler(w http.ResponseWriter, r *h
 	}
 	delay := dr.Delay
 
-	// if err := s.uploader.verify(d, uid); err != nil {
-	// 	return err
-	// }
 	if err := s.uploader.commit(d, uid); err != nil {
 		return err
 	}

--- a/origin/blobserver/uploader.go
+++ b/origin/blobserver/uploader.go
@@ -18,10 +18,10 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/docker/distribution/uuid"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/store"
 	"github.com/uber/kraken/utils/handler"
-	"github.com/docker/distribution/uuid"
 )
 
 // uploader executes a chunked upload.
@@ -67,28 +67,6 @@ func (u *uploader) patch(
 	}
 	if _, err := io.CopyN(f, chunk, end-start); err != nil {
 		return handler.Errorf("copy: %s", err)
-	}
-	return nil
-}
-
-func (u *uploader) verify(d core.Digest, uid string) error {
-	digester := core.NewDigester()
-	f, err := u.cas.GetUploadFileReader(uid)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return handler.ErrorStatus(http.StatusNotFound)
-		}
-		return handler.Errorf("get upload file: %s", err)
-	}
-	defer f.Close()
-	computedDigest, err := digester.FromReader(f)
-	if err != nil {
-		return handler.Errorf("calculate digest: %s", err)
-	}
-	if computedDigest != d {
-		return handler.
-			Errorf("computed digest %s doesn't match parameter %s", computedDigest, d).
-			Status(http.StatusBadRequest)
 	}
 	return nil
 }

--- a/origin/blobserver/uploader.go
+++ b/origin/blobserver/uploader.go
@@ -73,6 +73,9 @@ func (u *uploader) patch(
 
 func (u *uploader) commit(d core.Digest, uid string) error {
 	if err := u.cas.MoveUploadFileToCache(uid, d.Hex()); err != nil {
+		if os.IsNotExist(err) {
+			return handler.ErrorStatus(http.StatusNotFound)
+		}
 		if os.IsExist(err) {
 			return handler.ErrorStatus(http.StatusConflict)
 		}


### PR DESCRIPTION
Hash calculation is expensive, especially when processing big layer pushed through proxy, as both proxy and origin need to verify it.

Moved all verification logic to store package, and added option to disable it.