### PR TITLE
Remove outdated nginx log migration

### DIFF
--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -17,7 +17,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/uber/kraken/agent/agentserver"
@@ -223,17 +222,6 @@ func Run(flags *Flags, opts ...Option) {
 	}()
 
 	go heartbeat(stats)
-
-	// Wipe log files created by the old nginx process which ran as root.
-	// TODO(codyg): Swap these with the v2 log files once they are deleted.
-	for _, name := range []string{
-		"/var/log/kraken/kraken-agent/nginx-access.log",
-		"/var/log/kraken/kraken-agent/nginx-error.log",
-	} {
-		if err := os.Remove(name); err != nil && !os.IsNotExist(err) {
-			log.Warnf("Could not remove old root-owned nginx log: %s", err)
-		}
-	}
 
 	log.Fatal(nginx.Run(config.Nginx, map[string]interface{}{
 		"allowed_cidrs": config.AllowedCidrs,


### PR DESCRIPTION
This migration path is long expired. Let's remove it.