### PR TITLE
Add Aggressive cleanup when disk util is high

### DIFF
--- a/lib/store/upload_store.go
+++ b/lib/store/upload_store.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/andres-erbsen/clock"
 	"github.com/uber/kraken/lib/store/base"
 	"github.com/uber/kraken/lib/store/metadata"
-	"github.com/andres-erbsen/clock"
 )
 
 // uploadStore provides basic upload file operations. Intended to be embedded

--- a/utils/diskspaceutil/diskspaceutil.go
+++ b/utils/diskspaceutil/diskspaceutil.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package diskspaceutil
+
+import (
+	"syscall"
+)
+
+const path = "/"
+
+// Helper method to get disk util.
+func DiskSpaceUtil() (int, error) {
+	fs := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &fs)
+	if err != nil {
+		return 0, err
+	}
+
+	diskAll := fs.Blocks * uint64(fs.Bsize)
+	diskFree := fs.Bfree * uint64(fs.Bsize)
+	diskUsed := diskAll - diskFree
+	return int(diskUsed * 100 / diskAll), nil
+
+}

--- a/utils/diskspaceutil/diskspaceutil_test.go
+++ b/utils/diskspaceutil/diskspaceutil_test.go
@@ -1,0 +1,17 @@
+package diskspaceutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/kraken/utils/diskspaceutil"
+)
+
+func TestParseManifestV2List(t *testing.T) {
+	util, err := diskspaceutil.DiskSpaceUtil()
+	require.NoError(t, err)
+
+	require.Equal(t, true, util > 0)
+	require.Equal(t, true, util < 100)
+}


### PR DESCRIPTION
Kraken currently isn't able to handle a lot of downloading traffic in a short amount of time because disk space is used up very quickly.

Add the aggressive cleanup so that Kraken cleans up disk space when the current disk space util is higher than the configured threshold.