### PR TITLE
Monitor Backend Download Usage

### DIFF
--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -63,4 +63,7 @@ type Client interface {
 
 	// List lists entries whose names start with prefix.
 	List(prefix string, opts ...ListOption) (*ListResult, error)
+
+	// BackendName returns of the name of the client's backend.
+	BackendName() string
 }

--- a/lib/backend/gcsbackend/client.go
+++ b/lib/backend/gcsbackend/client.go
@@ -211,6 +211,11 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 	return result, nil
 }
 
+// BackendName returns of the name of the client's backend.
+func (c *Client) BackendName() string {
+	return _gcs
+}
+
 // isObjectNotFound is helper function for identify non-existing object error.
 func isObjectNotFound(err error) bool {
 	return err == storage.ErrObjectNotExist || err == storage.ErrBucketNotExist

--- a/lib/backend/hdfsbackend/client.go
+++ b/lib/backend/hdfsbackend/client.go
@@ -128,6 +128,11 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 	return c.webhdfs.Rename(uploadPath, blobPath)
 }
 
+// BackendName returns of the name of the client's backend.
+func (c *Client) BackendName() string {
+	return _hdfs
+}
+
 var (
 	_ignoreRegex = regexp.MustCompile(
 		"^.+/repositories/.+/(_layers|_uploads|_manifests/(revisions|tags/.+/index)).*")
@@ -269,5 +274,5 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 
 	return &backend.ListResult{
 		Names: files,
-	},  nil
+	}, nil
 }

--- a/lib/backend/httpbackend/http.go
+++ b/lib/backend/httpbackend/http.go
@@ -118,3 +118,7 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }
+// BackendName returns of the name of the client's backend.
+func (c *Client) BackendName() string {
+	return _http
+}

--- a/lib/backend/noop.go
+++ b/lib/backend/noop.go
@@ -48,3 +48,8 @@ func (c NoopClient) Download(namespace, name string, dst io.Writer) error {
 func (c NoopClient) List(prefix string, opts ...ListOption) (*ListResult, error) {
 	return nil, nil
 }
+
+// BackendName returns of the name of the client's backend.
+func (c NoopClient) BackendName() string {
+	return NoopNamespace
+}

--- a/lib/backend/registrybackend/blobclient.go
+++ b/lib/backend/registrybackend/blobclient.go
@@ -158,3 +158,8 @@ func (c *BlobClient) Upload(namespace, name string, src io.Reader) error {
 func (c *BlobClient) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }
+
+// BackendName returns of the name of the client's backend.
+func (c *BlobClient) BackendName() string {
+	return _registryblob
+}

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -159,3 +159,8 @@ func (c *TagClient) Upload(namespace, name string, src io.Reader) error {
 func (c *TagClient) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }
+
+// BackendName returns of the name of the client's backend.
+func (c *TagClient) BackendName() string {
+	return _registrytag
+}

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -272,7 +272,6 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 			names = append(names, name)
 		}
 
-
 		if int64(len(names)) < maxKeys {
 			// Continue iterating pages to get more keys
 			return true
@@ -294,4 +293,9 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 		Names:             names,
 		ContinuationToken: nextContinuationToken,
 	}, nil
+}
+
+// BackendName returns of the name of the client's backend.
+func (c *Client) BackendName() string {
+	return _s3
 }

--- a/lib/backend/shadowbackend/client.go
+++ b/lib/backend/shadowbackend/client.go
@@ -31,8 +31,10 @@ import (
 
 type factory struct{}
 
+const _shadow = "shadow"
+
 func (f *factory) Name() string {
-	return "shadow"
+	return _shadow
 }
 
 func (f *factory) Create(
@@ -221,4 +223,9 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 		return nil, err
 	}
 	return res, nil
+}
+
+// BackendName returns of the name of the client's backend.
+func (c *Client) BackendName() string {
+	return _shadow
 }

--- a/lib/backend/sqlbackend/client.go
+++ b/lib/backend/sqlbackend/client.go
@@ -32,8 +32,10 @@ import (
 
 type factory struct{}
 
+const _sql = "sql"
+
 func (f *factory) Name() string {
-	return "sql"
+	return _sql
 }
 
 func (f *factory) Create(
@@ -223,6 +225,11 @@ func (c *Client) List(prefix string, _ ...backend.ListOption) (*backend.ListResu
 	default:
 		return dockerTagsQuery(c, prefix)
 	}
+}
+
+// BackendName returns of the name of the client's backend.
+func (c *Client) BackendName() string {
+	return _sql
 }
 
 func dockerCatalogQuery(c *Client) (*backend.ListResult, error) {

--- a/lib/backend/testfs/client.go
+++ b/lib/backend/testfs/client.go
@@ -164,3 +164,8 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 		Names: names,
 	}, nil
 }
+
+// BackendName returns of the name of the client's backend.
+func (c *Client) BackendName() string {
+	return _testfs
+}

--- a/lib/blobrefresh/refresher.go
+++ b/lib/blobrefresh/refresher.go
@@ -107,7 +107,7 @@ func (r *Refresher) Refresh(namespace string, d core.Digest, hooks ...PostHook) 
 			return err
 		}
 		t := time.Since(start)
-		r.stats.Timer("download_remote_blob").Record(t)
+		r.stats.Tagged(map[string]string{"backend": client.BackendName()}).Timer("download_remote_blob").Record(t)
 		log.With(
 			"namespace", namespace,
 			"name", d.Hex(),

--- a/lib/blobrefresh/refresher_test.go
+++ b/lib/blobrefresh/refresher_test.go
@@ -81,6 +81,7 @@ func TestRefresh(t *testing.T) {
 	blob := core.SizedBlobFixture(100, uint64(_testPieceLength))
 
 	client.EXPECT().Stat(namespace, blob.Digest.Hex()).Return(core.NewBlobInfo(int64(len(blob.Content))), nil)
+	client.EXPECT().BackendName().Return("mockbackend")
 	client.EXPECT().Download(namespace, blob.Digest.Hex(), mockutil.MatchWriter(blob.Content)).Return(nil)
 
 	require.NoError(refresher.Refresh(namespace, blob.Digest))
@@ -136,6 +137,7 @@ func TestRefreshSizeLimitWithValidSize(t *testing.T) {
 	blob := core.SizedBlobFixture(100, uint64(_testPieceLength))
 
 	client.EXPECT().Stat(namespace, blob.Digest.Hex()).Return(core.NewBlobInfo(int64(len(blob.Content))), nil)
+	client.EXPECT().BackendName().Return("mockbackend")
 	client.EXPECT().Download(namespace, blob.Digest.Hex(), mockutil.MatchWriter(blob.Content)).Return(nil)
 
 	require.NoError(refresher.Refresh(namespace, blob.Digest))

--- a/mocks/lib/backend/client.go
+++ b/mocks/lib/backend/client.go
@@ -5,37 +5,52 @@
 package mockbackend
 
 import (
+	io "io"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	core "github.com/uber/kraken/core"
 	backend "github.com/uber/kraken/lib/backend"
-	io "io"
-	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Download mocks base method
+// BackendName mocks base method.
+func (m *MockClient) BackendName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackendName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// BackendName indicates an expected call of BackendName.
+func (mr *MockClientMockRecorder) BackendName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackendName", reflect.TypeOf((*MockClient)(nil).BackendName))
+}
+
+// Download mocks base method.
 func (m *MockClient) Download(arg0, arg1 string, arg2 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Download", arg0, arg1, arg2)
@@ -43,13 +58,13 @@ func (m *MockClient) Download(arg0, arg1 string, arg2 io.Writer) error {
 	return ret0
 }
 
-// Download indicates an expected call of Download
+// Download indicates an expected call of Download.
 func (mr *MockClientMockRecorder) Download(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockClient)(nil).Download), arg0, arg1, arg2)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockClient) List(arg0 string, arg1 ...backend.ListOption) (*backend.ListResult, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -62,14 +77,14 @@ func (m *MockClient) List(arg0 string, arg1 ...backend.ListOption) (*backend.Lis
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockClientMockRecorder) List(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
-// Stat mocks base method
+// Stat mocks base method.
 func (m *MockClient) Stat(arg0, arg1 string) (*core.BlobInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", arg0, arg1)
@@ -78,13 +93,13 @@ func (m *MockClient) Stat(arg0, arg1 string) (*core.BlobInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat
+// Stat indicates an expected call of Stat.
 func (mr *MockClientMockRecorder) Stat(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockClient)(nil).Stat), arg0, arg1)
 }
 
-// Upload mocks base method
+// Upload mocks base method.
 func (m *MockClient) Upload(arg0, arg1 string, arg2 io.Reader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upload", arg0, arg1, arg2)
@@ -92,7 +107,7 @@ func (m *MockClient) Upload(arg0, arg1 string, arg2 io.Reader) error {
 	return ret0
 }
 
-// Upload indicates an expected call of Upload
+// Upload indicates an expected call of Upload.
 func (mr *MockClientMockRecorder) Upload(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockClient)(nil).Upload), arg0, arg1, arg2)


### PR DESCRIPTION
Looking to monitor which backends are in use during migration

```
rm coverage.txt; go test -timeout=30s -race -coverprofile=coverage.txt github.com/uber/kraken/lib/blobrefresh --tags "unit"
ok      github.com/uber/kraken/lib/blobrefresh  0.824s  coverage: 71.1% of statements
```

It looks like mocks and tests are in degraded state so only showing test for modified package with tests.