### PR TITLE
Support file read/write with max part size

### DIFF
--- a/lib/store/base/file_entry.go
+++ b/lib/store/base/file_entry.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -79,8 +79,8 @@ type FileEntry interface {
 	LinkTo(targetPath string) error
 	Delete() error
 
-	GetReader() (FileReader, error)
-	GetReadWriter() (FileReadWriter, error)
+	GetReader(readPartSize int) (FileReader, error)
+	GetReadWriter(readPartSize, writePartSize int) (FileReadWriter, error)
 
 	AddMetadata(md metadata.Metadata) error
 
@@ -438,29 +438,32 @@ func (entry *localFileEntry) Delete() error {
 }
 
 // GetReader returns a FileReader object for read operations.
-func (entry *localFileEntry) GetReader() (FileReader, error) {
+func (entry *localFileEntry) GetReader(readPartSize int) (FileReader, error) {
 	f, err := os.OpenFile(entry.GetPath(), os.O_RDONLY, 0775)
 	if err != nil {
 		return nil, err
 	}
 
 	reader := &localFileReadWriter{
-		entry:      entry,
-		descriptor: f,
+		entry:        entry,
+		descriptor:   f,
+		readPartSize: readPartSize,
 	}
 	return reader, nil
 }
 
 // GetReadWriter returns a FileReadWriter object for read/write operations.
-func (entry *localFileEntry) GetReadWriter() (FileReadWriter, error) {
+func (entry *localFileEntry) GetReadWriter(readPartSize, writePartSize int) (FileReadWriter, error) {
 	f, err := os.OpenFile(entry.GetPath(), os.O_RDWR, 0775)
 	if err != nil {
 		return nil, err
 	}
 
 	readWriter := &localFileReadWriter{
-		entry:      entry,
-		descriptor: f,
+		entry:         entry,
+		descriptor:    f,
+		readPartSize:  readPartSize,
+		writePartSize: writePartSize,
 	}
 	return readWriter, nil
 }

--- a/lib/store/base/file_map_test.go
+++ b/lib/store/base/file_map_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -446,17 +446,17 @@ func TestLRUUpdateLastAccessTimeOnOpen(t *testing.T) {
 
 	// No LAT change below resolution.
 	clk.Add(time.Minute)
-	_, err := store.NewFileOp().AcceptState(s1).GetFileReader(fn)
+	_, err := store.NewFileOp().AcceptState(s1).GetFileReader(fn, 0 /* readPartSize */)
 	require.NoError(err)
 	checkLAT(store.NewFileOp().AcceptState(s1), t0)
 
 	clk.Add(time.Hour)
-	_, err = store.NewFileOp().AcceptState(s1).GetFileReader(fn)
+	_, err = store.NewFileOp().AcceptState(s1).GetFileReader(fn, 0 /* readPartSize */)
 	require.NoError(err)
 	checkLAT(store.NewFileOp().AcceptState(s1), clk.Now())
 
 	clk.Add(time.Hour)
-	_, err = store.NewFileOp().AcceptState(s1).GetFileReadWriter(fn)
+	_, err = store.NewFileOp().AcceptState(s1).GetFileReadWriter(fn, 0 /* readPartSize */, 0 /*writePartSize*/)
 	require.NoError(err)
 	checkLAT(store.NewFileOp().AcceptState(s1), clk.Now())
 }

--- a/lib/store/base/file_op.go
+++ b/lib/store/base/file_op.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,8 @@ type FileOp interface {
 	GetFilePath(name string) (string, error)
 	GetFileStat(name string) (os.FileInfo, error)
 
-	GetFileReader(name string) (FileReader, error)
-	GetFileReadWriter(name string) (FileReadWriter, error)
+	GetFileReader(name string, readPartSize int) (FileReader, error)
+	GetFileReadWriter(name string, readPartSize, writePartSize int) (FileReadWriter, error)
 
 	GetFileMetadata(name string, md metadata.Metadata) error
 	SetFileMetadata(name string, md metadata.Metadata) (bool, error)
@@ -358,9 +358,9 @@ func (op *localFileOp) GetFileStat(name string) (info os.FileInfo, err error) {
 }
 
 // GetFileReader returns a FileReader object for read operations.
-func (op *localFileOp) GetFileReader(name string) (r FileReader, err error) {
+func (op *localFileOp) GetFileReader(name string, readPartSize int) (r FileReader, err error) {
 	if loadErr := op.lockHelper(name, _lockLevelRead, func(name string, entry FileEntry) {
-		r, err = entry.GetReader()
+		r, err = entry.GetReader(readPartSize)
 	}); loadErr != nil {
 		return nil, loadErr
 	}
@@ -368,9 +368,9 @@ func (op *localFileOp) GetFileReader(name string) (r FileReader, err error) {
 }
 
 // GetFileReadWriter returns a FileReadWriter object for read/write operations.
-func (op *localFileOp) GetFileReadWriter(name string) (w FileReadWriter, err error) {
+func (op *localFileOp) GetFileReadWriter(name string, readPartSize, writePartSize int) (w FileReadWriter, err error) {
 	if loadErr := op.lockHelper(name, _lockLevelWrite, func(name string, entry FileEntry) {
-		w, err = entry.GetReadWriter()
+		w, err = entry.GetReadWriter(readPartSize, writePartSize)
 	}); loadErr != nil {
 		return nil, loadErr
 	}

--- a/lib/store/ca_download_store.go
+++ b/lib/store/ca_download_store.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,10 +17,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/uber/kraken/lib/store/base"
-	"github.com/uber/kraken/lib/store/metadata"
 	"github.com/andres-erbsen/clock"
 	"github.com/uber-go/tally"
+	"github.com/uber/kraken/lib/store/base"
+	"github.com/uber/kraken/lib/store/metadata"
 )
 
 // CADownloadStore allows simultaneously downloading and uploading
@@ -30,6 +30,8 @@ type CADownloadStore struct {
 	downloadState base.FileState
 	cacheState    base.FileState
 	cleanup       *cleanupManager
+	readPartSize  int
+	writePartSize int
 }
 
 // NewCADownloadStore creates a new CADownloadStore.
@@ -66,6 +68,8 @@ func NewCADownloadStore(config CADownloadStoreConfig, stats tally.Scope) (*CADow
 		downloadState: downloadState,
 		cacheState:    cacheState,
 		cleanup:       cleanup,
+		readPartSize:  config.ReadPartSize,
+		writePartSize: config.WritePartSize,
 	}, nil
 }
 
@@ -81,7 +85,7 @@ func (s *CADownloadStore) CreateDownloadFile(name string, length int64) error {
 
 // GetDownloadFileReadWriter returns a FileReadWriter for name.
 func (s *CADownloadStore) GetDownloadFileReadWriter(name string) (FileReadWriter, error) {
-	return s.backend.NewFileOp().AcceptState(s.downloadState).GetFileReadWriter(name)
+	return s.backend.NewFileOp().AcceptState(s.downloadState).GetFileReadWriter(name, s.readPartSize, s.writePartSize)
 }
 
 // MoveDownloadFileToCache moves a download file to the cache.
@@ -157,7 +161,7 @@ func (s *CADownloadStore) Any() *CADownloadStoreScope {
 
 // GetFileReader returns a reader for name.
 func (a *CADownloadStoreScope) GetFileReader(name string) (FileReader, error) {
-	return a.op.GetFileReader(name)
+	return a.op.GetFileReader(name, a.store.readPartSize)
 }
 
 // GetFileStat returns file info for name.

--- a/lib/store/ca_store.go
+++ b/lib/store/ca_store.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,13 +46,13 @@ func NewCAStore(config CAStoreConfig, stats tally.Scope) (*CAStore, error) {
 		"module": "castore",
 	})
 
-	uploadStore, err := newUploadStore(config.UploadDir)
+	uploadStore, err := newUploadStore(config.UploadDir, config.ReadPartSize, config.WritePartSize)
 	if err != nil {
 		return nil, fmt.Errorf("new upload store: %s", err)
 	}
 
 	cacheBackend := base.NewCASFileStoreWithLRUMap(config.Capacity, clock.New())
-	cacheStore, err := newCacheStore(config.CacheDir, cacheBackend)
+	cacheStore, err := newCacheStore(config.CacheDir, cacheBackend, config.ReadPartSize)
 	if err != nil {
 		return nil, fmt.Errorf("new cache store: %s", err)
 	}
@@ -85,7 +85,7 @@ func (s *CAStore) MoveUploadFileToCache(uploadName, cacheName string) error {
 	}
 	defer s.DeleteUploadFile(uploadName)
 
-	f, err := s.uploadStore.newFileOp().GetFileReader(uploadName)
+	f, err := s.uploadStore.newFileOp().GetFileReader(uploadName, s.uploadStore.readPartSize)
 	if err != nil {
 		return fmt.Errorf("get file reader %s: %s", uploadName, err)
 	}

--- a/lib/store/ca_store_test.go
+++ b/lib/store/ca_store_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -151,7 +151,7 @@ func TestCAStoreCreateUploadFileAndMoveToCache(t *testing.T) {
 	_, err = os.Stat(path.Join(config.UploadDir, src))
 	require.NoError(err)
 
-	f, err := s.uploadStore.newFileOp().GetFileReader(src)
+	f, err := s.uploadStore.newFileOp().GetFileReader(src, 0 /* readPartSize */)
 	require.NoError(err)
 	defer f.Close()
 	digester := core.NewDigester()
@@ -182,7 +182,7 @@ func TestCAStoreCreateUploadFileAndMoveToCacheFailure(t *testing.T) {
 	_, err = os.Stat(path.Join(config.UploadDir, src))
 	require.NoError(err)
 
-	f, err := s.uploadStore.newFileOp().GetFileReader(src)
+	f, err := s.uploadStore.newFileOp().GetFileReader(src, 0 /* readPartSize */)
 	require.NoError(err)
 	defer f.Close()
 	digester := core.NewDigester()

--- a/lib/store/cache_store.go
+++ b/lib/store/cache_store.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,20 +24,21 @@ import (
 // cacheStore provides basic cache file operations. Intended to be embedded in
 // higher level structs.
 type cacheStore struct {
-	state   base.FileState
-	backend base.FileStore
+	state        base.FileState
+	backend      base.FileStore
+	readPartSize int
 }
 
-func newCacheStore(dir string, backend base.FileStore) (*cacheStore, error) {
+func newCacheStore(dir string, backend base.FileStore, readPartSize int) (*cacheStore, error) {
 	if err := os.MkdirAll(dir, 0775); err != nil {
 		return nil, fmt.Errorf("mkdir: %s", err)
 	}
 	state := base.NewFileState(dir)
-	return &cacheStore{state, backend}, nil
+	return &cacheStore{state, backend, readPartSize}, nil
 }
 
 func (s *cacheStore) GetCacheFileReader(name string) (FileReader, error) {
-	return s.newFileOp().GetFileReader(name)
+	return s.newFileOp().GetFileReader(name, s.readPartSize)
 }
 
 func (s *cacheStore) GetCacheFileStat(name string) (os.FileInfo, error) {

--- a/lib/store/config.go
+++ b/lib/store/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,10 @@ type CAStoreConfig struct {
 	Capacity      int           `yaml:"capacity"`
 	UploadCleanup CleanupConfig `yaml:"upload_cleanup"`
 	CacheCleanup  CleanupConfig `yaml:"cache_cleanup"`
+	// Part size limit for each file read. 0 means no limit.
+	ReadPartSize int `yaml:"read_part_size"`
+	// Part size limit for each file write. 0 means no limit.
+	WritePartSize int `yaml:"write_part_size"`
 
 	SkipHashVerification bool `yaml:"skip_hash_verification"`
 }
@@ -46,6 +50,10 @@ type SimpleStoreConfig struct {
 	CacheDir      string        `yaml:"cache_dir"`
 	UploadCleanup CleanupConfig `yaml:"upload_cleanup"`
 	CacheCleanup  CleanupConfig `yaml:"cache_cleanup"`
+	// Part size limit for each file read. 0 means no limit.
+	ReadPartSize int `yaml:"read_part_size"`
+	// Part size limit for each file write. 0 means no limit.
+	WritePartSize int `yaml:"write_part_size"`
 }
 
 // CADownloadStoreConfig defines CADownloadStore configuration.
@@ -55,4 +63,8 @@ type CADownloadStoreConfig struct {
 	CacheDir        string        `yaml:"cache_dir"`
 	DownloadCleanup CleanupConfig `yaml:"download_cleanup"`
 	CacheCleanup    CleanupConfig `yaml:"cache_cleanup"`
+	// Part size limit for each file read. 0 means no limit.
+	ReadPartSize int `yaml:"read_part_size"`
+	// Part size limit for each file write. 0 means no limit.
+	WritePartSize int `yaml:"write_part_size"`
 }

--- a/lib/store/simple_store.go
+++ b/lib/store/simple_store.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,10 +18,10 @@ import (
 	"io"
 	"os"
 
-	"github.com/uber/kraken/lib/store/base"
 	"github.com/andres-erbsen/clock"
 	"github.com/docker/distribution/uuid"
 	"github.com/uber-go/tally"
+	"github.com/uber/kraken/lib/store/base"
 )
 
 // SimpleStore allows uploading / caching raw files of any format.
@@ -37,13 +37,13 @@ func NewSimpleStore(config SimpleStoreConfig, stats tally.Scope) (*SimpleStore, 
 		"module": "simplestore",
 	})
 
-	uploadStore, err := newUploadStore(config.UploadDir)
+	uploadStore, err := newUploadStore(config.UploadDir, config.ReadPartSize, config.WritePartSize)
 	if err != nil {
 		return nil, fmt.Errorf("new upload store: %s", err)
 	}
 
 	cacheBackend := base.NewLocalFileStore(clock.New())
-	cacheStore, err := newCacheStore(config.CacheDir, cacheBackend)
+	cacheStore, err := newCacheStore(config.CacheDir, cacheBackend, config.ReadPartSize)
 	if err != nil {
 		return nil, fmt.Errorf("new cache store: %s", err)
 	}

--- a/lib/store/upload_store.go
+++ b/lib/store/upload_store.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,9 +27,12 @@ import (
 type uploadStore struct {
 	state   base.FileState
 	backend base.FileStore
+
+	readPartSize  int
+	writePartSize int
 }
 
-func newUploadStore(dir string) (*uploadStore, error) {
+func newUploadStore(dir string, readPartSize, writePartSize int) (*uploadStore, error) {
 	// Always wipe upload directory on startup.
 	os.RemoveAll(dir)
 
@@ -38,7 +41,7 @@ func newUploadStore(dir string) (*uploadStore, error) {
 	}
 	state := base.NewFileState(dir)
 	backend := base.NewLocalFileStore(clock.New())
-	return &uploadStore{state, backend}, nil
+	return &uploadStore{state, backend, readPartSize, writePartSize}, nil
 }
 
 func (s *uploadStore) CreateUploadFile(name string, length int64) error {
@@ -50,11 +53,11 @@ func (s *uploadStore) GetUploadFileStat(name string) (os.FileInfo, error) {
 }
 
 func (s *uploadStore) GetUploadFileReader(name string) (FileReader, error) {
-	return s.newFileOp().GetFileReader(name)
+	return s.newFileOp().GetFileReader(name, s.readPartSize)
 }
 
 func (s *uploadStore) GetUploadFileReadWriter(name string) (FileReadWriter, error) {
-	return s.newFileOp().GetFileReadWriter(name)
+	return s.newFileOp().GetFileReadWriter(name, s.readPartSize, s.writePartSize)
 }
 
 func (s *uploadStore) GetUploadFileMetadata(name string, md metadata.Metadata) error {


### PR DESCRIPTION
By limiting the max part size(block size) for each write, the disk IO bandwidth can be limited.

Tested push and pull with local server.