### PR TITLE
Replace Redis with local in-memory peer store

### DIFF
--- a/config/tracker/test.template
+++ b/config/tracker/test.template
@@ -1,9 +1,5 @@
 extends: base.yaml
 
-peerstore:
-  redis:
-    addr: {redis}
-
 origin:
   hosts:
     static: {origins}

--- a/mocks/tracker/peerstore/store.go
+++ b/mocks/tracker/peerstore/store.go
@@ -33,6 +33,18 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method
+func (m *MockStore) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close
+func (mr *MockStoreMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStore)(nil).Close))
+}
+
 // GetPeers mocks base method
 func (m *MockStore) GetPeers(arg0 core.InfoHash, arg1 int) ([]*core.PeerInfo, error) {
 	m.ctrl.T.Helper()

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -26,7 +26,6 @@ from components import (
     Origin,
     OriginCluster,
     Proxy,
-    Redis,
     TestFS,
     Tracker,
     find_free_port,
@@ -54,15 +53,8 @@ TEST_IMAGE_2 = _setup_test_image('redis:latest')
 
 
 @pytest.fixture
-def redis():
-    redis = Redis(DEFAULT)
-    yield redis
-    redis.teardown()
-
-
-@pytest.fixture
-def tracker(redis, origin_cluster, testfs):
-    tracker = Tracker(DEFAULT, redis, origin_cluster)
+def tracker(origin_cluster, testfs):
+    tracker = Tracker(DEFAULT, origin_cluster)
     yield tracker
     tracker.teardown()
 

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -121,7 +121,7 @@ func Run(flags *Flags, opts ...Option) {
 
 	go metrics.EmitVersion(stats)
 
-	peerStore, err := peerstore.NewRedisStore(config.PeerStore.Redis, clock.New())
+	peerStore, err := peerstore.New(config.PeerStore)
 	if err != nil {
 		log.Fatalf("Could not create PeerStore: %s", err)
 	}

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -125,6 +125,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Could not create PeerStore: %s", err)
 	}
+	defer peerStore.Close()
 
 	tls, err := config.TLS.BuildClient()
 	if err != nil {

--- a/tracker/peerstore/config.go
+++ b/tracker/peerstore/config.go
@@ -18,13 +18,29 @@ import (
 )
 
 // Config defines Store configuration.
+//
+// NOTE: By default, the LocalStore implementation is used. Redis configuration
+// is ignored unless RedisConfig.Enabled is true.
 type Config struct {
+	Local LocalConfig `yaml:"local"`
 	Redis RedisConfig `yaml:"redis"`
+}
+
+// LocalConfig defines LocalStore configuration.
+type LocalConfig struct {
+	TTL time.Duration `yaml:"ttl"`
+}
+
+func (c *LocalConfig) applyDefaults() {
+	if c.TTL == 0 {
+		c.TTL = 5 * time.Hour
+	}
 }
 
 // RedisConfig defines RedisStore configuration.
 // TODO(evelynl94): rename
 type RedisConfig struct {
+	Enabled           bool          `yaml:"enabled"`
 	Addr              string        `yaml:"addr"`
 	DialTimeout       time.Duration `yaml:"dial_timeout"`
 	ReadTimeout       time.Duration `yaml:"read_timeout"`

--- a/tracker/peerstore/local.go
+++ b/tracker/peerstore/local.go
@@ -189,21 +189,15 @@ func (s *LocalStore) cleanupTask() {
 
 func (s *LocalStore) cleanupExpiredPeerEntries() {
 	s.mu.RLock()
-	hashes := make([]core.InfoHash, 0, len(s.peerGroups))
-	for h := range s.peerGroups {
-		hashes = append(hashes, h)
+	groups := make([]*peerGroup, 0, len(s.peerGroups))
+	for _, g := range s.peerGroups {
+		groups = append(groups, g)
 	}
 	s.mu.RUnlock()
 
-	for _, h := range hashes {
-		s.mu.RLock()
-		g, ok := s.peerGroups[h]
-		s.mu.RUnlock()
-		if !ok {
-			continue
-		}
-
+	for _, g := range groups {
 		var expired []int
+
 		g.mu.RLock()
 		for i, e := range g.peerList {
 			if s.clk.Now().After(e.expiresAt) {

--- a/tracker/peerstore/local.go
+++ b/tracker/peerstore/local.go
@@ -136,7 +136,7 @@ func (s *LocalStore) getOrInitLockedPeerGroup(h core.InfoHash) *peerGroup {
 	// At this point, A is holding onto a peerGroup reference which has been
 	// deleted from the peerGroups map, and thus has no choice but to attempt to
 	// reload a new peerGroup. Since the cleanup interval is quite large, it is
-	// *extremeley* unlikely this for-loop will execute more than twice.
+	// *extremely* unlikely this for-loop will execute more than twice.
 	for {
 		s.mu.Lock()
 		g, ok := s.peerGroups[h]

--- a/tracker/peerstore/local.go
+++ b/tracker/peerstore/local.go
@@ -1,0 +1,161 @@
+package peerstore
+
+import (
+	"sync"
+	"time"
+
+	"github.com/andres-erbsen/clock"
+	"github.com/uber/kraken/core"
+	"github.com/uber/kraken/utils/dedup"
+)
+
+const _peerGroupCleanupInterval = time.Hour
+
+// LocalStore is an in-memory Store implementation.
+type LocalStore struct {
+	config  LocalConfig
+	clk     clock.Clock
+	cleanup *dedup.IntervalTrap
+
+	mu         sync.RWMutex
+	peerGroups map[core.InfoHash]*peerGroup
+}
+
+type peerGroup struct {
+	mu            sync.Mutex
+	peers         map[core.PeerID]*peerEntry
+	lastExpiresAt time.Time
+	deleted       bool
+}
+
+type peerEntry struct {
+	ip        string
+	port      int
+	complete  bool
+	expiresAt time.Time
+}
+
+type cleanupTask struct {
+	store *LocalStore
+}
+
+func (t *cleanupTask) Run() {
+	t.store.runCleanup()
+}
+
+// NewLocalStore creates a new LocalStore.
+func NewLocalStore(config LocalConfig, clk clock.Clock) *LocalStore {
+	config.applyDefaults()
+	s := &LocalStore{
+		config:     config,
+		clk:        clk,
+		peerGroups: make(map[core.InfoHash]*peerGroup),
+	}
+	s.cleanup = dedup.NewIntervalTrap(_peerGroupCleanupInterval, clk, &cleanupTask{s})
+	return s
+}
+
+// GetPeers implements Store.
+func (s *LocalStore) GetPeers(h core.InfoHash, n int) ([]*core.PeerInfo, error) {
+	if n <= 0 {
+		// Simpler for below logic to assume positive n.
+		return nil, nil
+	}
+
+	s.mu.RLock()
+	g, ok := s.peerGroups[h]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := s.clk.Now()
+	var result []*core.PeerInfo
+
+	// We rely on random map iteration to pick n random peers.
+	for id, p := range g.peers {
+		if now.After(p.expiresAt) {
+			// Clean up any expired peers we run into.
+			delete(g.peers, id)
+			continue
+		}
+		result = append(result, core.NewPeerInfo(id, p.ip, p.port, false /* origin */, p.complete))
+		if len(result) == n {
+			break
+		}
+	}
+	return result, nil
+}
+
+// UpdatePeer implements Store.
+func (s *LocalStore) UpdatePeer(h core.InfoHash, p *core.PeerInfo) error {
+	s.cleanup.Trap()
+
+	g := s.getOrInitLockedPeerGroup(h)
+	defer g.mu.Unlock()
+
+	expiresAt := s.clk.Now().Add(s.config.TTL)
+
+	g.peers[p.PeerID] = &peerEntry{
+		ip:        p.IP,
+		port:      p.Port,
+		complete:  p.Complete,
+		expiresAt: expiresAt,
+	}
+
+	// Allows runCleanup to quickly determine when the last peerEntry expires.
+	g.lastExpiresAt = expiresAt
+
+	return nil
+}
+
+func (s *LocalStore) getOrInitLockedPeerGroup(h core.InfoHash) *peerGroup {
+	// We must take care to handle a race condition against runCleanup. Consider
+	// two goroutines, A and B, where A executes getOrInitLockedPeerGroup and B
+	// executes runCleanup:
+	//
+	// A: locks s.mu, reads g from s.peerGroups, unlocks s.mu
+	// B: locks s.mu, locks g.mu, deletes g from s.peerGroups, unlocks g.mu
+	// A: locks g.mu
+	//
+	// At this point, A is holding onto a peerGroup reference which has been
+	// deleted from the peerGroups map, and thus has no choice but to attempt to
+	// reload a new peerGroup. Since the cleanup interval is quite large, it is
+	// *extremeley* unlikely this for-loop will execute more than twice.
+	for {
+		s.mu.Lock()
+		g, ok := s.peerGroups[h]
+		if !ok {
+			g = &peerGroup{
+				peers:         make(map[core.PeerID]*peerEntry),
+				lastExpiresAt: s.clk.Now().Add(s.config.TTL),
+			}
+			s.peerGroups[h] = g
+		}
+		s.mu.Unlock()
+
+		g.mu.Lock()
+		if g.deleted {
+			g.mu.Unlock()
+			continue
+		}
+		return g
+	}
+}
+
+func (s *LocalStore) runCleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for h, g := range s.peerGroups {
+		g.mu.Lock()
+		if s.clk.Now().After(g.lastExpiresAt) {
+			delete(s.peerGroups, h)
+			g.deleted = true
+		}
+		g.mu.Unlock()
+	}
+}

--- a/tracker/peerstore/local_test.go
+++ b/tracker/peerstore/local_test.go
@@ -93,6 +93,7 @@ func TestLocalStoreExpiration(t *testing.T) {
 
 func TestLocalStoreConcurrency(t *testing.T) {
 	s := NewLocalStore(LocalConfig{TTL: time.Millisecond}, clock.New())
+	defer s.Close()
 
 	hashes := []core.InfoHash{
 		core.InfoHashFixture(),

--- a/tracker/peerstore/local_test.go
+++ b/tracker/peerstore/local_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/andres-erbsen/clock"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/kraken/core"
 )
 
@@ -32,7 +32,7 @@ func TestLocalStoreExpiration(t *testing.T) {
 	defer s.Close()
 
 	h1 := core.InfoHashFixture()
-	
+
 	// No peers initially.
 
 	peers, err := s.GetPeers(h1, 0)
@@ -71,6 +71,14 @@ func TestLocalStoreExpiration(t *testing.T) {
 	// should be a noop.
 	s.cleanupExpiredPeerEntries()
 	s.cleanupExpiredPeerGroups()
+
+	peers, err = s.GetPeers(h1, 3)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []*core.PeerInfo{p1, p2, p3}, peers)
+
+	// Update existing peer.
+	p3.Complete = true
+	require.NoError(t, s.UpdatePeer(h1, p3))
 
 	peers, err = s.GetPeers(h1, 3)
 	require.NoError(t, err)

--- a/tracker/peerstore/local_test.go
+++ b/tracker/peerstore/local_test.go
@@ -70,6 +70,7 @@ func TestLocalStoreExpiration(t *testing.T) {
 	// Manually triggered for testing purposes. Nothing has expired, so
 	// should be a noop.
 	s.cleanupExpiredPeerEntries()
+	s.cleanupExpiredPeerGroups()
 
 	peers, err = s.GetPeers(h1, 3)
 	require.NoError(t, err)

--- a/tracker/peerstore/local_test.go
+++ b/tracker/peerstore/local_test.go
@@ -32,6 +32,8 @@ func TestLocalStoreExpiration(t *testing.T) {
 	defer s.Close()
 
 	h1 := core.InfoHashFixture()
+	
+	// No peers initially.
 
 	peers, err := s.GetPeers(h1, 0)
 	require.NoError(t, err)
@@ -47,8 +49,13 @@ func TestLocalStoreExpiration(t *testing.T) {
 	p2 := core.PeerInfoFixture()
 	require.NoError(t, s.UpdatePeer(h1, p2))
 
+	// Two peers with some different n values.
+
 	peers, err = s.GetPeers(h1, 2)
 	require.NoError(t, err)
+	require.ElementsMatch(t, []*core.PeerInfo{p1, p2}, peers)
+
+	peers, err = s.GetPeers(h1, 50)
 	require.ElementsMatch(t, []*core.PeerInfo{p1, p2}, peers)
 
 	peers, err = s.GetPeers(h1, 1)
@@ -59,6 +66,10 @@ func TestLocalStoreExpiration(t *testing.T) {
 
 	p3 := core.PeerInfoFixture()
 	require.NoError(t, s.UpdatePeer(h1, p3))
+
+	// Manually triggered for testing purposes. Nothing has expired, so
+	// should be a noop.
+	s.cleanupExpiredPeerEntries()
 
 	peers, err = s.GetPeers(h1, 3)
 	require.NoError(t, err)

--- a/tracker/peerstore/local_test.go
+++ b/tracker/peerstore/local_test.go
@@ -1,0 +1,114 @@
+package peerstore
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/andres-erbsen/clock"
+	"github.com/uber/kraken/core"
+)
+
+func TestLocalStoreExpiration(t *testing.T) {
+	now := time.Date(2019, time.November, 1, 1, 0, 0, 0, time.UTC)
+	clk := clock.NewMock()
+	clk.Set(now)
+
+	s := NewLocalStore(LocalConfig{TTL: 10 * time.Minute}, clk)
+
+	h1 := core.InfoHashFixture()
+
+	peers, err := s.GetPeers(h1, 0)
+	require.NoError(t, err)
+	require.Empty(t, peers)
+
+	peers, err = s.GetPeers(h1, 1)
+	require.NoError(t, err)
+	require.Empty(t, peers)
+
+	p1 := core.PeerInfoFixture()
+	require.NoError(t, s.UpdatePeer(h1, p1))
+
+	p2 := core.PeerInfoFixture()
+	require.NoError(t, s.UpdatePeer(h1, p2))
+
+	peers, err = s.GetPeers(h1, 2)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []*core.PeerInfo{p1, p2}, peers)
+
+	peers, err = s.GetPeers(h1, 1)
+	require.NoError(t, err)
+	require.Len(t, peers, 1)
+
+	clk.Add(5 * time.Minute)
+
+	p3 := core.PeerInfoFixture()
+	require.NoError(t, s.UpdatePeer(h1, p3))
+
+	peers, err = s.GetPeers(h1, 3)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []*core.PeerInfo{p1, p2, p3}, peers)
+
+	clk.Add(5*time.Minute + 1)
+
+	// p1 and p2 are now expired.
+	peers, err = s.GetPeers(h1, 3)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []*core.PeerInfo{p3}, peers)
+
+	clk.Add(5*time.Minute + 1)
+
+	// p3 is now expired.
+	peers, err = s.GetPeers(h1, 1)
+	require.NoError(t, err)
+	require.Empty(t, peers)
+
+	clk.Add(_peerGroupCleanupInterval)
+
+	h2 := core.InfoHashFixture()
+	p4 := core.PeerInfoFixture()
+
+	// An arbitrary UpdatePeer call should trigger the cleanup trap.
+	// Unfortunately we must reach into the LocalStore's private state
+	// to determine whether cleanup actually occurred.
+	require.Contains(t, s.peerGroups, h1)
+	require.NoError(t, s.UpdatePeer(h2, p4))
+	require.NotContains(t, s.peerGroups, h1)
+
+	peers, err = s.GetPeers(h2, 1)
+	require.NoError(t, err)
+	require.Equal(t, []*core.PeerInfo{p4}, peers)
+}
+
+func TestLocalStoreConcurrency(t *testing.T) {
+	s := NewLocalStore(LocalConfig{TTL: time.Millisecond}, clock.New())
+
+	hashes := []core.InfoHash{
+		core.InfoHashFixture(),
+		core.InfoHashFixture(),
+		core.InfoHashFixture(),
+	}
+
+	// We don't care what the results are, we just want to trigger any race
+	// conditions.
+	var wg sync.WaitGroup
+	for n := 0; n < 1000; n++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for _, h := range hashes {
+				require.NoError(t, s.UpdatePeer(h, core.PeerInfoFixture()))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for _, h := range hashes {
+				peers, err := s.GetPeers(h, 10)
+				require.NoError(t, err)
+				require.True(t, len(peers) <= 10)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/tracker/peerstore/redis.go
+++ b/tracker/peerstore/redis.go
@@ -109,6 +109,9 @@ func NewRedisStore(config RedisConfig, clk clock.Clock) (*RedisStore, error) {
 	return s, nil
 }
 
+// Close implements Store.
+func (s *RedisStore) Close() {}
+
 func (s *RedisStore) curPeerSetWindow() int64 {
 	t := s.clk.Now().Unix()
 	return t - (t % int64(s.config.PeerSetWindowSize.Seconds()))

--- a/tracker/peerstore/store.go
+++ b/tracker/peerstore/store.go
@@ -23,6 +23,8 @@ import (
 
 // Store provides storage for announcing peers.
 type Store interface {
+	// Close cleans up any Store resources.
+	Close()
 
 	// GetPeers returns at most n random peers announcing for h.
 	GetPeers(h core.InfoHash, n int) ([]*core.PeerInfo, error)

--- a/tracker/peerstore/store.go
+++ b/tracker/peerstore/store.go
@@ -14,7 +14,11 @@
 package peerstore
 
 import (
+	"fmt"
+
+	"github.com/andres-erbsen/clock"
 	"github.com/uber/kraken/core"
+	"github.com/uber/kraken/utils/log"
 )
 
 // Store provides storage for announcing peers.
@@ -25,4 +29,18 @@ type Store interface {
 
 	// UpdatePeer updates peer fields.
 	UpdatePeer(h core.InfoHash, peer *core.PeerInfo) error
+}
+
+// New creates a new Store implementation based on config.
+func New(config Config) (Store, error) {
+	if config.Redis.Enabled {
+		log.Info("Redis peer store enabled")
+		s, err := NewRedisStore(config.Redis, clock.New())
+		if err != nil {
+			return nil, fmt.Errorf("new redis store: %s", err)
+		}
+		return s, nil
+	}
+	log.Info("Defaulting to local peer store")
+	return NewLocalStore(config.Local, clock.New()), nil
 }

--- a/tracker/peerstore/testing.go
+++ b/tracker/peerstore/testing.go
@@ -32,6 +32,8 @@ func NewTestStore() Store {
 	}
 }
 
+func (s *testStore) Close() {}
+
 func (s *testStore) UpdatePeer(h core.InfoHash, p *core.PeerInfo) error {
 	s.Lock()
 	defer s.Unlock()


### PR DESCRIPTION
The use of Redis in Kraken is purely a historical artifact from when announce requests were not sharded and all Trackers shared the same Redis instance. These days, we have used client-side hashing in Agent to ensure that all Agent announces for a particular info hash are sent to the same Tracker, meaning the Trackers do not need to share peer stores anymore. As such, Tracker deployments have generally used local Redis instances.

This PR introduces a new peerstore.Store implementation called LocalStore, which is an in-memory two-level locking map. I made a couple of performance-conscious decisions that made the implementation more complex than reviewers may be accustomed to. The main optimization is ensuring that the top-level lock and infohash-level locks are never held at the same time except for runCleanup (which only runs every hour). This ensures that reads/writes to different infohashes only ever compete for the top-level lock. The alternative is to acquire the infohash-level lock while still holding the top-level lock, which is simpler, but causes more lock contention.

Here are the benchmarks for 4 hosts x 400 peers x 100 hashes announcing every 2s for 2m:

Redis:

```
min(ms) p50(ms) p95(ms) p99(ms) max(ms)
0.00    1.00    20.00   71.00   79.00
```

Local:

```
min(ms) p50(ms) p95(ms) p99(ms) max(ms)
0.00    1.00    15.00   22.00   25.00
```