### PR TITLE
Support Multi-Arch by Supporting Manifest List

### DIFF
--- a/build-index/tagtype/docker_resolver.go
+++ b/build-index/tagtype/docker_resolver.go
@@ -17,10 +17,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/docker/distribution"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/origin/blobclient"
 	"github.com/uber/kraken/utils/dockerutil"
-	"github.com/docker/distribution"
 )
 
 type dockerResolver struct {
@@ -45,7 +45,7 @@ func (r *dockerResolver) downloadManifest(tag string, d core.Digest) (distributi
 	if err := r.originClient.DownloadBlob(tag, d, buf); err != nil {
 		return nil, fmt.Errorf("download blob: %s", err)
 	}
-	manifest, _, err := dockerutil.ParseManifestV2(buf)
+	manifest, _, err := dockerutil.ParseManifest(buf)
 	if err != nil {
 		return nil, fmt.Errorf("parse manifest: %s", err)
 	}

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -53,7 +53,6 @@ func (f *tagClientFactory) Create(
 }
 
 const _tagquery = "http://%s/v2/%s/manifests/%s"
-const _v2ManifestType = "application/vnd.docker.distribution.manifest.v2+json"
 
 // TagClient stats and downloads tag from registry.
 type TagClient struct {
@@ -92,7 +91,7 @@ func (c *TagClient) Stat(namespace, name string) (*core.BlobInfo, error) {
 		URL,
 		append(
 			opts,
-			httputil.SendHeaders(map[string]string{"Accept": _v2ManifestType}),
+			httputil.SendHeaders(map[string]string{"Accept": dockerutil.GetSupportedManifestTypes()}),
 			httputil.SendAcceptedCodes(http.StatusOK, http.StatusNotFound),
 		)...,
 	)
@@ -128,7 +127,7 @@ func (c *TagClient) Download(namespace, name string, dst io.Writer) error {
 		URL,
 		append(
 			opts,
-			httputil.SendHeaders(map[string]string{"Accept": _v2ManifestType}),
+			httputil.SendHeaders(map[string]string{"Accept": dockerutil.GetSupportedManifestTypes()}),
 			httputil.SendAcceptedCodes(http.StatusOK, http.StatusNotFound),
 		)...,
 	)
@@ -141,7 +140,7 @@ func (c *TagClient) Download(namespace, name string, dst io.Writer) error {
 		return backenderrors.ErrBlobNotFound
 	}
 
-	_, digest, err := dockerutil.ParseManifestV2(resp.Body)
+	_, digest, err := dockerutil.ParseManifest(resp.Body)
 	if err != nil {
 		return fmt.Errorf("parse manifest v2: %s", err)
 	}

--- a/proxy/proxyserver/preheat.go
+++ b/proxy/proxyserver/preheat.go
@@ -113,7 +113,7 @@ func (ph *PreheatHandler) fetchManifest(repo, digest string) (distribution.Manif
 		return nil, fmt.Errorf("manifest not found")
 	}
 
-	manifest, _, err := dockerutil.ParseManifestV2(buf)
+	manifest, _, err := dockerutil.ParseManifest(buf)
 	if err != nil {
 		return nil, fmt.Errorf("parse manifest: %s", err)
 	}

--- a/utils/dockerutil/dockerutil_test.go
+++ b/utils/dockerutil/dockerutil_test.go
@@ -1,0 +1,90 @@
+package dockerutil_test
+
+import (
+	"testing"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/kraken/utils/dockerutil"
+)
+
+var testManifestListBytes = []byte(`{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+	"manifests": [
+	   {
+		  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+		  "size": 985,
+		  "digest": "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+		  "platform": {
+			 "architecture": "amd64",
+			 "os": "linux",
+			 "features": [
+				"sse4"
+			 ]
+		  }
+	   },
+	   {
+		  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+		  "size": 2392,
+		  "digest": "sha256:6346340964309634683409684360934680934608934608934608934068934608",
+		  "platform": {
+			 "architecture": "sun4m",
+			 "os": "sunos"
+		  }
+	   }
+	]
+ }`)
+
+var testManifestBytes = []byte(`{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+	"config": {
+	   "mediaType": "application/vnd.docker.container.image.v1+json",
+	   "size": 985,
+	   "digest": "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
+	},
+	"layers": [
+	   {
+		  "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		  "size": 153263,
+		  "digest": "sha256:62d8908bee94c202b2d35224a221aaa2058318bfa9879fa541efaecba272331b"
+	   }
+	]
+ }`)
+
+func TestParseManifestV2List(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name          string
+		hasError      bool
+		manifestBytes []byte
+	}{
+		{
+			name:          "success",
+			hasError:      false,
+			manifestBytes: testManifestListBytes,
+		},
+		{
+			name:          "wrong manifest type",
+			hasError:      true,
+			manifestBytes: testManifestBytes,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, d, err := dockerutil.ParseManifestV2List(tt.manifestBytes)
+			if tt.hasError {
+				require.Error(err)
+				return
+			}
+
+			require.NoError(err)
+			mediaType, _, err := manifest.Payload()
+			require.NoError(err)
+			require.EqualValues(manifestlist.MediaTypeManifestList, mediaType)
+			require.Equal("sha256", d.Algo())
+		})
+	}
+}


### PR DESCRIPTION
**Summary**:
Adds Multi-Arch support by supporting manifest list.

**Testing**
Bring up dev cluster locally.
1. Build two images with different arch.
```
REPOSITORY              TAG           IMAGE ID       CREATED      SIZE
testing/testing-build   arm64v8-1.0   cb18cbc8100d   6 days ago   74.5MB
testing/testing-build   amd64-1.0     840a89ece7a1   6 days ago   80.9MB
```
2. Push them.
```
xinlongz@xinlongz-C02ZX4VAMD6M multi-arch % docker push localhost:15000/testing/testing-build:arm64v8-1.0
The push refers to repository [localhost:15000/testing/testing-build]
948260395c24: Pushed 
377e88cd1334: Pushed 
arm64v8-1.0: digest: sha256:0e19e811ecf370db27644346585b89152af8c647addf9e1b302e0864f0e07b93 size: 740
xinlongz@xinlongz-C02ZX4VAMD6M multi-arch % docker push localhost:15000/testing/testing-build:amd64-1.0
The push refers to repository [localhost:15000/testing/testing-build]
ebbade774b0d: Pushed 
56a5c11640c8: Pushed 
amd64-1.0: digest: sha256:d35e2f18bd6f155884c9f91ff85120480e9aed203b7285911c922d6f900c5a15 size: 740
```
3. Create the manifest list.
```
docker manifest create --insecure localhost:15000/testing/testing-build:1.0 localhost:15000/testing/testing-build:arm64v8-1.0 localhost:15000/testing/testing-build:amd64-1.0
Created manifest list localhost:15000/testing/testing-build:1.0
```
4. Push the manifest list.
```
docker manifest push --insecure localhost:15000/testing/testing-build:1.0
sha256:6f4eb514d2427f874bc2176111a794a1fcaf49bbdd2d87ac95075799b5bf281b
```
5. docker pull with the manifest list tag.
```
docker pull localhost:16000/testing/testing-build:1.0
1.0: Pulling from testing/testing-build
Digest: sha256:6f4eb514d2427f874bc2176111a794a1fcaf49bbdd2d87ac95075799b5bf281b
Status: Downloaded newer image for localhost:16000/testing/testing-build:1.0
localhost:16000/testing/testing-build:1.0
```
6. The pulled image localhost:16000/testing/testing-build:1.0 has the same image ID as the images with amd64-1.0 tag. This is because the platform of the local machine is amd64.
```
testing/testing-build                            arm64v8-1.0   cb18cbc8100d   6 days ago      74.5MB
localhost:15000/testing/testing-build            arm64v8-1.0   cb18cbc8100d   6 days ago      74.5MB
testing/testing-build                            amd64-1.0     840a89ece7a1   6 days ago      80.9MB
localhost:15000/testing/testing-build            amd64-1.0     840a89ece7a1   6 days ago      80.9MB
localhost:16000/testing/testing-build            1.0           840a89ece7a1   6 days ago      80.9MB
```