### PR TITLE
Switch agent to use V2 announce endpoint

### DIFF
--- a/lib/torrent/scheduler/announcer/announcer.go
+++ b/lib/torrent/scheduler/announcer/announcer.go
@@ -89,7 +89,7 @@ func Default(
 func (a *Announcer) Announce(
 	d core.Digest, h core.InfoHash, complete bool) ([]*core.PeerInfo, error) {
 
-	peers, interval, err := a.client.Announce(d, h, complete, announceclient.V1)
+	peers, interval, err := a.client.Announce(d, h, complete, announceclient.V2)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/torrent/scheduler/announcer/announcer_test.go
+++ b/lib/torrent/scheduler/announcer/announcer_test.go
@@ -97,7 +97,7 @@ func TestAnnouncerAnnounceUpdatesInterval(t *testing.T) {
 	interval := 10 * time.Second
 	peers := []*core.PeerInfo{core.PeerInfoFixture()}
 
-	mocks.client.EXPECT().Announce(d, hash, false, announceclient.V1).Return(peers, interval, nil)
+	mocks.client.EXPECT().Announce(d, hash, false, announceclient.V2).Return(peers, interval, nil)
 
 	result, err := announcer.Announce(d, hash, false)
 	require.NoError(err)
@@ -129,7 +129,7 @@ func TestAnnouncerAnnounceErr(t *testing.T) {
 	hash := core.InfoHashFixture()
 	err := errors.New("some error")
 
-	mocks.client.EXPECT().Announce(d, hash, false, announceclient.V1).Return(nil, time.Duration(0), err)
+	mocks.client.EXPECT().Announce(d, hash, false, announceclient.V2).Return(nil, time.Duration(0), err)
 
 	_, aErr := announcer.Announce(d, hash, false)
 	require.Equal(err, aErr)

--- a/lib/torrent/scheduler/events_test.go
+++ b/lib/torrent/scheduler/events_test.go
@@ -142,7 +142,7 @@ func TestAnnounceTickEvent(t *testing.T) {
 			ctrls[0].dispatcher.Digest(),
 			ctrls[0].dispatcher.InfoHash(),
 			false,
-			announceclient.V1).
+			announceclient.V2).
 		Return(nil, time.Second, nil)
 
 	announceTickEvent{}.apply(state)
@@ -187,7 +187,7 @@ func TestAnnounceTickEventSkipsFullTorrents(t *testing.T) {
 			empty.dispatcher.Digest(),
 			empty.dispatcher.InfoHash(),
 			false,
-			announceclient.V1).
+			announceclient.V2).
 		Return(nil, time.Second, nil)
 
 	announceTickEvent{}.apply(state)
@@ -219,7 +219,7 @@ func TestAnnounceTickEventSkipsFullTorrents(t *testing.T) {
 			full.dispatcher.Digest(),
 			full.dispatcher.InfoHash(),
 			false,
-			announceclient.V1).
+			announceclient.V2).
 		Return(nil, time.Second, nil)
 
 	announceTickEvent{}.apply(state)


### PR DESCRIPTION
This is long overdue. We added the V2 endpoint to Tracker over a year ago
and never migrated the agents over.

By using the V2 endpoint, the info hash will be part of the request URL,
and thus our nginx access logs in Tracker will show which info hash is being announced.