### PR TITLE
Disable TLS1.0

### DIFF
--- a/nginx/config/base.go
+++ b/nginx/config/base.go
@@ -73,7 +73,7 @@ http {
     ssl_verify_client on;
     ssl_client_certificate {{.ssl_client_certificate}};
   {{end}}
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_protocols TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
   ssl_prefer_server_ciphers on;
   ssl_ciphers ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5@SECLEVEL=1;
 


### PR DESCRIPTION
TLS 1.0 is considered vulnerability and requested to be disabled.

It should be a noop change since in the client side, we don't set minVersion and MaxVersion field in the [TLS config](https://pkg.go.dev/crypto/tls#Config) so the default minVersion is 1.2 and the default maxVersion is 1.3.

For example, Kraken internal clients TLS config: https://sourcegraph.com/github.com/uber/kraken@master/-/blob/utils/httputil/tls.go?L91
uBuild TLS config: https://sg.uberinternal.com/code.uber.internal/uber-code/go-code/-/blob/src/code.uber.internal/infra/ubuild/build/gateway/kraken/http_client.go?L63