### PR TITLE
fix(sec): upgrade github.com/gorilla/handlers to 1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.0
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
-	github.com/gorilla/handlers v0.0.0-20190227193432-ac6d24f88de4 // indirect
+	github.com/gorilla/handlers v1.3.0 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jackpal/bencode-go v0.0.0-20180813173944-227668e840fa

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/handlers v0.0.0-20190227193432-ac6d24f88de4 h1:0Kf6Olt6OB/0z28orAeuAQ6eK4Ub8peqJ7k4wiOA2c8=
 github.com/gorilla/handlers v0.0.0-20190227193432-ac6d24f88de4/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/handlers v1.3.0 h1:tsg9qP3mjt1h4Roxp+M1paRjrVBfPSOpBuVclh6YluI=
+github.com/gorilla/handlers v1.3.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/gorilla/handlers v0.0.0-20190227193432-ac6d24f88de4
- [MPS-2022-13376](https://www.oscs1024.com/hd/MPS-2022-13376)


### What did I do？
Upgrade github.com/gorilla/handlers from v0.0.0-20190227193432-ac6d24f88de4 to 1.3.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS