### PR TITLE
Fixed a small issue in testfs helm template

### DIFF
--- a/helm/templates/testfs.yaml
+++ b/helm/templates/testfs.yaml
@@ -3,15 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kraken-testfs
-  labels:
-    app.kubernetes.io/name: kraken
-    app.kubernetes.io/component: testfs
-    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      kraken-app: testfs
+      app.kubernetes.io/name: kraken
+      app.kubernetes.io/component: testfs
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
When tried to deploy kraken via helm in a kubernetes cluster,  an installation error occurred.

versions:
- kubernetes: v1.16.2
- helm: v3.0.2

command:
```bash
$ helm install kraken ./helm
```

error message:
    Error: Deployment.apps "kraken-testfs" is invalid: spec.template.metadata.labels: Invalid value: map [string] string {"app.kubernetes.io/component": "testfs", "app.kubernetes.io / instance ":" kraken "," app.kubernetes.io/name":"kraken "}:` selector` does not match template `labels