### PR TITLE
Disable HTTPS to HTTP fallback

### DIFF
--- a/utils/httputil/httputil.go
+++ b/utils/httputil/httputil.go
@@ -287,7 +287,7 @@ func Send(method, rawurl string, options ...SendOption) (*http.Response, error) 
 		transport:            nil, // Use HTTP default.
 		ctx:                  context.Background(),
 		url:                  u,
-		httpFallbackDisabled: false,
+		httpFallbackDisabled: true,
 	}
 	for _, o := range options {
 		o(opts)


### PR DESCRIPTION
This fallback would prevent retries from happening after TLS enabling because the fallbacked HTTP requests would always get HTTP 400 which is not a retryable code.

This would make all requests from tagclient cannot be retries which impact reliability.