### PR TITLE
Bug. Fixing backend settings in helm chart

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,15 +31,15 @@ build_index:
   extraVolumes:
   extraVolumeMounts:
   initContainers:
-#  extraBackends: |-
-#    - namespace: library/.*
-#      backend:
-#        registry_tag:
-#          address: my.private.registry
-#          security:
-#            basic:
-#              username: "joebloggs"
-#              password: "12345"
+  extraBackends: |-
+   - namespace: library/.*
+     backend:
+       registry_tag:
+         address: index.docker.io
+         security:
+           basic:
+            username: ""
+            password: ""
 
 origin:
   config: /etc/config/origin.yaml
@@ -48,15 +48,15 @@ origin:
   extraVolumes:
   extraVolumeMounts:
   initContainers:
-#  extraBackends: |-
-#    - namespace: library/.*
-#      backend:
-#        registry_blob:
-#          address: my.private.registry
-#          security:
-#            basic:
-#              username: "joebloggs"
-#              password: "12345"
+  extraBackends: |-
+   - namespace: library/.*
+     backend:
+       registry_blob:
+         address: index.docker.io
+         security:
+           basic:
+            username: ""
+            password: ""
 
 proxy:
   config: /etc/config/proxy.yaml
@@ -75,5 +75,5 @@ agent:
   tolerations:
 #    - operator: "Exists"
 testfs:
-  enabled: true
+  enabled: false
   annotations:


### PR DESCRIPTION
The current values in the helm/values.yaml will not work with the current kubeconfig in examples/k8s/. This is because busybox would not be in the temp/files directory hence the registry will return a 404. This change adds a backend to docker.io so that the demo will start in k8s. Addresses #269

Signed-off-by: Julius Liu <juliusl@microsoft.com>