### PR TITLE
Route health check request to agent server

### DIFF
--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -235,6 +235,7 @@ func Run(flags *Flags, opts ...Option) {
 		"port":          flags.AgentRegistryPort,
 		"registry_server": nginx.GetServer(
 			config.Registry.Docker.HTTP.Net, config.Registry.Docker.HTTP.Addr),
+		"agent_server":    fmt.Sprintf("127.0.0.1:%d", flags.AgentServerPort),
 		"registry_backup": config.RegistryBackup},
 		nginx.WithTLS(config.TLS)))
 }

--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -20,6 +20,10 @@ upstream registry-backend {
   {{if ne .registry_backup ""}} server {{.registry_backup}} backup; {{end}}
 }
 
+upstream agent-server {
+  server {{.agent_server}};
+}
+
 server {
   listen {{.port}};
 
@@ -35,6 +39,10 @@ server {
 
   gzip on;
   gzip_types text/plain test/csv application/json;
+
+  location /health {
+    proxy_pass http://agent-server;
+  }
 
   location / {
     proxy_pass http://registry-backend;


### PR DESCRIPTION
Route health check request to agent server.
Currently, it is routed to the registry backend.


Test: 
```
xinlongz@xinlongz-C02ZX4VAMD6M kraken % curl localhost:16000/health                        
OK
```