### PR TITLE
Allow overriding nginx log paths

### DIFF
--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -30,8 +30,8 @@ server {
 
   {{.client_verification}}
 
-  access_log {{.log_dir}}/nginx-access.v2.log;
-  error_log {{.log_dir}}/nginx-error.v2.log;
+  access_log {{.access_log_path}};
+  error_log {{.error_log_path}};
 
   gzip on;
   gzip_types text/plain test/csv application/json;

--- a/nginx/config/base.go
+++ b/nginx/config/base.go
@@ -81,9 +81,6 @@ http {
   # Logging Settings
   ##
 
-  # access_log /var/log/nginx/access.log;
-  error_log /var/log/nginx/error.log;
-
   # JSON log_format
   log_format json '{'
        '"verb":"$request_method",'

--- a/nginx/config/build-index.go
+++ b/nginx/config/build-index.go
@@ -28,8 +28,8 @@ server {
 
   {{.client_verification}}
 
-  access_log {{.log_dir}}/nginx-access.log;
-  error_log {{.log_dir}}/nginx-error.log;
+  access_log {{.access_log_path}};
+  error_log {{.error_log_path}};
 
   location / {
     proxy_pass http://build-index;

--- a/nginx/config/origin.go
+++ b/nginx/config/origin.go
@@ -22,8 +22,8 @@ server {
 
   client_max_body_size 10G;
 
-  access_log {{.log_dir}}/nginx-access.log json;
-  error_log {{.log_dir}}/nginx-error.log;
+  access_log {{.access_log_path}} json;
+  error_log {{.error_log_path}};
 
   gzip on;
   gzip_types text/plain test/csv application/json;

--- a/nginx/config/proxy.go
+++ b/nginx/config/proxy.go
@@ -31,8 +31,8 @@ server {
 
   client_max_body_size 10G;
 
-  access_log {{$.log_dir}}/nginx-access.log json;
-  error_log {{$.log_dir}}/nginx-error.log;
+  access_log {{$.access_log_path}} json;
+  error_log {{$.error_log_path}};
 
   gzip on;
   gzip_types text/plain test/csv application/json;

--- a/nginx/config/tracker.go
+++ b/nginx/config/tracker.go
@@ -26,8 +26,8 @@ server {
 
   {{.client_verification}}
 
-  access_log {{.log_dir}}/nginx-access.log;
-  error_log {{.log_dir}}/nginx-error.log;
+  access_log {{.access_log_path}};
+  error_log {{.error_log_path}};
 
   location / {
     proxy_pass http://tracker;


### PR DESCRIPTION
Lets us optionally emit nginx logs to specific files instead of just a directory.