### PR TITLE
Propagate PathNotFound error in proxy

### DIFF
--- a/lib/dockerregistry/blobs.go
+++ b/lib/dockerregistry/blobs.go
@@ -64,13 +64,7 @@ func (b *blobs) stat(ctx context.Context, path string) (storagedriver.FileInfo, 
 	}
 	bi, err := b.transferer.Stat(repo, digest)
 	if err != nil {
-		if err == transfer.ErrBlobNotFound {
-			return nil, storagedriver.PathNotFoundError{
-				DriverName: "kraken",
-				Path:       digest.Hex(),
-			}
-		}
-		return nil, fmt.Errorf("transferer stat: %s", err)
+		return nil, fmt.Errorf("transferer stat: %w", err)
 	}
 	// Hacking the path, since kraken storage driver is also the consumer of this info.
 	// Instead of the relative path from root that docker registry expected, just use content hash.
@@ -112,13 +106,7 @@ func (b *blobs) getCacheReaderHelper(
 
 	r, err := b.transferer.Download(repo, digest)
 	if err != nil {
-		if err == transfer.ErrBlobNotFound {
-			return nil, storagedriver.PathNotFoundError{
-				DriverName: "kraken",
-				Path:       digest.Hex(),
-			}
-		}
-		return nil, fmt.Errorf("transferer download: %s", err)
+		return nil, fmt.Errorf("transferer download: %w", err)
 	}
 
 	if _, err := r.Seek(offset, 0); err != nil {

--- a/lib/dockerregistry/testutils_test.go
+++ b/lib/dockerregistry/testutils_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/uber/kraken/lib/store"
 	"github.com/uber/kraken/utils/dockerutil"
 
+	"github.com/docker/distribution/uuid"
 	"github.com/uber-go/tally"
 )
 
@@ -32,7 +33,6 @@ const (
 	tagName          = "latest"
 	hashStateContent = "this is a test hashstate"
 	uploadContent    = "this is a test upload"
-	uploadUUID       = "a20fe261-0060-467f-a44e-46eba3798d63"
 )
 
 // TODO(codyg): Get rid of this and all of the above constants.
@@ -60,6 +60,7 @@ func (d *testDriver) setup() (*KrakenStorageDriver, testImageUploadBundle) {
 	sd := NewReadWriteStorageDriver(Config{}, d.cas, d.transferer, tally.NoopScope)
 
 	// Create upload
+	uploadUUID := uuid.Generate().String()
 	path := genUploadStartedAtPath(uploadUUID)
 	if err := sd.uploads.putContent(path, _startedat, nil); err != nil {
 		log.Panic(err)

--- a/lib/dockerregistry/transfer/testing.go
+++ b/lib/dockerregistry/transfer/testing.go
@@ -14,7 +14,6 @@
 package transfer
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -48,7 +47,7 @@ func NewTestTransferer(cas *store.CAStore) ImageTransferer {
 func (t *testTransferer) Stat(namespace string, d core.Digest) (*core.BlobInfo, error) {
 	fi, err := t.cas.GetCacheFileStat(d.Hex())
 	if err != nil {
-		return nil, fmt.Errorf("stat cache file: %s", err)
+		return nil, fmt.Errorf("stat cache file: %w", err)
 	}
 	return core.NewBlobInfo(fi.Size()), nil
 }
@@ -68,7 +67,7 @@ func (t *testTransferer) GetTag(tag string) (core.Digest, error) {
 	}
 	d, ok := t.tags[p]
 	if !ok {
-		return core.Digest{}, errors.New("tag not found")
+		return core.Digest{}, ErrTagNotFound
 	}
 	return d, nil
 }

--- a/lib/dockerregistry/uploads.go
+++ b/lib/dockerregistry/uploads.go
@@ -83,10 +83,10 @@ func (u *casUploads) reader(path string, subtype PathSubType, offset int64) (io.
 		}
 		r, err := u.cas.GetUploadFileReader(uuid)
 		if err != nil {
-			return nil, fmt.Errorf("get reader: %s", err)
+			return nil, fmt.Errorf("get reader: %w", err)
 		}
 		if _, err := r.Seek(offset, io.SeekStart); err != nil {
-			return nil, fmt.Errorf("seek: %s", err)
+			return nil, fmt.Errorf("seek: %w", err)
 		}
 		return r, nil
 	}
@@ -101,11 +101,11 @@ func (u *casUploads) putContent(path string, subtype PathSubType, content []byte
 	switch subtype {
 	case _startedat:
 		if err := u.cas.CreateUploadFile(uuid, 0); err != nil {
-			return fmt.Errorf("create upload file: %s", err)
+			return fmt.Errorf("create upload file: %w", err)
 		}
 		s := newStartedAtMetadata(time.Now())
 		if err := u.cas.SetUploadFileMetadata(uuid, s); err != nil {
-			return fmt.Errorf("set started at: %s", err)
+			return fmt.Errorf("set started at: %w", err)
 		}
 		return nil
 	case _hashstates:
@@ -128,10 +128,10 @@ func (u *casUploads) putBlobContent(path string, content []byte) error {
 		return fmt.Errorf("get digest: %s", err)
 	}
 	if err := u.cas.CreateCacheFile(d.Hex(), bytes.NewReader(content)); err != nil {
-		return fmt.Errorf("create cache file: %s", err)
+		return fmt.Errorf("create cache file: %w", err)
 	}
 	if err := u.transferer.Upload("TODO", d, store.NewBufferFileReader(content)); err != nil {
-		return fmt.Errorf("upload: %s", err)
+		return fmt.Errorf("upload: %w", err)
 	}
 	return nil
 }
@@ -199,14 +199,14 @@ func (u *casUploads) move(uploadPath, blobPath string) error {
 		return fmt.Errorf("get blob uuid: %s", err)
 	}
 	if err := u.cas.MoveUploadFileToCache(uuid, d.Hex()); err != nil {
-		return fmt.Errorf("move upload file to cache: %s", err)
+		return fmt.Errorf("move upload file to cache: %w", err)
 	}
 	f, err := u.cas.GetCacheFileReader(d.Hex())
 	if err != nil {
-		return fmt.Errorf("get cache file: %s", err)
+		return fmt.Errorf("get cache file: %w", err)
 	}
 	if err := u.transferer.Upload("TODO", d, f); err != nil {
-		return fmt.Errorf("upload: %s", err)
+		return fmt.Errorf("upload: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
In manifests.go and blobs.go, we are returning PathNotFound on selected errors from transferer. We should also propagate this error in uploads.go.

This fixes an issue when clients blindly retries committing a layer on 5xx code when the upload file is actually removed:
`{"log":"time=\"2020-09-15T18:30:29.187931425Z\" level=error msg=\"error resolving upload: file does not exist\" go.version=go1.14.4 http.request.contenttype=application/octet-stream http.request.host=\"kraken-origin01-phx4:5367\" http.request.id=fb81ce9a-54c8-4465-8305-993fc28907d3 http.request.method=PUT http.request.remoteaddr=@ http.request.uri=\"/v2/uber-usi/sdv-router/blobs/uploads/b0ffae9c-bf2f-4655-8254-a413b77db17d?_state=6s1EKv5wIWpiiOoPxg_dWXsw4pk1Z0L3SLurXEvORDV7Ik5hbWUiOiJ1YmVyLXVzaS9zZHYtcm91dGVyIiwiVVVJRCI6ImIwZmZhZTljLWJmMmYtNDY1NS04MjU0LWE0MTNiNzdkYjE3ZCIsIk9mZnNldCI6NjcwOTg2MTE1OCwiU3RhcnRlZEF0IjoiMjAyMC0wOS0xNVQxODoyNDo1M1oifQ%3D%3D\u0026digest=sha256%3A7e5a79dca6eaf28244b2787fc8b3ef388847363ba5cd705ac8a09b4fbf57b82c\" http.request.useragent=Go-http-client/1.1 vars.name=uber-usi/sdv-router vars.uuid=b0ffae9c-bf2f-4655-8254-a413b77db17d\n","stream":"stderr","time":"2020-09-15T18:30:29.188531996Z"}`
In the above case, registry should return PathNotFound.