### PR TITLE
Delete codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  token: 5231c3a9-08d2-4ee3-bcdd-57273da57745


### PR DESCRIPTION
The code can be used to upload fake coverage report to codecov. Although it does not impact the integrity of the code base, we should still remove it.