### PR TITLE
Making lib/backend/client.getFactory public

### DIFF
--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -32,8 +32,9 @@ func Register(name string, factory ClientFactory) {
 	_factories[name] = factory
 }
 
-// getFactory returns backend client factory given client name.
-func getFactory(name string) (ClientFactory, error) {
+// GetFactory returns backend client factory given client name.
+// This function should stay public to allow for wrapper custom backends.
+func GetFactory(name string) (ClientFactory, error) {
 	factory, ok := _factories[name]
 	if !ok {
 		return nil, fmt.Errorf("no backend client defined with name %s", name)

--- a/lib/backend/client_test.go
+++ b/lib/backend/client_test.go
@@ -1,0 +1,32 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterAndGetFactory(t *testing.T) {
+	t.Run("round-trip", func(t *testing.T) {
+		name := "dummy"
+		factory := &dummyFactory{}
+
+		Register(name, factory)
+		roundTrip, err := GetFactory(name)
+
+		assert.NoError(t, err)
+		assert.Equal(t, factory, roundTrip)
+	})
+
+	t.Run("GetFactory errors out on missing factory", func(t *testing.T) {
+		_, err := GetFactory("i_dont_exist")
+
+		assert.Error(t, err)
+	})
+}
+
+type dummyFactory struct{}
+
+func (f *dummyFactory) Create(config interface{}, authConfig interface{}) (Client, error) {
+	return nil, nil
+}

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -62,7 +62,7 @@ func NewManager(configs []Config, auth AuthConfig) (*Manager, error) {
 		var backendConfig interface{}
 		for name, backendConfig = range config.Backend { // Pull the only key/value out of map
 		}
-		factory, err := getFactory(name)
+		factory, err := GetFactory(name)
 		if err != nil {
 			return nil, fmt.Errorf("get backend client factory: %s", err)
 		}


### PR DESCRIPTION
Mainly to allow writing "wrapper" custom backends, see eg
https://github.com/uber/kraken/issues/278#issuecomment-705121495