### PR TITLE
Fixed Broken Unit tests in Kraken

### DIFF
--- a/lib/backend/registrybackend/security/security.go
+++ b/lib/backend/registrybackend/security/security.go
@@ -97,9 +97,12 @@ func (a *authenticator) Authenticate(repo string) ([]httputil.SendOption, error)
 		return opts, nil
 	}
 
-	if !config.EnableHTTPFallback {
+	if config.EnableHTTPFallback {
+		opts = append(opts, httputil.EnableHTTPFallback())
+	} else {
 		opts = append(opts, httputil.DisableHTTPFallback())
 	}
+
 	if !a.shouldAuth() {
 		opts = append(opts, httputil.SendTLSTransport(a.roundTripper))
 		return opts, nil

--- a/utils/httputil/httputil.go
+++ b/utils/httputil/httputil.go
@@ -243,6 +243,13 @@ func DisableHTTPFallback() SendOption {
 	}
 }
 
+// EnableHTTPFallback enables http fallback when https request fails.
+func EnableHTTPFallback() SendOption {
+	return func(o *sendOptions) {
+		o.httpFallbackDisabled = false
+	}
+}
+
 // SendTLS sets the transport with TLS config for the HTTP client.
 func SendTLS(config *tls.Config) SendOption {
 	return func(o *sendOptions) {


### PR DESCRIPTION
Fixed failing unit tests as we were not properly enabling HTTP Fallback configuration in the registry backend mode.

### Before 
```
go test ./...  -cover
        github.com/uber/kraken/agent/agentclient                coverage: 0.0% of statements
        github.com/uber/kraken/agent            coverage: 0.0% of statements
        github.com/uber/kraken/agent/cmd                coverage: 0.0% of statements
ok      github.com/uber/kraken/agent/agentserver        0.033s  coverage: 80.2% of statements
        github.com/uber/kraken/build-index              coverage: 0.0% of statements
        github.com/uber/kraken/build-index/cmd          coverage: 0.0% of statements
        github.com/uber/kraken/build-index/tagclient            coverage: 0.0% of statements
        github.com/uber/kraken/build-index/tagmodels            coverage: 0.0% of statements
ok      github.com/uber/kraken/build-index/tagserver    0.032s  coverage: 77.0% of statements
ok      github.com/uber/kraken/build-index/tagstore     (cached)        coverage: 79.2% of statements
ok      github.com/uber/kraken/build-index/tagtype      (cached)        coverage: 81.8% of statements
ok      github.com/uber/kraken/core     (cached)        coverage: 80.9% of statements
        github.com/uber/kraken/gen/go/proto/p2p         coverage: 0.0% of statements
?       github.com/uber/kraken/lib/backend/backenderrors        [no test files]
ok      github.com/uber/kraken/lib/backend      (cached)        coverage: 60.0% of statements
ok      github.com/uber/kraken/lib/backend/gcsbackend   (cached)        coverage: 55.6% of statements
ok      github.com/uber/kraken/lib/backend/hdfsbackend  0.035s  coverage: 81.7% of statements
ok      github.com/uber/kraken/lib/backend/hdfsbackend/webhdfs  0.021s  coverage: 80.1% of statements
ok      github.com/uber/kraken/lib/backend/httpbackend  0.009s  coverage: 74.1% of statements
ok      github.com/uber/kraken/lib/backend/namepath     (cached)        coverage: 84.2% of statements
        github.com/uber/kraken/lib/backend/registrybackend/security             coverage: 0.0% of statements
--- FAIL: TestBlobDownloadBlobSuccess (0.01s)
    blobclient_test.go:64: 
                Error Trace:    blobclient_test.go:64
                Error:          Received unexpected error:
                                head blob: network error: Head "https://127.0.0.1:33779/v2/namespace-foo/repo-bar-XUdWuny7/blobs/sha256:data": http: server gave HTTP response to HTTPS client
                Test:           TestBlobDownloadBlobSuccess
--- FAIL: TestBlobDownloadManifestSuccess (0.00s)
    blobclient_test.go:94: 
                Error Trace:    blobclient_test.go:94
                Error:          Received unexpected error:
                                head blob: network error: Head "https://127.0.0.1:44817/v2/namespace-foo/repo-bar-8YtCQNzQ/blobs/sha256:data": http: server gave HTTP response to HTTPS client
                Test:           TestBlobDownloadManifestSuccess
--- FAIL: TestBlobDownloadFileNotFound (0.00s)
    blobclient_test.go:124: 
                Error Trace:    blobclient_test.go:124
                Error:          Not equal: 
                                expected: &errors.errorString{s:"blob not found"}
                                actual  : &errors.errorString{s:"head blob: network error: Head \"https://127.0.0.1:37963/v2/namespace-foo/repo-bar-c1xbqdFA/blobs/sha256:data\": http: server gave HTTP response to HTTPS client"}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 (*errors.errorString)({
                                - s: (string) (len=14) "blob not found"
                                + s: (string) (len=158) "head blob: network error: Head \"https://127.0.0.1:37963/v2/namespace-foo/repo-bar-c1xbqdFA/blobs/sha256:data\": http: server gave HTTP response to HTTPS client"
                                 })
                Test:           TestBlobDownloadFileNotFound
--- FAIL: TestTagDownloadSuccess (0.00s)
    tagclient_test.go:66: 
                Error Trace:    tagclient_test.go:66
                Error:          Received unexpected error:
                                check blob exists: network error: Head "https://127.0.0.1:43907/v2/namespace-foo/repo-bar/manifests/x3vgv7Sd": http: server gave HTTP response to HTTPS client
                Test:           TestTagDownloadSuccess
--- FAIL: TestTagDownloadFileNotFound (0.00s)
    tagclient_test.go:96: 
                Error Trace:    tagclient_test.go:96
                Error:          Not equal: 
                                expected: &errors.errorString{s:"blob not found"}
                                actual  : &errors.errorString{s:"check blob exists: network error: Head \"https://127.0.0.1:40137/v2/namespace-foo/repo-bar/manifests/aD62c2bE\": http: server gave HTTP response to HTTPS client"}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 (*errors.errorString)({
                                - s: (string) (len=14) "blob not found"
                                + s: (string) (len=158) "check blob exists: network error: Head \"https://127.0.0.1:40137/v2/namespace-foo/repo-bar/manifests/aD62c2bE\": http: server gave HTTP response to HTTPS client"
                                 })
                Test:           TestTagDownloadFileNotFound
FAIL
coverage: 34.9% of statements
FAIL    github.com/uber/kraken/lib/backend/registrybackend      0.029s
ok      github.com/uber/kraken/lib/backend/s3backend    (cached)        coverage: 75.6% of statements
ok      github.com/uber/kraken/lib/backend/shadowbackend        0.017s  coverage: 78.4% of statements
ok      github.com/uber/kraken/lib/backend/sqlbackend   (cached)        coverage: 83.7% of statements
ok      github.com/uber/kraken/lib/backend/sqlbackend/benchmark (cached)        coverage: [no statements] [no tests to run]
        github.com/uber/kraken/lib/containerruntime             coverage: 0.0% of statements
        github.com/uber/kraken/lib/containerruntime/containerd          coverage: 0.0% of statements
        github.com/uber/kraken/lib/containerruntime/dockerdaemon                coverage: 0.0% of statements
ok      github.com/uber/kraken/lib/backend/testfs       0.024s  coverage: 75.4% of statements
ok      github.com/uber/kraken/lib/blobrefresh  (cached)        coverage: 71.1% of statements
ok      github.com/uber/kraken/lib/dockerregistry       (cached)        coverage: 71.6% of statements
ok      github.com/uber/kraken/lib/dockerregistry/transfer      (cached)        coverage: 50.4% of statements
ok      github.com/uber/kraken/lib/hashring     (cached)        coverage: 95.9% of statements
ok      github.com/uber/kraken/lib/healthcheck  (cached)        coverage: 86.8% of statements
ok      github.com/uber/kraken/lib/hostlist     (cached)        coverage: 42.9% of statements
ok      github.com/uber/kraken/lib/hrw  (cached)        coverage: 92.4% of statements
ok      github.com/uber/kraken/lib/metainfogen  (cached)        coverage: 71.4% of statements
ok      github.com/uber/kraken/lib/middleware   0.218s  coverage: 100.0% of statements
ok      github.com/uber/kraken/lib/persistedretry       (cached)        coverage: 73.6% of statements
ok      github.com/uber/kraken/lib/persistedretry/tagreplication        5.746s  coverage: 74.1% of statements
ok      github.com/uber/kraken/lib/persistedretry/writeback     (cached)        coverage: 75.3% of statements
ok      github.com/uber/kraken/lib/store        (cached)        coverage: 64.2% of statements
ok      github.com/uber/kraken/lib/store/base   (cached)        coverage: 79.7% of statements
ok      github.com/uber/kraken/lib/store/metadata       (cached)        coverage: 60.0% of statements
ok      github.com/uber/kraken/lib/torrent/networkevent (cached)        coverage: 33.3% of statements
        github.com/uber/kraken/lib/torrent/scheduler/torrentlog         coverage: 0.0% of statements
        github.com/uber/kraken/lib/torrent/storage/piecereader          coverage: 0.0% of statements
        github.com/uber/kraken/lib/upstream             coverage: 0.0% of statements
        github.com/uber/kraken/localdb          coverage: 0.0% of statements
        github.com/uber/kraken/localdb/migrations               coverage: 0.0% of statements
        github.com/uber/kraken/metrics          coverage: 0.0% of statements
        github.com/uber/kraken/mocks/agent/agentclient          coverage: 0.0% of statements
        github.com/uber/kraken/mocks/build-index/tagclient              coverage: 0.0% of statements
        github.com/uber/kraken/mocks/build-index/tagstore               coverage: 0.0% of statements
        github.com/uber/kraken/mocks/build-index/tagtype                coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/backend                coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/backend/gcsbackend             coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/backend/hdfsbackend/webhdfs            coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/backend/s3backend              coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/containerruntime               coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/containerruntime/containerd            coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/containerruntime/dockerdaemon          coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/dockerregistry/transfer                coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/hashring               coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/healthcheck            coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/hostlist               coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/persistedretry         coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/persistedretry/tagreplication          coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/store          coverage: 0.0% of statements
        github.com/uber/kraken/mocks/lib/torrent/scheduler              coverage: 0.0% of statements
        github.com/uber/kraken/mocks/origin/blobclient          coverage: 0.0% of statements
        github.com/uber/kraken/mocks/tracker/announceclient             coverage: 0.0% of statements
        github.com/uber/kraken/mocks/tracker/metainfoclient             coverage: 0.0% of statements
        github.com/uber/kraken/mocks/tracker/originstore                coverage: 0.0% of statements
        github.com/uber/kraken/mocks/tracker/peerstore          coverage: 0.0% of statements
        github.com/uber/kraken/mocks/utils/dedup                coverage: 0.0% of statements
        github.com/uber/kraken/mocks/utils/httputil             coverage: 0.0% of statements
        github.com/uber/kraken/nginx            coverage: 0.0% of statements
        github.com/uber/kraken/nginx/config             coverage: 0.0% of statements
        github.com/uber/kraken/origin           coverage: 0.0% of statements
        github.com/uber/kraken/origin/blobclient                coverage: 0.0% of statements
        github.com/uber/kraken/origin/cmd               coverage: 0.0% of statements
        github.com/uber/kraken/proxy            coverage: 0.0% of statements
        github.com/uber/kraken/proxy/cmd                coverage: 0.0% of statements
        github.com/uber/kraken/proxy/registryoverride           coverage: 0.0% of statements
        github.com/uber/kraken/tools/bin/puller         coverage: 0.0% of statements
        github.com/uber/kraken/tools/bin/reload         coverage: 0.0% of statements
        github.com/uber/kraken/tools/bin/testfs         coverage: 0.0% of statements
        github.com/uber/kraken/tools/bin/visualization          coverage: 0.0% of statements
        github.com/uber/kraken/tools/lib                coverage: 0.0% of statements
        github.com/uber/kraken/tools/lib/image          coverage: 0.0% of statements
        github.com/uber/kraken/tracker          coverage: 0.0% of statements
        github.com/uber/kraken/tracker/announceclient           coverage: 0.0% of statements
        github.com/uber/kraken/tracker/cmd              coverage: 0.0% of statements
        github.com/uber/kraken/tracker/metainfoclient           coverage: 0.0% of statements
        github.com/uber/kraken/utils/bitsetutil         coverage: 0.0% of statements
        github.com/uber/kraken/utils/flagutil           coverage: 0.0% of statements
        github.com/uber/kraken/utils/handler            coverage: 0.0% of statements
ok      github.com/uber/kraken/lib/torrent/scheduler    11.817s coverage: 75.2% of statements
ok      github.com/uber/kraken/lib/torrent/scheduler/announcequeue      (cached)        coverage: 84.2% of statements
ok      github.com/uber/kraken/lib/torrent/scheduler/announcer  (cached)        coverage: 82.6% of statements
ok      github.com/uber/kraken/lib/torrent/scheduler/conn       (cached)        coverage: 67.2% of statements
ok      github.com/uber/kraken/lib/torrent/scheduler/connstate  (cached)        coverage: 93.9% of statements
ok      github.com/uber/kraken/lib/torrent/scheduler/dispatch   (cached)        coverage: 54.2% of statements
ok      github.com/uber/kraken/lib/torrent/scheduler/dispatch/piecerequest      (cached)        coverage: 96.4% of statements
ok      github.com/uber/kraken/lib/torrent/storage      (cached)        coverage: 75.0% of statements
ok      github.com/uber/kraken/lib/torrent/storage/agentstorage (cached)        coverage: 75.4% of statements
ok      github.com/uber/kraken/lib/torrent/storage/originstorage        (cached)        coverage: 78.7% of statements
ok      github.com/uber/kraken/origin/blobserver        1.573s  coverage: 81.6% of statements
ok      github.com/uber/kraken/proxy/proxyserver        0.011s  coverage: 80.3% of statements
ok      github.com/uber/kraken/tracker/originstore      (cached)        coverage: 90.2% of statements
ok      github.com/uber/kraken/tracker/peerhandoutpolicy        (cached)        coverage: 91.7% of statements
ok      github.com/uber/kraken/tracker/peerstore        (cached)        coverage: 75.6% of statements
ok      github.com/uber/kraken/tracker/trackerserver    0.011s  coverage: 74.5% of statements
ok      github.com/uber/kraken/utils/bandwidth  (cached)        coverage: 91.5% of statements
ok      github.com/uber/kraken/utils/configutil (cached)        coverage: 95.2% of statements
ok      github.com/uber/kraken/utils/dedup      (cached)        coverage: 99.1% of statements
ok      github.com/uber/kraken/utils/diskspaceutil      (cached)        coverage: 87.5% of statements
ok      github.com/uber/kraken/utils/dockerutil (cached)        coverage: 21.7% of statements
ok      github.com/uber/kraken/utils/errutil    (cached)        coverage: 100.0% of statements
ok      github.com/uber/kraken/utils/heap       (cached)        coverage: 94.4% of statements
        github.com/uber/kraken/utils/listener           coverage: 0.0% of statements
        github.com/uber/kraken/utils/log                coverage: 0.0% of statements
        github.com/uber/kraken/utils/netutil            coverage: 0.0% of statements
        github.com/uber/kraken/utils/osutil             coverage: 0.0% of statements
        github.com/uber/kraken/utils/randutil           coverage: 0.0% of statements
        github.com/uber/kraken/utils/stringset          coverage: 0.0% of statements
        github.com/uber/kraken/utils/testutil           coverage: 0.0% of statements
ok      github.com/uber/kraken/utils/httputil   2.813s  coverage: 38.5% of statements
ok      github.com/uber/kraken/utils/lockermap  (cached)        coverage: 92.3% of statements
ok      github.com/uber/kraken/utils/memsize    (cached)        coverage: 100.0% of statements
ok      github.com/uber/kraken/utils/mockutil   (cached)        coverage: 90.3% of statements
ok      github.com/uber/kraken/utils/rwutil     (cached)        coverage: 90.9% of statements
ok      github.com/uber/kraken/utils/syncutil   (cached)        coverage: 100.0% of statements
ok      github.com/uber/kraken/utils/timeutil   (cached)        coverage: 90.0% of statements
```

### After
```
go test ./... -cover
?   	github.com/uber/kraken/agent	[no test files]
?   	github.com/uber/kraken/agent/agentclient	[no test files]
?   	github.com/uber/kraken/agent/cmd	[no test files]
ok  	github.com/uber/kraken/agent/agentserver	(cached)	coverage: 80.2% of statements
?   	github.com/uber/kraken/build-index	[no test files]
?   	github.com/uber/kraken/build-index/cmd	[no test files]
?   	github.com/uber/kraken/build-index/tagclient	[no test files]
?   	github.com/uber/kraken/build-index/tagmodels	[no test files]
ok  	github.com/uber/kraken/build-index/tagserver	(cached)	coverage: 77.0% of statements
?   	github.com/uber/kraken/gen/go/proto/p2p	[no test files]
ok  	github.com/uber/kraken/build-index/tagstore	(cached)	coverage: 79.2% of statements
ok  	github.com/uber/kraken/build-index/tagtype	(cached)	coverage: 81.8% of statements
ok  	github.com/uber/kraken/core	(cached)	coverage: 80.9% of statements
?   	github.com/uber/kraken/lib/backend/backenderrors	[no test files]
ok  	github.com/uber/kraken/lib/backend	(cached)	coverage: 60.0% of statements
?   	github.com/uber/kraken/lib/backend/registrybackend/security	[no test files]
ok  	github.com/uber/kraken/lib/backend/gcsbackend	(cached)	coverage: 55.6% of statements
ok  	github.com/uber/kraken/lib/backend/hdfsbackend	(cached)	coverage: 81.7% of statements
ok  	github.com/uber/kraken/lib/backend/hdfsbackend/webhdfs	(cached)	coverage: 80.1% of statements
ok  	github.com/uber/kraken/lib/backend/httpbackend	(cached)	coverage: 74.1% of statements
ok  	github.com/uber/kraken/lib/backend/namepath	(cached)	coverage: 84.2% of statements
ok  	github.com/uber/kraken/lib/backend/registrybackend	(cached)	coverage: 71.7% of statements
ok  	github.com/uber/kraken/lib/backend/s3backend	(cached)	coverage: 75.6% of statements
ok  	github.com/uber/kraken/lib/backend/shadowbackend	(cached)	coverage: 79.8% of statements
ok  	github.com/uber/kraken/lib/backend/sqlbackend	(cached)	coverage: 83.7% of statements
ok  	github.com/uber/kraken/lib/backend/sqlbackend/benchmark	(cached)	coverage: [no statements] [no tests to run]
ok  	github.com/uber/kraken/lib/backend/testfs	(cached)	coverage: 75.4% of statements
?   	github.com/uber/kraken/lib/containerruntime	[no test files]
?   	github.com/uber/kraken/lib/containerruntime/containerd	[no test files]
?   	github.com/uber/kraken/lib/containerruntime/dockerdaemon	[no test files]
ok  	github.com/uber/kraken/lib/blobrefresh	(cached)	coverage: 71.1% of statements
ok  	github.com/uber/kraken/lib/dockerregistry	(cached)	coverage: 71.6% of statements
ok  	github.com/uber/kraken/lib/dockerregistry/transfer	(cached)	coverage: 50.4% of statements
ok  	github.com/uber/kraken/lib/hashring	(cached)	coverage: 95.9% of statements
ok  	github.com/uber/kraken/lib/healthcheck	(cached)	coverage: 86.8% of statements
ok  	github.com/uber/kraken/lib/hostlist	(cached)	coverage: 42.9% of statements
ok  	github.com/uber/kraken/lib/hrw	(cached)	coverage: 92.4% of statements
ok  	github.com/uber/kraken/lib/metainfogen	(cached)	coverage: 71.4% of statements
ok  	github.com/uber/kraken/lib/middleware	(cached)	coverage: 100.0% of statements
ok  	github.com/uber/kraken/lib/persistedretry	(cached)	coverage: 73.6% of statements
ok  	github.com/uber/kraken/lib/persistedretry/tagreplication	(cached)	coverage: 74.1% of statements
ok  	github.com/uber/kraken/lib/persistedretry/writeback	(cached)	coverage: 75.3% of statements
ok  	github.com/uber/kraken/lib/store	(cached)	coverage: 64.2% of statements
ok  	github.com/uber/kraken/lib/store/base	(cached)	coverage: 79.7% of statements
ok  	github.com/uber/kraken/lib/store/metadata	(cached)	coverage: 60.0% of statements
ok  	github.com/uber/kraken/lib/torrent/networkevent	(cached)	coverage: 33.3% of statements
ok  	github.com/uber/kraken/lib/torrent/scheduler	(cached)	coverage: 73.9% of statements
ok  	github.com/uber/kraken/lib/torrent/scheduler/announcequeue	(cached)	coverage: 84.2% of statements
ok  	github.com/uber/kraken/lib/torrent/scheduler/announcer	(cached)	coverage: 82.6% of statements
ok  	github.com/uber/kraken/lib/torrent/scheduler/conn	(cached)	coverage: 67.6% of statements
ok  	github.com/uber/kraken/lib/torrent/scheduler/connstate	(cached)	coverage: 93.9% of statements
ok  	github.com/uber/kraken/lib/torrent/scheduler/dispatch	(cached)	coverage: 53.9% of statements
?   	github.com/uber/kraken/lib/torrent/scheduler/torrentlog	[no test files]
ok  	github.com/uber/kraken/lib/torrent/scheduler/dispatch/piecerequest	(cached)	coverage: 96.4% of statements
ok  	github.com/uber/kraken/lib/torrent/storage	(cached)	coverage: 75.0% of statements
ok  	github.com/uber/kraken/lib/torrent/storage/agentstorage	(cached)	coverage: 75.4% of statements
?   	github.com/uber/kraken/lib/torrent/storage/piecereader	[no test files]
?   	github.com/uber/kraken/lib/upstream	[no test files]
?   	github.com/uber/kraken/localdb	[no test files]
?   	github.com/uber/kraken/localdb/migrations	[no test files]
?   	github.com/uber/kraken/metrics	[no test files]
?   	github.com/uber/kraken/mocks/agent/agentclient	[no test files]
?   	github.com/uber/kraken/mocks/build-index/tagclient	[no test files]
?   	github.com/uber/kraken/mocks/build-index/tagstore	[no test files]
?   	github.com/uber/kraken/mocks/build-index/tagtype	[no test files]
?   	github.com/uber/kraken/mocks/lib/backend	[no test files]
?   	github.com/uber/kraken/mocks/lib/backend/gcsbackend	[no test files]
?   	github.com/uber/kraken/mocks/lib/backend/hdfsbackend/webhdfs	[no test files]
?   	github.com/uber/kraken/mocks/lib/backend/s3backend	[no test files]
?   	github.com/uber/kraken/mocks/lib/containerruntime	[no test files]
?   	github.com/uber/kraken/mocks/lib/containerruntime/containerd	[no test files]
?   	github.com/uber/kraken/mocks/lib/containerruntime/dockerdaemon	[no test files]
ok  	github.com/uber/kraken/lib/torrent/storage/originstorage	(cached)	coverage: 78.7% of statements
?   	github.com/uber/kraken/mocks/lib/dockerregistry/transfer	[no test files]
?   	github.com/uber/kraken/mocks/lib/hashring	[no test files]
?   	github.com/uber/kraken/mocks/lib/healthcheck	[no test files]
?   	github.com/uber/kraken/mocks/lib/hostlist	[no test files]
?   	github.com/uber/kraken/mocks/lib/persistedretry	[no test files]
?   	github.com/uber/kraken/mocks/lib/persistedretry/tagreplication	[no test files]
?   	github.com/uber/kraken/mocks/lib/store	[no test files]
?   	github.com/uber/kraken/mocks/lib/torrent/scheduler	[no test files]
?   	github.com/uber/kraken/mocks/origin/blobclient	[no test files]
?   	github.com/uber/kraken/mocks/tracker/announceclient	[no test files]
?   	github.com/uber/kraken/mocks/tracker/metainfoclient	[no test files]
?   	github.com/uber/kraken/mocks/tracker/originstore	[no test files]
?   	github.com/uber/kraken/mocks/tracker/peerstore	[no test files]
?   	github.com/uber/kraken/mocks/utils/dedup	[no test files]
?   	github.com/uber/kraken/mocks/utils/httputil	[no test files]
?   	github.com/uber/kraken/nginx	[no test files]
?   	github.com/uber/kraken/nginx/config	[no test files]
?   	github.com/uber/kraken/origin	[no test files]
?   	github.com/uber/kraken/origin/blobclient	[no test files]
?   	github.com/uber/kraken/origin/cmd	[no test files]
?   	github.com/uber/kraken/proxy	[no test files]
?   	github.com/uber/kraken/proxy/cmd	[no test files]
?   	github.com/uber/kraken/proxy/registryoverride	[no test files]
?   	github.com/uber/kraken/tools/bin/puller	[no test files]
?   	github.com/uber/kraken/tools/bin/reload	[no test files]
?   	github.com/uber/kraken/tools/bin/testfs	[no test files]
?   	github.com/uber/kraken/tools/bin/visualization	[no test files]
ok  	github.com/uber/kraken/origin/blobserver	(cached)	coverage: 81.6% of statements
ok  	github.com/uber/kraken/proxy/proxyserver	(cached)	coverage: 80.3% of statements
?   	github.com/uber/kraken/tools/lib	[no test files]
?   	github.com/uber/kraken/tools/lib/image	[no test files]
?   	github.com/uber/kraken/tracker	[no test files]
?   	github.com/uber/kraken/tracker/announceclient	[no test files]
?   	github.com/uber/kraken/tracker/cmd	[no test files]
?   	github.com/uber/kraken/tracker/metainfoclient	[no test files]
ok  	github.com/uber/kraken/tracker/originstore	(cached)	coverage: 90.2% of statements
ok  	github.com/uber/kraken/tracker/peerhandoutpolicy	(cached)	coverage: 91.7% of statements
?   	github.com/uber/kraken/utils/bitsetutil	[no test files]
ok  	github.com/uber/kraken/tracker/peerstore	(cached)	coverage: 75.6% of statements
ok  	github.com/uber/kraken/tracker/trackerserver	(cached)	coverage: 74.5% of statements
ok  	github.com/uber/kraken/utils/bandwidth	(cached)	coverage: 91.5% of statements
ok  	github.com/uber/kraken/utils/configutil	(cached)	coverage: 95.2% of statements
?   	github.com/uber/kraken/utils/flagutil	[no test files]
?   	github.com/uber/kraken/utils/handler	[no test files]
ok  	github.com/uber/kraken/utils/dedup	(cached)	coverage: 99.1% of statements
ok  	github.com/uber/kraken/utils/diskspaceutil	(cached)	coverage: 87.5% of statements
ok  	github.com/uber/kraken/utils/dockerutil	(cached)	coverage: 21.7% of statements
ok  	github.com/uber/kraken/utils/errutil	(cached)	coverage: 100.0% of statements
ok  	github.com/uber/kraken/utils/heap	(cached)	coverage: 94.4% of statements
?   	github.com/uber/kraken/utils/listener	[no test files]
?   	github.com/uber/kraken/utils/log	[no test files]
ok  	github.com/uber/kraken/utils/httputil	(cached)	coverage: 38.2% of statements
ok  	github.com/uber/kraken/utils/lockermap	(cached)	coverage: 92.3% of statements
ok  	github.com/uber/kraken/utils/memsize	(cached)	coverage: 100.0% of statements
?   	github.com/uber/kraken/utils/netutil	[no test files]
?   	github.com/uber/kraken/utils/osutil	[no test files]
?   	github.com/uber/kraken/utils/randutil	[no test files]
ok  	github.com/uber/kraken/utils/mockutil	(cached)	coverage: 90.3% of statements
?   	github.com/uber/kraken/utils/stringset	[no test files]
ok  	github.com/uber/kraken/utils/rwutil	(cached)	coverage: 90.9% of statements
?   	github.com/uber/kraken/utils/testutil	[no test files]
ok  	github.com/uber/kraken/utils/syncutil	(cached)	coverage: 100.0% of statements
ok  	github.com/uber/kraken/utils/timeutil	(cached)	coverage: 90.0% of statements
```

