### PR TITLE
Adding CGO flags to supress warnings and fix build failures

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,28 +1,41 @@
 name: Build and Test
 
-on: [push]
+# Trigger the action on push and pull requests
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21', '1.22' , '1.23' ]
+        go-version: ['1.21', '1.22', '1.23']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          
       - name: Display Go version
         run: go version
+
       - name: Install dependencies
         run: go mod download
+
+      # Add CGO_CFLAGS environment variable to suppress the warning
       - name: Build
         run: go build -v ./...
+        env:
+          CGO_CFLAGS: "-Wno-return-local-addr"
+
+      # Run tests with CGO_CFLAGS set
       - name: Test with the Go CLI
         run: go test $(go list ./...) -cover -json > TestResults-${{ matrix.go-version }}.json
+        env:
+          CGO_CFLAGS: "-Wno-return-local-addr"
+
       - name: Upload Go test results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The build and test pipeline was failing due to one of the libararies which uses CGO bindings with the warning

```
sqlite3-binding.c:129019:10: warning: function may return address of local variable [-Wreturn-local-addr]
129019 |   return pNew;
       |          ^~~~
sqlite3-binding.c:128979:10: note: declared here
128979 |   Select standin; 
```

Failed build linked :-  [here](https://github.com/uber/kraken/actions/runs/11003116013/job/30552136991#step:7:34)

This change runs the builds on push and pull request and ignores the warnings by passing an ENV variable. 