### PR TITLE
[fix] Remove left out pressly/chi/middleware import

### DIFF
--- a/build-index/tagserver/server.go
+++ b/build-index/tagserver/server.go
@@ -42,7 +42,7 @@ import (
 	"github.com/uber/kraken/utils/log"
 
 	"github.com/go-chi/chi"
-	chimiddleware "github.com/pressly/chi/middleware"
+	chimiddleware "github.com/go-chi/chi/middleware"
 	"github.com/uber-go/tally"
 )
 

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/go-chi/chi v0.0.0-20190316151245-d08916613452 h1:jO5Yr6G8v5j4TfeULuAOIQi5KcRxHE7p0L5QB7dm38Y=
-github.com/go-chi/chi v0.0.0-20190316151245-d08916613452/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=


### PR DESCRIPTION
In this diff: https://github.com/uber/kraken/pull/321, I left out the middleware import, fixing.