### PR TITLE
disable tls on tests

### DIFF
--- a/lib/backend/registrybackend/config_test.go
+++ b/lib/backend/registrybackend/config_test.go
@@ -14,13 +14,17 @@
 
 package registrybackend
 
-import "github.com/uber/kraken/lib/backend/registrybackend/security"
+import (
+	"github.com/uber/kraken/lib/backend/registrybackend/security"
+	"github.com/uber/kraken/utils/httputil"
+)
 
 func newTestConfig(addr string) Config {
 	return Config{
 		Address: addr,
 		Security: security.Config{
-			EnableHTTPFallback: true,
+			TLS: httputil.TLSConfig{Server: httputil.X509Pair{Disabled: true}, Client: httputil.X509Pair{Disabled: true}},
+			EnableHTTPFallback: false,
 		},
 	}
 }


### PR DESCRIPTION
Test were failing for
```
--- FAIL: TestBlobDownloadBlobSuccess (0.01s)
    blobclient_test.go:64:
                Error Trace:    blobclient_test.go:64
                Error:          Received unexpected error:
                                head blob: network error: Head "https://127.0.0.1:51702/v2/namespace-foo/repo-bar-Ww3BZRFk/blobs/sha256:data": http: server gave HTTP response to HTTPS client
                Test:           TestBlobDownloadBlobSuccess
--- FAIL: TestBlobDownloadManifestSuccess (0.01s)
    blobclient_test.go:94:
                Error Trace:    blobclient_test.go:94
                Error:          Received unexpected error:
                                head blob: network error: Head "https://127.0.0.1:51704/v2/namespace-foo/repo-bar-Wlp5Yymt/blobs/sha256:data": http: server gave HTTP response to HTTPS client
                Test:           TestBlobDownloadManifestSuccess
--- FAIL: TestBlobDownloadFileNotFound (0.00s)
    blobclient_test.go:124:
                Error Trace:    blobclient_test.go:124
                Error:          Not equal:
                                expected: &errors.errorString{s:"blob not found"}
                                actual  : &errors.errorString{s:"head blob: network error: Head \"https://127.0.0.1:51706/v2/namespace-foo/repo-bar-j95SUC6P/blobs/sha256:data\": http: server gave HTTP response to HTTPS client"}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 (*errors.errorString)({
                                - s: (string) (len=14) "blob not found"
                                + s: (string) (len=158) "head blob: network error: Head \"https://127.0.0.1:51706/v2/namespace-foo/repo-bar-j95SUC6P/blobs/sha256:data\": http: server gave HTTP response to HTTPS client"
                                 })
                Test:           TestBlobDownloadFileNotFound
--- FAIL: TestTagDownloadSuccess (0.01s)
    tagclient_test.go:66:
                Error Trace:    tagclient_test.go:66
                Error:          Received unexpected error:
                                check blob exists: network error: Head "https://127.0.0.1:51708/v2/namespace-foo/repo-bar/manifests/CjwupegU": http: server gave HTTP response to HTTPS client
                Test:           TestTagDownloadSuccess
--- FAIL: TestTagDownloadFileNotFound (0.01s)
    tagclient_test.go:96:
                Error Trace:    tagclient_test.go:96
                Error:          Not equal:
                                expected: &errors.errorString{s:"blob not found"}
                                actual  : &errors.errorString{s:"check blob exists: network error: Head \"https://127.0.0.1:51710/v2/namespace-foo/repo-bar/manifests/r1bKmTNX\": http: server gave HTTP response to HTTPS client"}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 (*errors.errorString)({
                                - s: (string) (len=14) "blob not found"
                                + s: (string) (len=158) "check blob exists: network error: Head \"https://127.0.0.1:51710/v2/namespace-foo/repo-bar/manifests/r1bKmTNX\": http: server gave HTTP response to HTTPS client"
                                 })
                Test:           TestTagDownloadFileNotFound
FAIL
coverage: 34.9% of statements
FAIL    github.com/uber/kraken/lib/backend/registrybackend      4.317s
```

Now:
`ok      github.com/uber/kraken/lib/backend/registrybackend      0.607s  coverage: 71.7% of statements`