### PR TITLE
[Kraken] Add WithPullUnpack option for PullImage

### DIFF
--- a/lib/containerruntime/containerd/client.go
+++ b/lib/containerruntime/containerd/client.go
@@ -40,7 +40,7 @@ func (c *Impl) PullImage(ctx context.Context, ns, repo, tag string) error {
 	}
 	defer client.Close()
 
-	_, err = client.Pull(ctx, fmt.Sprintf("%s/%s:%s", c.registry, repo, tag))
+	_, err = client.Pull(ctx, fmt.Sprintf("%s/%s:%s", c.registry, repo, tag), containerd.WithPullUnpack)
 	if err != nil {
 		return fmt.Errorf("containerd pull image: %s", err)
 	}


### PR DESCRIPTION
Currently preload endpoint does not unpack an image after fetch. WithPullUnpack option is used to unpack an image after the pull is completed. This will reduce time for containerd to create containers, especially for large images that have been fetched through the preload endpoint.