### PR TITLE
[helm] feat: support preheat function in kraken-proxy

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,7 +1,7 @@
 name: kraken
 description: P2P Docker registry capable of distributing TBs of data in seconds
-version: 0.2.0
-kubeVersion: ">=1.10.0"
+version: 0.2.1
+kubeVersion: "^1.10.0-0"
 keywords:
   - http
   - docker

--- a/helm/config/agent.yaml
+++ b/helm/config/agent.yaml
@@ -2,3 +2,7 @@ extends: /etc/kraken/config/agent/base.yaml
 {{ include "tls" . }}
 {{ include "trackers" . }}
 {{ include "build-index" . }}
+{{- with .Values.agent.allowedCidrs }}
+allowed_cidrs:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/helm/templates/proxy.yaml
+++ b/helm/templates/proxy.yaml
@@ -32,6 +32,7 @@ spec:
         - /usr/bin/kraken-proxy
         - --config={{ .Values.proxy.config }}
         - --port=80
+        - --server-port=81
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -55,3 +56,8 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 80
+    name: proxy
+  - protocol: TCP
+    port: 81
+    targetPort: 81
+    name: proxy-server

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -74,6 +74,17 @@ agent:
   initContainers:
   tolerations:
 #    - operator: "Exists"
+  # Override the list of IP address (ranges) allowed to access the agents
+  # Will be interpreted by NGINX allow statement.
+  #
+  # This can be useful e.g. when using AWS EKS with vpc-cni where the requests
+  # are made not from 127.0.0.1 but from the host IP
+  # default is:
+  # - 127.0.0.1
+  # - 172.17.0.1
+  allowedCidrs:
+    # - 192.168.178.1/24
+    # - 10.10.0.1
 testfs:
   enabled: true
   annotations:


### PR DESCRIPTION
Hi folks,

I've enabled the kraken-proxy server required for preheat (e.g. with Harbor) on port 81.

In addition to this, I've updated the `kubeVersion` restriction to work with current kubernetes versions. See also https://github.com/uber/kraken/issues/277

Best regards,
Florian.
