### PR TITLE
Fix shadow backend mode auth config parsing

### DIFF
--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -25,7 +25,7 @@ var _factories = make(map[string]ClientFactory)
 
 // ClientFactory creates backend client given name.
 type ClientFactory interface {
-	Create(config interface{}, authConfig interface{}, stats tally.Scope) (Client, error)
+	Create(config interface{}, masterAuthConfig AuthConfig, stats tally.Scope) (Client, error)
 }
 
 // Register registers new Factory with corresponding backend client name.

--- a/lib/backend/gcsbackend/client.go
+++ b/lib/backend/gcsbackend/client.go
@@ -42,13 +42,13 @@ func init() {
 type factory struct{}
 
 func (f *factory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {
 		return nil, errors.New("marshal gcs config")
 	}
-	authConfBytes, err := yaml.Marshal(authConfRaw)
+	authConfBytes, err := yaml.Marshal(masterAuthConfig[_gcs])
 	if err != nil {
 		return nil, errors.New("marshal gcs auth config")
 	}

--- a/lib/backend/gcsbackend/client_test.go
+++ b/lib/backend/gcsbackend/client_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -83,8 +83,9 @@ func TestClientFactory(t *testing.T) {
 	var auth AuthConfig
 	auth.GCS.AccessBlob = "access_blob"
 	userAuth := UserAuthConfig{"test-user": auth}
+	masterAuth := backend.AuthConfig{_gcs: userAuth}
 	f := factory{}
-	_, err := f.Create(config, userAuth, tally.NoopScope)
+	_, err := f.Create(config, masterAuth, tally.NoopScope)
 	fmt.Println(err.Error())
 	require.True(strings.Contains(err.Error(), "invalid gcs credentials"))
 }

--- a/lib/backend/hdfsbackend/client.go
+++ b/lib/backend/hdfsbackend/client.go
@@ -42,7 +42,7 @@ func init() {
 type factory struct{}
 
 func (f *factory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {

--- a/lib/backend/httpbackend/http.go
+++ b/lib/backend/httpbackend/http.go
@@ -38,7 +38,7 @@ func init() {
 type factory struct{}
 
 func (f *factory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -68,16 +68,7 @@ func NewManager(configs []Config, auth AuthConfig, stats tally.Scope) (*Manager,
 		if err != nil {
 			return nil, fmt.Errorf("get backend client factory: %s", err)
 		}
-		var backendAuthConfig interface{}
-		// Normally, when creating a backend client, we only need to pass its own auth credentials to its Create function.
-		// However, the shadow backend mode requires the auth configs of 2 backends (e.g. GCS and S3),
-		// thus we pass the whole AuthConfig (which includes the credentials of all used backends) to it. 
-		if backendName == "shadow" {
-			backendAuthConfig = auth
-		} else {
-			backendAuthConfig = auth[backendName]
-		}
-		c, err = factory.Create(backendConfig, backendAuthConfig, stats)
+		c, err = factory.Create(backendConfig, auth, stats)
 		if err != nil {
 			return nil, fmt.Errorf("create backend client: %s", err)
 		}

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -60,15 +60,24 @@ func NewManager(configs []Config, auth AuthConfig, stats tally.Scope) (*Manager,
 		if len(config.Backend) != 1 {
 			return nil, fmt.Errorf("no backend or more than one backend configured")
 		}
-		var name string
+		var backendName string
 		var backendConfig interface{}
-		for name, backendConfig = range config.Backend { // Pull the only key/value out of map
+		for backendName, backendConfig = range config.Backend { // Pull the only key/value out of map
 		}
-		factory, err := getFactory(name)
+		factory, err := getFactory(backendName)
 		if err != nil {
 			return nil, fmt.Errorf("get backend client factory: %s", err)
 		}
-		c, err = factory.Create(backendConfig, auth[name], stats)
+		var backendAuthConfig interface{}
+		// Normally, when creating a backend client, we only need to pass its own auth credentials to its Create function.
+		// However, the shadow backend mode requires the auth configs of 2 backends (e.g. GCS and S3),
+		// thus we pass the whole AuthConfig (which includes the credentials of all used backends) to it. 
+		if backendName == "shadow" {
+			backendAuthConfig = auth
+		} else {
+			backendAuthConfig = auth[backendName]
+		}
+		c, err = factory.Create(backendConfig, backendAuthConfig, stats)
 		if err != nil {
 			return nil, fmt.Errorf("create backend client: %s", err)
 		}

--- a/lib/backend/registrybackend/blobclient.go
+++ b/lib/backend/registrybackend/blobclient.go
@@ -39,7 +39,7 @@ func init() {
 type blobClientFactory struct{}
 
 func (f *blobClientFactory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -40,7 +40,7 @@ func init() {
 type tagClientFactory struct{}
 
 func (f *tagClientFactory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -45,13 +45,13 @@ func init() {
 type factory struct{}
 
 func (f *factory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {
 		return nil, errors.New("marshal s3 config")
 	}
-	authConfBytes, err := yaml.Marshal(authConfRaw)
+	authConfBytes, err := yaml.Marshal(masterAuthConfig[_s3])
 	if err != nil {
 		return nil, errors.New("marshal s3 auth config")
 	}

--- a/lib/backend/s3backend/client_test.go
+++ b/lib/backend/s3backend/client_test.go
@@ -80,8 +80,9 @@ func TestClientFactory(t *testing.T) {
 	auth.S3.AccessKeyID = "accesskey"
 	auth.S3.AccessSecretKey = "secret"
 	userAuth := UserAuthConfig{"test-user": auth}
+	masterAuth := backend.AuthConfig{_s3: userAuth}
 	f := factory{}
-	_, err := f.Create(config, userAuth, tally.NoopScope)
+	_, err := f.Create(config, masterAuth, tally.NoopScope)
 	require.NoError(err)
 }
 

--- a/lib/backend/shadowbackend/client.go
+++ b/lib/backend/shadowbackend/client.go
@@ -37,7 +37,7 @@ func (f *factory) Name() string {
 }
 
 func (f *factory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {
@@ -48,7 +48,7 @@ func (f *factory) Create(
 	if err := yaml.Unmarshal(confBytes, &config); err != nil {
 		return nil, fmt.Errorf("unmarshal shadow config: %v", err)
 	}
-	return NewClient(config, authConfRaw, stats)
+	return NewClient(config, masterAuthConfRaw, stats)
 }
 
 // Client implements a backend.Client for shadow mode. See the README for full details on what shadow mode means.
@@ -63,13 +63,19 @@ type Client struct {
 type Option func(*Client)
 
 // NewClient creates a new shadow Client
-func NewClient(config Config, authConfRaw interface{}, stats tally.Scope) (*Client, error) {
-	a, err := getBackendClient(config.ActiveClientConfig, authConfRaw, stats)
+func NewClient(config Config, masterAuthConfRaw interface{}, stats tally.Scope) (*Client, error) {
+	// By contrast to the other backends, the shadow backend mode receives the whole master auth file,
+	// as it needs to parse the auth credentials of both the active and shadow backends.
+	aAuthConfig, sAuthConfig, err := extractAuthConfigs(config, masterAuthConfRaw)
+	if err != nil {
+		return nil, err
+	}
+	a, err := getBackendClient(config.ActiveClientConfig, aAuthConfig, stats)
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := getBackendClient(config.ShadowClientConfig, authConfRaw, stats)
+	s, err := getBackendClient(config.ShadowClientConfig, sAuthConfig, stats)
 	if err != nil {
 		return nil, err
 	}
@@ -80,6 +86,42 @@ func NewClient(config Config, authConfRaw interface{}, stats tally.Scope) (*Clie
 		shadow: s,
 		stats:  stats,
 	}, nil
+}
+
+func extractAuthConfigs(config Config, masterAuthConfRaw interface{}) (interface{}, interface{}, error) {
+	aName, sName, err := getBackendNames(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	masterAuth, ok := masterAuthConfRaw.(map[string]interface{})
+	if !ok {
+		return nil, nil, fmt.Errorf("cannot parse master auth config")
+	}
+	aAuth, ok := masterAuth[aName]
+	if !ok {
+		return nil, nil, fmt.Errorf("active backend auth config missing")
+	}
+	sAuth, ok := masterAuth[sName]
+	if !ok {
+		return nil, nil, fmt.Errorf("shadow backend auth config missing")
+	}
+	return aAuth, sAuth, nil
+}
+
+func getBackendNames(config Config) (string, string, error) {
+	if len(config.ActiveClientConfig) != 1 {
+		return "", "", fmt.Errorf("no active backend or more than one active backend configured")
+	}
+	if len(config.ShadowClientConfig) != 1 {
+		return "", "", fmt.Errorf("no shadow backend or more than one shadow backend configured")
+	}
+	var aName string
+	var sName string
+	for aName = range config.ActiveClientConfig { // Map should have only 1 key/value
+	}
+	for sName = range config.ShadowClientConfig { // Map should have only 1 key/value
+	}
+	return aName, sName, nil
 }
 
 func getBackendClient(backendConfig map[string]interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {

--- a/lib/backend/shadowbackend/client_test.go
+++ b/lib/backend/shadowbackend/client_test.go
@@ -79,8 +79,6 @@ func TestClientFactory(t *testing.T) {
 	s3Auth.S3.AccessKeyID = "accesskey"
 	s3Auth.S3.AccessSecretKey = "secret"
 	s3AuthCfg := s3backend.UserAuthConfig{"test-user": s3Auth}
-
-
 	sqlAuthCfg := sqlbackend.UserAuthConfig{
 		"testuser": sqlbackend.AuthConfig{
 			SQL: sqlbackend.SQL{
@@ -91,7 +89,6 @@ func TestClientFactory(t *testing.T) {
 	}
 
 	masterAuthCfg := backend.AuthConfig{"s3": s3AuthCfg, "sql": sqlAuthCfg}
-
 	config := Config{
 		ActiveClientConfig: map[string]interface{}{"sql": sqlCfg},
 		ShadowClientConfig: map[string]interface{}{"s3": s3Cfg},

--- a/lib/backend/shadowbackend/config.go
+++ b/lib/backend/shadowbackend/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/lib/backend/sqlbackend/client.go
+++ b/lib/backend/sqlbackend/client.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,7 +47,7 @@ func (f *factory) Create(
 
 	authConfBytes, err := yaml.Marshal(authConfRaw)
 	if err != nil {
-		return nil, errors.New("marshal s3 auth config")
+		return nil, errors.New("marshal sql auth config")
 	}
 
 	var config Config
@@ -56,7 +56,7 @@ func (f *factory) Create(
 	}
 	var userAuth UserAuthConfig
 	if err := yaml.Unmarshal(authConfBytes, &userAuth); err != nil {
-		return nil, errors.New("unmarshal s3 auth config")
+		return nil, errors.New("unmarshal sql auth config")
 	}
 
 	return NewClient(config, userAuth, stats)

--- a/lib/backend/sqlbackend/client.go
+++ b/lib/backend/sqlbackend/client.go
@@ -31,21 +31,23 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const _sql = "sql"
+
 type factory struct{}
 
 func (f *factory) Name() string {
-	return "sql"
+	return _sql
 }
 
 func (f *factory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {
 		return nil, errors.New("marshal sql config")
 	}
 
-	authConfBytes, err := yaml.Marshal(authConfRaw)
+	authConfBytes, err := yaml.Marshal(masterAuthConfig[_sql])
 	if err != nil {
 		return nil, errors.New("marshal sql auth config")
 	}

--- a/lib/backend/testfs/client.go
+++ b/lib/backend/testfs/client.go
@@ -40,7 +40,7 @@ func init() {
 type factory struct{}
 
 func (f *factory) Create(
-	confRaw interface{}, authConfRaw interface{}, stats tally.Scope) (backend.Client, error) {
+	confRaw interface{}, masterAuthConfig backend.AuthConfig, stats tally.Scope) (backend.Client, error) {
 
 	confBytes, err := yaml.Marshal(confRaw)
 	if err != nil {


### PR DESCRIPTION
**Why**
Currently, the shadow backend mode does not parse the backend credentials correctly. The structure of the Go object with all backend auth credentials looks like this:
```
{
    "s3": {
      <s3 credentials>
    },
   "gcs": {
	<gcs credentials>
    },
}
```

Upon creating a backend client, we look for a key/value pair in this file where the key is the name of the backend we are using (e.g. we would look for the key/value "s3"/<s3-credentials>). 

However, when we use the "shadow" backend, this does not work anymore - Kraken looks for a key/value pair with "shadow" as the key. Instead, Kraken should:
1. Figure out what active and shadow backends it uses (e.g. s3 and gcs).
2. Look for their key/value pairs.

To make this change, we'll change the way we pass the master auth config to the backend client factories - up until this point, we passed only the auth credentials of the respective backend. However, the shadow backend doesn't have its own credentials but rather uses the credentials of two other backends (e.g. gcs and s3). So instead, we'll pass the full config to the `factory.Create` methods and they can parse it as they require.

**What**
 - Properly parse auth credentials when using shadow backend mode.
 - Pass master auth config (the config with the credentials of all backends) to `factory.Create` methods. The Create methods then parse the config as they require.
 - Rename variables for readability.
 - Correct 2 typos in error logs in the SQL backend.