### PR TITLE
Remove the new line sign from health check response

### DIFF
--- a/agent/agentserver/server.go
+++ b/agent/agentserver/server.go
@@ -190,7 +190,7 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) error {
 	if err := s.sched.Probe(); err != nil {
 		return handler.Errorf("probe torrent client: %s", err)
 	}
-	fmt.Fprintln(w, "OK")
+	io.WriteString(w, "OK")
 	return nil
 }
 


### PR DESCRIPTION
The healthfx used internal returns "OK" without new line. 
Correct for Kraken Agent to make it consistent.


Test:
bash-3.2$ curl localhost:16000/health
OKbash-3.2$