### PR TITLE
Allow storing the registry password in a file

### DIFF
--- a/lib/backend/registrybackend/security/security.go
+++ b/lib/backend/registrybackend/security/security.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,7 @@ package security
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
@@ -47,6 +48,7 @@ var v2Version = auth.APIVersion{
 type Config struct {
 	TLS                    httputil.TLSConfig `yaml:"tls"`
 	BasicAuth              *types.AuthConfig  `yaml:"basic"`
+	PasswordFile           string             `yaml:"passwordFile"`
 	RemoteCredentialsStore string             `yaml:"credsStore"`
 	EnableHTTPFallback     bool               `yaml:"enableHTTPFallback"`
 }
@@ -172,6 +174,12 @@ func (c credentialStore) Basic(*url.URL) (string, string) {
 	basic := c.config.BasicAuth
 	if basic == nil {
 		return "", ""
+	}
+	if c.config.PasswordFile != "" {
+		passwordBytes, err := ioutil.ReadFile(c.config.PasswordFile)
+		if err == nil {
+			return basic.Username, (string)(passwordBytes)
+		}
 	}
 	return basic.Username, basic.Password
 }


### PR DESCRIPTION
This lets you mount the registry password in a secret that is kept separate from regular configuration. Also it means that the password can be updated dynamically without restarting the process.