### PR TITLE
tally stats for backend clients

### DIFF
--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -136,7 +136,7 @@ func Run(flags *Flags, opts ...Option) {
 		log.Fatalf("Error creating simple store: %s", err)
 	}
 
-	backends, err := backend.NewManager(config.Backends, config.Auth)
+	backends, err := backend.NewManager(config.Backends, config.Auth, stats)
 	if err != nil {
 		log.Fatalf("Error creating backend manager: %s", err)
 	}

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -18,13 +18,14 @@ import (
 	"io"
 
 	"github.com/uber/kraken/core"
+	"github.com/uber-go/tally"
 )
 
 var _factories = make(map[string]ClientFactory)
 
 // ClientFactory creates backend client given name.
 type ClientFactory interface {
-	Create(config interface{}, authConfig interface{}) (Client, error)
+	Create(config interface{}, authConfig interface{}, stats tally.Scope) (Client, error)
 }
 
 // Register registers new Factory with corresponding backend client name.

--- a/lib/backend/fixtures.go
+++ b/lib/backend/fixtures.go
@@ -13,9 +13,11 @@
 // limitations under the License.
 package backend
 
+import "github.com/uber-go/tally"
+
 // ManagerFixture returns a Manager with no clients for testing purposes.
 func ManagerFixture() *Manager {
-	m, err := NewManager(nil, AuthConfig{})
+	m, err := NewManager(nil, AuthConfig{}, tally.NoopScope)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/backend/gcsbackend/client_test.go
+++ b/lib/backend/gcsbackend/client_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/mocks/lib/backend/gcsbackend"
@@ -62,7 +63,7 @@ func newClientMocks(t *testing.T) (*clientMocks, func()) {
 }
 
 func (m *clientMocks) new() *Client {
-	c, err := NewClient(m.config, m.userAuth, WithGCS(m.gcs))
+	c, err := NewClient(m.config, m.userAuth, tally.NoopScope, WithGCS(m.gcs))
 	if err != nil {
 		panic(err)
 	}
@@ -83,7 +84,7 @@ func TestClientFactory(t *testing.T) {
 	auth.GCS.AccessBlob = "access_blob"
 	userAuth := UserAuthConfig{"test-user": auth}
 	f := factory{}
-	_, err := f.Create(config, userAuth)
+	_, err := f.Create(config, userAuth, tally.NoopScope)
 	fmt.Println(err.Error())
 	require.True(strings.Contains(err.Error(), "invalid gcs credentials"))
 }

--- a/lib/backend/hdfsbackend/client_test.go
+++ b/lib/backend/hdfsbackend/client_test.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/hdfsbackend/webhdfs"
 	"github.com/uber/kraken/mocks/lib/backend/hdfsbackend/webhdfs"
@@ -46,7 +47,7 @@ func (m *clientMocks) new() *Client {
 		RootDirectory: "/root",
 		NamePath:      "identity",
 		testing:       true,
-	}, WithWebHDFS(m.webhdfs))
+	}, tally.NoopScope, WithWebHDFS(m.webhdfs))
 	if err != nil {
 		panic(err)
 	}
@@ -63,7 +64,7 @@ func TestClientFactory(t *testing.T) {
 		testing:       true,
 	}
 	f := factory{}
-	_, err := f.Create(config, nil)
+	_, err := f.Create(config, nil, tally.NoopScope)
 	require.NoError(err)
 }
 

--- a/lib/backend/httpbackend/http_test.go
+++ b/lib/backend/httpbackend/http_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/utils/memsize"
@@ -34,7 +35,7 @@ func TestClientFactory(t *testing.T) {
 
 	config := Config{}
 	f := factory{}
-	_, err := f.Create(config, nil)
+	_, err := f.Create(config, nil, tally.NoopScope)
 	require.NoError(err)
 }
 
@@ -52,7 +53,7 @@ func TestHttpDownloadSuccess(t *testing.T) {
 	defer stop()
 
 	config := Config{DownloadURL: "http://" + addr + "/data/%s"}
-	client, err := NewClient(config)
+	client, err := NewClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	var b bytes.Buffer
@@ -72,7 +73,7 @@ func TestHttpDownloadFileNotFound(t *testing.T) {
 	defer stop()
 
 	config := Config{DownloadURL: "http://" + addr + "/data/%s"}
-	client, err := NewClient(config)
+	client, err := NewClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	var b bytes.Buffer
@@ -87,7 +88,7 @@ func TestDownloadMalformedURLThrowsError(t *testing.T) {
 	defer stop()
 
 	config := Config{DownloadURL: "http://" + addr + "/data"}
-	client, err := NewClient(config)
+	client, err := NewClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	var b bytes.Buffer

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/uber/kraken/utils/bandwidth"
 	"github.com/uber/kraken/utils/log"
+
+	"github.com/uber-go/tally"
 )
 
 // Manager errors.
@@ -49,7 +51,7 @@ type Manager struct {
 }
 
 // NewManager creates a new backend Manager.
-func NewManager(configs []Config, auth AuthConfig) (*Manager, error) {
+func NewManager(configs []Config, auth AuthConfig, stats tally.Scope) (*Manager, error) {
 	var backends []*backend
 	for _, config := range configs {
 		config = config.applyDefaults()
@@ -66,7 +68,7 @@ func NewManager(configs []Config, auth AuthConfig) (*Manager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("get backend client factory: %s", err)
 		}
-		c, err = factory.Create(backendConfig, auth[name])
+		c, err = factory.Create(backendConfig, auth[name], stats)
 		if err != nil {
 			return nil, fmt.Errorf("create backend client: %s", err)
 		}

--- a/lib/backend/manager_test.go
+++ b/lib/backend/manager_test.go
@@ -16,6 +16,7 @@ package backend_test
 import (
 	"testing"
 
+	"github.com/uber-go/tally"
 	. "github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/lib/backend/namepath"
 	"github.com/uber/kraken/lib/backend/testfs"
@@ -103,7 +104,7 @@ func TestManagerNamespaceOrdering(t *testing.T) {
 	var configs []Config
 	require.NoError(yaml.Unmarshal([]byte(configStr), &configs))
 
-	m, err := NewManager(configs, AuthConfig{})
+	m, err := NewManager(configs, AuthConfig{}, tally.NoopScope)
 	require.NoError(err)
 
 	for ns, expected := range map[string]string{
@@ -135,7 +136,7 @@ func TestManagerBandwidth(t *testing.T) {
 		Backend: map[string]interface{}{
 			"testfs": testfs.Config{Addr: "test-addr", NamePath: namepath.Identity},
 		},
-	}}, AuthConfig{})
+	}}, AuthConfig{}, tally.NoopScope)
 	require.NoError(err)
 
 	checkBandwidth := func(egress, ingress int64) {

--- a/lib/backend/registrybackend/blobclient_test.go
+++ b/lib/backend/registrybackend/blobclient_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/utils/memsize"
@@ -34,7 +35,7 @@ func TestClientFactory(t *testing.T) {
 
 	config := Config{}
 	f := blobClientFactory{}
-	_, err := f.Create(config, nil)
+	_, err := f.Create(config, nil, tally.NoopScope)
 	require.NoError(err)
 }
 
@@ -56,7 +57,7 @@ func TestBlobDownloadBlobSuccess(t *testing.T) {
 	defer stop()
 
 	config := newTestConfig(addr)
-	client, err := NewBlobClient(config)
+	client, err := NewBlobClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	info, err := client.Stat(namespace, "data")
@@ -86,7 +87,7 @@ func TestBlobDownloadManifestSuccess(t *testing.T) {
 	defer stop()
 
 	config := newTestConfig(addr)
-	client, err := NewBlobClient(config)
+	client, err := NewBlobClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	info, err := client.Stat(namespace, "data")
@@ -116,7 +117,7 @@ func TestBlobDownloadFileNotFound(t *testing.T) {
 	defer stop()
 
 	config := newTestConfig(addr)
-	client, err := NewBlobClient(config)
+	client, err := NewBlobClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	_, err = client.Stat(namespace, "data")

--- a/lib/backend/registrybackend/tagclient_test.go
+++ b/lib/backend/registrybackend/tagclient_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/utils/dockerutil"
@@ -58,7 +59,7 @@ func TestTagDownloadSuccess(t *testing.T) {
 	defer stop()
 
 	config := newTestConfig(addr)
-	client, err := NewTagClient(config)
+	client, err := NewTagClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	info, err := client.Stat(tag, tag)
@@ -88,7 +89,7 @@ func TestTagDownloadFileNotFound(t *testing.T) {
 	defer stop()
 
 	config := newTestConfig(addr)
-	client, err := NewTagClient(config)
+	client, err := NewTagClient(config, tally.NoopScope)
 	require.NoError(err)
 
 	_, err = client.Stat(tag, tag)

--- a/lib/backend/s3backend/client_test.go
+++ b/lib/backend/s3backend/client_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/mocks/lib/backend/s3backend"
@@ -58,7 +59,7 @@ func newClientMocks(t *testing.T) (*clientMocks, func()) {
 }
 
 func (m *clientMocks) new() *Client {
-	c, err := NewClient(m.config, m.userAuth, WithS3(m.s3))
+	c, err := NewClient(m.config, m.userAuth, tally.NoopScope, WithS3(m.s3))
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +81,7 @@ func TestClientFactory(t *testing.T) {
 	auth.S3.AccessSecretKey = "secret"
 	userAuth := UserAuthConfig{"test-user": auth}
 	f := factory{}
-	_, err := f.Create(config, userAuth)
+	_, err := f.Create(config, userAuth, tally.NoopScope)
 	require.NoError(err)
 }
 

--- a/lib/backend/shadowbackend/client_test.go
+++ b/lib/backend/shadowbackend/client_test.go
@@ -15,12 +15,14 @@ package shadowbackend
 
 import (
 	"bytes"
-	mockbackend "github.com/uber/kraken/mocks/lib/backend"
+	"errors"
 	"io"
 	"reflect"
 	"strings"
 	"testing"
-	"errors"
+
+	"github.com/uber-go/tally"
+	mockbackend "github.com/uber/kraken/mocks/lib/backend"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +79,7 @@ func TestClientFactory(t *testing.T) {
 	}
 
 	f := factory{}
-	c, err := f.Create(config, authCfg)
+	c, err := f.Create(config, authCfg, tally.NoopScope)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 }
@@ -169,7 +171,7 @@ func TestGetBackendClient(t *testing.T) {
 	for testName, tt := range testCases {
 		t.Run(testName, func(t *testing.T) {
 
-			client, err := getBackendClient(tt.cfg, tt.authCfg)
+			client, err := getBackendClient(tt.cfg, tt.authCfg, tally.NoopScope)
 
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)

--- a/lib/backend/sqlbackend/benchmark/client_test.go
+++ b/lib/backend/sqlbackend/benchmark/client_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/lib/backend/sqlbackend"
@@ -46,7 +47,7 @@ const connString = ":memory:"
 // are no non-benchmark tests. Instead, each benchmark test will call generateTestData(), which will load the database
 // if it is not already loaded. After this, we reset the benchmark timers before beginning the test.
 func TestMain(m *testing.M) {
-	c, err := sqlbackend.NewClient(sqlbackend.Config{Dialect: dialect, ConnectionString: connString}, sqlbackend.UserAuthConfig{})
+	c, err := sqlbackend.NewClient(sqlbackend.Config{Dialect: dialect, ConnectionString: connString}, sqlbackend.UserAuthConfig{}, tally.NoopScope)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/backend/sqlbackend/client_test.go
+++ b/lib/backend/sqlbackend/client_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 )
@@ -36,7 +37,7 @@ func generateSingleTag(sqlClient *Client, repo string, tag string) Tag {
 }
 
 func newClient() *Client {
-	sqlClient, err := NewClient(Config{Dialect: "sqlite3", ConnectionString: ":memory:"}, UserAuthConfig{})
+	sqlClient, err := NewClient(Config{Dialect: "sqlite3", ConnectionString: ":memory:"}, UserAuthConfig{}, tally.NoopScope)
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +48,7 @@ func TestClientFactory(t *testing.T) {
 	config := Config{Dialect: "sqlite3", ConnectionString: ":memory:"}
 
 	f := factory{}
-	_, err := f.Create(config, nil)
+	_, err := f.Create(config, nil, tally.NoopScope)
 	require.NoError(t, err)
 }
 
@@ -55,7 +56,7 @@ func TestClientFactoryAuth(t *testing.T) {
 	config := Config{Dialect: "sqlite3", ConnectionString: ":memory:"}
 
 	f := factory{}
-	_, err := f.Create(config, nil)
+	_, err := f.Create(config, nil, tally.NoopScope)
 	require.NoError(t, err)
 }
 

--- a/lib/backend/testfs/client_test.go
+++ b/lib/backend/testfs/client_test.go
@@ -16,6 +16,7 @@ package testfs
 import (
 	"testing"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/lib/backend/namepath"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,6 @@ func TestClientFactory(t *testing.T) {
 		NamePath: namepath.Identity,
 	}
 	f := factory{}
-	_, err := f.Create(config, nil)
+	_, err := f.Create(config, nil, tally.NoopScope)
 	require.NoError(err)
 }

--- a/lib/backend/testfs/server_test.go
+++ b/lib/backend/testfs/server_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/lib/backend/namepath"
@@ -34,7 +35,7 @@ func TestServerBlob(t *testing.T) {
 	addr, stop := testutil.StartServer(s.Handler())
 	defer stop()
 
-	c, err := NewClient(Config{Addr: addr, NamePath: namepath.Identity})
+	c, err := NewClient(Config{Addr: addr, NamePath: namepath.Identity}, tally.NoopScope)
 	require.NoError(err)
 
 	blob := core.NewBlobFixture()
@@ -63,7 +64,7 @@ func TestServerTag(t *testing.T) {
 	addr, stop := testutil.StartServer(s.Handler())
 	defer stop()
 
-	c, err := NewClient(Config{Addr: addr, NamePath: namepath.Identity})
+	c, err := NewClient(Config{Addr: addr, NamePath: namepath.Identity}, tally.NoopScope)
 	require.NoError(err)
 
 	ns := core.NamespaceFixture()
@@ -98,7 +99,7 @@ func TestServerList(t *testing.T) {
 			defer stop()
 
 			ns := core.NamespaceFixture()
-			c, err := NewClient(Config{Addr: addr, Root: "root", NamePath: namepath.Identity})
+			c, err := NewClient(Config{Addr: addr, Root: "root", NamePath: namepath.Identity}, tally.NoopScope)
 			require.NoError(err)
 
 			require.NoError(c.Upload(ns, "a/b/c.txt", bytes.NewBufferString("foo")))
@@ -121,7 +122,7 @@ func TestDockerTagList(t *testing.T) {
 	addr, stop := testutil.StartServer(s.Handler())
 	defer stop()
 
-	c, err := NewClient(Config{Addr: addr, Root: "tags", NamePath: namepath.DockerTag})
+	c, err := NewClient(Config{Addr: addr, Root: "tags", NamePath: namepath.DockerTag}, tally.NoopScope)
 	require.NoError(err)
 
 	ns := core.NamespaceFixture()

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -186,7 +186,7 @@ func Run(flags *Flags, opts ...Option) {
 		log.Fatalf("Failed to create peer context: %s", err)
 	}
 
-	backendManager, err := backend.NewManager(config.Backends, config.Auth)
+	backendManager, err := backend.NewManager(config.Backends, config.Auth, stats)
 	if err != nil {
 		log.Fatalf("Error creating backend manager: %s", err)
 	}


### PR DESCRIPTION
Allow for backend clients to emit stats

Depends on https://github.com/uber/kraken/pull/358

```
ok      github.com/uber/kraken/lib/backend      1.409s  coverage: 60.0% of statements
?       github.com/uber/kraken/lib/backend/backenderrors        [no test files]
ok      github.com/uber/kraken/lib/backend/gcsbackend   2.562s  coverage: 55.6% of statements
ok      github.com/uber/kraken/lib/backend/hdfsbackend  2.349s  coverage: 81.7% of statements
ok      github.com/uber/kraken/lib/backend/hdfsbackend/webhdfs  2.593s  coverage: 80.1% of statements
ok      github.com/uber/kraken/lib/backend/httpbackend  2.221s  coverage: 74.1% of statements
ok      github.com/uber/kraken/lib/backend/namepath     0.453s  coverage: 84.2% of statements
ok      github.com/uber/kraken/lib/backend/registrybackend      2.682s  coverage: 71.7% of statements
?       github.com/uber/kraken/lib/backend/registrybackend/security     [no test files]
ok      github.com/uber/kraken/lib/backend/s3backend    2.881s  coverage: 75.6% of statements
ok      github.com/uber/kraken/lib/backend/shadowbackend        3.485s  coverage: 79.8% of statements
ok      github.com/uber/kraken/lib/backend/sqlbackend   3.125s  coverage: 83.7% of statements
ok      github.com/uber/kraken/lib/backend/sqlbackend/benchmark 3.676s  coverage: [no statements] [no tests to run]
ok      github.com/uber/kraken/lib/backend/testfs       2.604s  coverage: 75.4% of statements
```