### PR TITLE
Fixed a small grammatical issue in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Following are some highlights of Kraken:
 # Design
 
 The high-level idea of Kraken is to have a small number of dedicated hosts seeding content to a
-the network of agents running on each host in the cluster.
+network of agents running on each host in the cluster.
 
 A central component, the tracker, will orchestrate all participants in the network to form a
 pseudo-random regular graph.


### PR DESCRIPTION
Fixed a small grammatical issue in the README.md where 'a' and 'the' were used one after the another but only 'a' was required.