### PR TITLE
[feat] Change pressly/chi imports to go-chi/chi

### DIFF
--- a/agent/agentserver/server.go
+++ b/agent/agentserver/server.go
@@ -32,7 +32,7 @@ import (
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/httputil"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/uber-go/tally"
 )
 

--- a/build-index/tagserver/server.go
+++ b/build-index/tagserver/server.go
@@ -41,7 +41,7 @@ import (
 	"github.com/uber/kraken/utils/listener"
 	"github.com/uber/kraken/utils/log"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	chimiddleware "github.com/pressly/chi/middleware"
 	"github.com/uber-go/tally"
 )

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/docker/go-units v0.0.0-20181030082039-2fb04c6466a5 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/garyburd/redigo v1.6.0
-	github.com/go-chi/chi v0.0.0-20190316151245-d08916613452 // indirect
+	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/gofrs/uuid v0.0.0-20190320161447-2593f3d8aa45 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.3.3
@@ -37,7 +37,6 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/opencontainers/go-digest v0.0.0-20190228220655-ac19fd6e7483
-	github.com/pressly/chi v4.0.2+incompatible
 	github.com/pressly/goose v2.6.0+incompatible
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
 	github.com/prometheus/common v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/go-chi/chi v0.0.0-20190316151245-d08916613452 h1:jO5Yr6G8v5j4TfeULuAOIQi5KcRxHE7p0L5QB7dm38Y=
 github.com/go-chi/chi v0.0.0-20190316151245-d08916613452/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
+github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -200,8 +202,6 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pressly/chi v4.0.2+incompatible h1:IQCvpYSGI/zsVuwr8+Q2R/13k9EHaFi05M3g8thnyqs=
-github.com/pressly/chi v4.0.2+incompatible/go.mod h1:s/kslmeFE633XtTPvfX2olbs4ymzIHxGGXmEJ/AvPT8=
 github.com/pressly/goose v2.6.0+incompatible h1:3f8zIQ8rfgP9tyI0Hmcs2YNAqUCL1c+diLe3iU8Qd/k=
 github.com/pressly/goose v2.6.0+incompatible/go.mod h1:m+QHWCqxR3k8D9l7qfzuC/djtlfzxr34mozWDYEu1z8=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/lib/backend/hdfsbackend/webhdfs/client_test.go
+++ b/lib/backend/hdfsbackend/webhdfs/client_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/uber/kraken/utils/rwutil"
 	"github.com/uber/kraken/utils/testutil"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
 )
 

--- a/lib/backend/httpbackend/http_test.go
+++ b/lib/backend/httpbackend/http_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/uber/kraken/utils/randutil"
 	"github.com/uber/kraken/utils/testutil"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
 )
 

--- a/lib/backend/registrybackend/blobclient_test.go
+++ b/lib/backend/registrybackend/blobclient_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"

--- a/lib/backend/registrybackend/tagclient_test.go
+++ b/lib/backend/registrybackend/tagclient_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"

--- a/lib/backend/testfs/server.go
+++ b/lib/backend/testfs/server.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/uber/kraken/utils/handler"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 )
 
 // Server provides HTTP endpoints for operating on files on disk.

--- a/lib/middleware/middleware.go
+++ b/lib/middleware/middleware.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/uber-go/tally"
 )
 

--- a/lib/middleware/middleware_test.go
+++ b/lib/middleware/middleware_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/uber/kraken/utils/httputil"
 	"github.com/uber/kraken/utils/testutil"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 )

--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -46,7 +46,7 @@ import (
 	"github.com/uber/kraken/utils/stringset"
 
 	"github.com/andres-erbsen/clock"
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/uber-go/tally"
 )
 

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -43,7 +43,7 @@ import (
 	"github.com/uber/kraken/utils/netutil"
 
 	"github.com/andres-erbsen/clock"
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )

--- a/proxy/proxyserver/server.go
+++ b/proxy/proxyserver/server.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	_ "net/http/pprof" // Registers /debug/pprof endpoints in http.DefaultServeMux.
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/uber-go/tally"
 	"github.com/uber/kraken/lib/middleware"
 	"github.com/uber/kraken/origin/blobclient"

--- a/proxy/registryoverride/server.go
+++ b/proxy/registryoverride/server.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/uber/kraken/build-index/tagclient"
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/listener"

--- a/tracker/trackerserver/server.go
+++ b/tracker/trackerserver/server.go
@@ -18,8 +18,8 @@ import (
 	"net/http"
 	_ "net/http/pprof" // Registers /debug/pprof endpoints in http.DefaultServeMux.
 
-	"github.com/pressly/chi"
-	chimiddleware "github.com/pressly/chi/middleware"
+	"github.com/go-chi/chi"
+	chimiddleware "github.com/go-chi/chi/middleware"
 	"github.com/uber-go/tally"
 
 	"github.com/uber/kraken/lib/middleware"

--- a/utils/httputil/httputil.go
+++ b/utils/httputil/httputil.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/utils/handler"

--- a/utils/httputil/httputil_test.go
+++ b/utils/httputil/httputil_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/golang/mock/gomock"
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/kraken/core"

--- a/utils/httputil/tls_test.go
+++ b/utils/httputil/tls_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/kraken/utils/randutil"


### PR DESCRIPTION
`pressly/chi` library is recommended to change to `go-chi/chi` https://github.com/go-chi/chi

And this change has been introduced from here:
https://github.com/go-chi/chi/blob/master/CHANGELOG.md#v300-2017-06-21

```
NOTE: please update your import paths to "github.com/go-chi/chi"
```