### PR TITLE
allow insecure server connection

### DIFF
--- a/lib/backend/registrybackend/security/security.go
+++ b/lib/backend/registrybackend/security/security.go
@@ -92,14 +92,10 @@ func (a *authenticator) Authenticate(repo string) ([]httputil.SendOption, error)
 	config := a.config
 
 	var opts []httputil.SendOption
-	if config.TLS.Client.Disabled {
-		opts = append(opts, httputil.SendNoop())
-		return opts, nil
-	}
-
 	if !config.EnableHTTPFallback {
 		opts = append(opts, httputil.DisableHTTPFallback())
 	}
+
 	if !a.shouldAuth() {
 		opts = append(opts, httputil.SendTLSTransport(a.roundTripper))
 		return opts, nil


### PR DESCRIPTION
This is a modification for test purpose

Currently use`tls.server.disabled` to indicate if the server certificate verification should be skipped, but i'm not sure whether it is good to use this option for client connection (the two related options are `tls.name` and `tls.cas` which are on the parent level of the config)

Thus, the tls config is always created (as well as the roundtripper for the authenticator)