### PR TITLE
Allow upload to a different origin on retryable errors

### DIFF
--- a/origin/blobclient/cluster_client.go
+++ b/origin/blobclient/cluster_client.go
@@ -120,7 +120,9 @@ func (c *clusterClient) UploadBlob(namespace string, d core.Digest, blob io.Read
 	// conflicts between local replicas.
 	for _, client := range clients {
 		err = client.UploadBlob(namespace, d, blob)
-		if httputil.IsNetworkError(err) {
+		// Allow retry on another origin if the current upstream is temporarily
+		// unavailable or under high load.
+		if httputil.IsNetworkError(err) || httputil.IsRetryable(err) {
 			continue
 		}
 		break

--- a/origin/blobclient/uploader.go
+++ b/origin/blobclient/uploader.go
@@ -79,7 +79,8 @@ func newTransferClient(addr string, tls *tls.Config) *transferClient {
 func (c *transferClient) start(d core.Digest) (uid string, err error) {
 	r, err := httputil.Post(
 		fmt.Sprintf("http://%s/internal/blobs/%s/uploads", c.addr, d),
-		httputil.SendTLS(c.tls))
+		httputil.SendTLS(c.tls),
+		httputil.SendRetry())
 	if err != nil {
 		return "", err
 	}
@@ -99,7 +100,8 @@ func (c *transferClient) patch(
 		httputil.SendHeaders(map[string]string{
 			"Content-Range": fmt.Sprintf("%d-%d", start, stop),
 		}),
-		httputil.SendTLS(c.tls))
+		httputil.SendTLS(c.tls),
+		httputil.SendRetry())
 	return err
 }
 
@@ -107,7 +109,8 @@ func (c *transferClient) commit(d core.Digest, uid string) error {
 	_, err := httputil.Put(
 		fmt.Sprintf("http://%s/internal/blobs/%s/uploads/%s", c.addr, d, uid),
 		httputil.SendTimeout(15*time.Minute),
-		httputil.SendTLS(c.tls))
+		httputil.SendTLS(c.tls),
+		httputil.SendRetry())
 	return err
 }
 
@@ -137,7 +140,8 @@ func (c *uploadClient) start(d core.Digest) (uid string, err error) {
 	r, err := httputil.Post(
 		fmt.Sprintf("http://%s/namespace/%s/blobs/%s/uploads",
 			c.addr, url.PathEscape(c.namespace), d),
-		httputil.SendTLS(c.tls))
+		httputil.SendTLS(c.tls),
+		httputil.SendRetry())
 	if err != nil {
 		return "", err
 	}
@@ -158,7 +162,8 @@ func (c *uploadClient) patch(
 		httputil.SendHeaders(map[string]string{
 			"Content-Range": fmt.Sprintf("%d-%d", start, stop),
 		}),
-		httputil.SendTLS(c.tls))
+		httputil.SendTLS(c.tls),
+		httputil.SendRetry())
 	return err
 }
 
@@ -187,6 +192,7 @@ func (c *uploadClient) commit(d core.Digest, uid string) error {
 		fmt.Sprintf(template, c.addr, url.PathEscape(c.namespace), d, uid),
 		httputil.SendTimeout(15*time.Minute),
 		httputil.SendBody(body),
-		httputil.SendTLS(c.tls))
+		httputil.SendTLS(c.tls),
+		httputil.SendRetry())
 	return err
 }

--- a/origin/blobclient/uploader.go
+++ b/origin/blobclient/uploader.go
@@ -79,8 +79,7 @@ func newTransferClient(addr string, tls *tls.Config) *transferClient {
 func (c *transferClient) start(d core.Digest) (uid string, err error) {
 	r, err := httputil.Post(
 		fmt.Sprintf("http://%s/internal/blobs/%s/uploads", c.addr, d),
-		httputil.SendTLS(c.tls),
-		httputil.SendRetry())
+		httputil.SendTLS(c.tls))
 	if err != nil {
 		return "", err
 	}
@@ -100,8 +99,7 @@ func (c *transferClient) patch(
 		httputil.SendHeaders(map[string]string{
 			"Content-Range": fmt.Sprintf("%d-%d", start, stop),
 		}),
-		httputil.SendTLS(c.tls),
-		httputil.SendRetry())
+		httputil.SendTLS(c.tls))
 	return err
 }
 
@@ -109,8 +107,7 @@ func (c *transferClient) commit(d core.Digest, uid string) error {
 	_, err := httputil.Put(
 		fmt.Sprintf("http://%s/internal/blobs/%s/uploads/%s", c.addr, d, uid),
 		httputil.SendTimeout(15*time.Minute),
-		httputil.SendTLS(c.tls),
-		httputil.SendRetry())
+		httputil.SendTLS(c.tls))
 	return err
 }
 
@@ -140,8 +137,7 @@ func (c *uploadClient) start(d core.Digest) (uid string, err error) {
 	r, err := httputil.Post(
 		fmt.Sprintf("http://%s/namespace/%s/blobs/%s/uploads",
 			c.addr, url.PathEscape(c.namespace), d),
-		httputil.SendTLS(c.tls),
-		httputil.SendRetry())
+		httputil.SendTLS(c.tls))
 	if err != nil {
 		return "", err
 	}
@@ -162,8 +158,7 @@ func (c *uploadClient) patch(
 		httputil.SendHeaders(map[string]string{
 			"Content-Range": fmt.Sprintf("%d-%d", start, stop),
 		}),
-		httputil.SendTLS(c.tls),
-		httputil.SendRetry())
+		httputil.SendTLS(c.tls))
 	return err
 }
 
@@ -192,7 +187,6 @@ func (c *uploadClient) commit(d core.Digest, uid string) error {
 		fmt.Sprintf(template, c.addr, url.PathEscape(c.namespace), d, uid),
 		httputil.SendTimeout(15*time.Minute),
 		httputil.SendBody(body),
-		httputil.SendTLS(c.tls),
-		httputil.SendRetry())
+		httputil.SendTLS(c.tls))
 	return err
 }

--- a/utils/httputil/httputil_test.go
+++ b/utils/httputil/httputil_test.go
@@ -74,7 +74,7 @@ func TestSendRetry(t *testing.T) {
 
 	transport := mockhttputil.NewMockRoundTripper(ctrl)
 
-	for _, status := range []int{503, 500, 200} {
+	for _, status := range []int{503, 502, 200} {
 		transport.EXPECT().RoundTrip(gomock.Any()).Return(newResponse(status), nil)
 	}
 


### PR DESCRIPTION
There is no retry in uploader so when client pushes to proxy and proxy uploads to origin, a failed call to origin could cause this chained push to fail, and registry's storage driver would return a non-informative 500 error:
```
{"log":"time=\"2020-09-15T18:29:24.098336695Z\" level=error msg=\"unknown error completing upload: upload: PUT https://10.86.32.14:9003/namespace/TODO/blobs/sha256:7e5a79dca6eaf28244b2787fc8b3ef388847363ba5cd705ac8a09b4fbf57b82c/uploads/a78df4be-9823-4859-855d-e6f4fa8d73d8 504: \u003chtml\u003e\\r\\n\u003chead\u003e\u003ctitle\u003e504 Gateway Time-out\u003c/title\u003e\u003c/head\u003e\\r\\n\u003cbody bgcolor=\\\"white\\\"\u003e\\r\\n\u003ccenter\u003e\u003ch1\u003e504 Gateway Time-out\u003c/h1\u003e\u003c/center\u003e\\r\\n\u003chr\u003e\u003ccenter\u003enginx/1.10.3\u003c/center\u003e\\r\\n\u003c/body\u003e\\r\\n\u003c/html\u003e\\r\\n\" go.version=go1.14.4 http.request.contenttype=application/octet-stream http.request.host=\"kraken-origin01-phx4:5367\" http.request.id=5ad657fe-c164-4ef5-aa70-8a63b294a610 http.request.method=PUT http.request.remoteaddr=@ http.request.uri=\"/v2/uber-usi/sdv-router/blobs/uploads/b0ffae9c-bf2f-4655-8254-a413b77db17d?_state=6s1EKv5wIWpiiOoPxg_dWXsw4pk1Z0L3SLurXEvORDV7Ik5hbWUiOiJ1YmVyLXVzaS9zZHYtcm91dGVyIiwiVVVJRCI6ImIwZmZhZTljLWJmMmYtNDY1NS04MjU0LWE0MTNiNzdkYjE3ZCIsIk9mZnNldCI6NjcwOTg2MTE1OCwiU3RhcnRlZEF0IjoiMjAyMC0wOS0xNVQxODoyNDo1M1oifQ%3D%3D\u0026digest=sha256%3A7e5a79dca6eaf28244b2787fc8b3ef388847363ba5cd705ac8a09b4fbf57b82c\" http.request.useragent=Go-http-client/1.1 vars.name=uber-usi/sdv-router vars.uuid=b0ffae9c-bf2f-4655-8254-a413b77db17d\n","stream":"stderr","time":"2020-09-15T18:29:24.098665108Z"}
```

Since the current origin is probably under high load due to hashing a big blob, retry on the same origin could make the load problem worse. This allow the cluster client to retry on a different origin if upload fails due to load error.