### PR TITLE
Enable ingestion of GCS SAs from files outside of auth config

### DIFF
--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,6 +21,7 @@ import (
 	"github.com/uber/kraken/build-index/tagstore"
 	"github.com/uber/kraken/build-index/tagtype"
 	"github.com/uber/kraken/lib/backend"
+	"github.com/uber/kraken/lib/backend/gcsbackend"
 	"github.com/uber/kraken/lib/healthcheck"
 	"github.com/uber/kraken/lib/hostlist"
 	"github.com/uber/kraken/lib/persistedretry"
@@ -110,6 +111,14 @@ func Run(flags *Flags, opts ...Option) {
 				panic(err)
 			}
 		}
+	}
+
+	if len(config.GCSServiceAccounts) != 0 {
+		gcsUserAuthConfig, err := gcsbackend.BuildUserAuthConfig(config.GCSServiceAccounts)
+		if err != nil {
+			panic(err)
+		}
+		config.Auth["gcs"] = gcsUserAuthConfig
 	}
 
 	if overrides.logger != nil {

--- a/build-index/cmd/config.go
+++ b/build-index/cmd/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,7 @@ import (
 	"github.com/uber/kraken/build-index/tagstore"
 	"github.com/uber/kraken/build-index/tagtype"
 	"github.com/uber/kraken/lib/backend"
+	"github.com/uber/kraken/lib/backend/gcsbackend"
 	"github.com/uber/kraken/lib/persistedretry"
 	"github.com/uber/kraken/lib/persistedretry/tagreplication"
 	"github.com/uber/kraken/lib/store"
@@ -32,20 +33,21 @@ import (
 
 // Config defines build-index configuration.
 type Config struct {
-	ZapLogging     zap.Config                   `yaml:"zap"`
-	Metrics        metrics.Config               `yaml:"metrics"`
-	Backends       []backend.Config             `yaml:"backends"`
-	Auth           backend.AuthConfig           `yaml:"auth"`
-	TagServer      tagserver.Config             `yaml:"tagserver"`
-	Remotes        tagreplication.RemotesConfig `yaml:"remotes"`
-	TagReplication persistedretry.Config        `yaml:"tag_replication"`
-	TagTypes       []tagtype.Config             `yaml:"tag_types"`
-	Origin         upstream.ActiveConfig        `yaml:"origin"`
-	LocalDB        localdb.Config               `yaml:"localdb"`
-	Cluster        upstream.ActiveConfig        `yaml:"cluster"`
-	TagStore       tagstore.Config              `yaml:"tag_store"`
-	Store          store.SimpleStoreConfig      `yaml:"store"`
-	WriteBack      persistedretry.Config        `yaml:"writeback"`
-	Nginx          nginx.Config                 `yaml:"nginx"`
-	TLS            httputil.TLSConfig           `yaml:"tls"`
+	ZapLogging         zap.Config                   `yaml:"zap"`
+	Metrics            metrics.Config               `yaml:"metrics"`
+	Backends           []backend.Config             `yaml:"backends"`
+	Auth               backend.AuthConfig           `yaml:"auth"`
+	TagServer          tagserver.Config             `yaml:"tagserver"`
+	Remotes            tagreplication.RemotesConfig `yaml:"remotes"`
+	TagReplication     persistedretry.Config        `yaml:"tag_replication"`
+	TagTypes           []tagtype.Config             `yaml:"tag_types"`
+	Origin             upstream.ActiveConfig        `yaml:"origin"`
+	LocalDB            localdb.Config               `yaml:"localdb"`
+	Cluster            upstream.ActiveConfig        `yaml:"cluster"`
+	TagStore           tagstore.Config              `yaml:"tag_store"`
+	Store              store.SimpleStoreConfig      `yaml:"store"`
+	WriteBack          persistedretry.Config        `yaml:"writeback"`
+	Nginx              nginx.Config                 `yaml:"nginx"`
+	TLS                httputil.TLSConfig           `yaml:"tls"`
+	GCSServiceAccounts []gcsbackend.ServiceAccount  `yaml:"gcs_service_accounts"`
 }

--- a/lib/backend/gcsbackend/config.go
+++ b/lib/backend/gcsbackend/config.go
@@ -74,14 +74,14 @@ func BuildUserAuthConfig(sas []ServiceAccount) (UserAuthConfig, error) {
 	gcsUserAuthConfig := UserAuthConfig{}
 
 	for _, sa := range sas {
-		var dataBytes []byte
-		dataBytes, err := os.ReadFile(sa.Path)
+		var accessBlobBytes []byte
+		accessBlobBytes, err := os.ReadFile(sa.Path)
 		if err != nil {
 			return nil, err
 		}
 
-		var data string
-		err = yaml.Unmarshal(dataBytes, data)
+		var accessBlob string
+		err = yaml.Unmarshal(accessBlobBytes, accessBlob)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func BuildUserAuthConfig(sas []ServiceAccount) (UserAuthConfig, error) {
 			GCS: struct {
 				AccessBlob string `yaml:"access_blob"`
 			}{
-				AccessBlob: data,
+				AccessBlob: accessBlob,
 			},
 		}
 	}

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,7 @@ import (
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend"
+	"github.com/uber/kraken/lib/backend/gcsbackend"
 	"github.com/uber/kraken/lib/blobrefresh"
 	"github.com/uber/kraken/lib/hashring"
 	"github.com/uber/kraken/lib/healthcheck"
@@ -134,6 +135,14 @@ func Run(flags *Flags, opts ...Option) {
 				panic(err)
 			}
 		}
+	}
+
+	if len(config.GCSServiceAccounts) != 0 {
+		gcsUserAuthConfig, err := gcsbackend.BuildUserAuthConfig(config.GCSServiceAccounts)
+		if err != nil {
+			panic(err)
+		}
+		config.Auth["gcs"] = gcsUserAuthConfig
 	}
 
 	if overrides.logger != nil {

--- a/origin/cmd/config.go
+++ b/origin/cmd/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ package cmd
 import (
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend"
+	"github.com/uber/kraken/lib/backend/gcsbackend"
 	"github.com/uber/kraken/lib/blobrefresh"
 	"github.com/uber/kraken/lib/hashring"
 	"github.com/uber/kraken/lib/healthcheck"
@@ -37,23 +38,24 @@ import (
 // Config defines origin server configuration.
 // TODO(evelynl94): consolidate cluster and hashring.
 type Config struct {
-	Verbose       bool
-	ZapLogging    zap.Config               `yaml:"zap"`
-	Cluster       hostlist.Config          `yaml:"cluster"`
-	HashRing      hashring.Config          `yaml:"hashring"`
-	HealthCheck   healthcheck.FilterConfig `yaml:"healthcheck"`
-	BlobServer    blobserver.Config        `yaml:"blobserver"`
-	CAStore       store.CAStoreConfig      `yaml:"castore"`
-	Scheduler     scheduler.Config         `yaml:"scheduler"`
-	NetworkEvent  networkevent.Config      `yaml:"network_event"`
-	PeerIDFactory core.PeerIDFactory       `yaml:"peer_id_factory"`
-	Metrics       metrics.Config           `yaml:"metrics"`
-	MetaInfoGen   metainfogen.Config       `yaml:"metainfogen"`
-	Backends      []backend.Config         `yaml:"backends"`
-	Auth          backend.AuthConfig       `yaml:"auth"`
-	BlobRefresh   blobrefresh.Config       `yaml:"blobrefresh"`
-	LocalDB       localdb.Config           `yaml:"localdb"`
-	WriteBack     persistedretry.Config    `yaml:"writeback"`
-	Nginx         nginx.Config             `yaml:"nginx"`
-	TLS           httputil.TLSConfig       `yaml:"tls"`
+	Verbose            bool
+	ZapLogging         zap.Config                  `yaml:"zap"`
+	Cluster            hostlist.Config             `yaml:"cluster"`
+	HashRing           hashring.Config             `yaml:"hashring"`
+	HealthCheck        healthcheck.FilterConfig    `yaml:"healthcheck"`
+	BlobServer         blobserver.Config           `yaml:"blobserver"`
+	CAStore            store.CAStoreConfig         `yaml:"castore"`
+	Scheduler          scheduler.Config            `yaml:"scheduler"`
+	NetworkEvent       networkevent.Config         `yaml:"network_event"`
+	PeerIDFactory      core.PeerIDFactory          `yaml:"peer_id_factory"`
+	Metrics            metrics.Config              `yaml:"metrics"`
+	MetaInfoGen        metainfogen.Config          `yaml:"metainfogen"`
+	Backends           []backend.Config            `yaml:"backends"`
+	Auth               backend.AuthConfig          `yaml:"auth"`
+	BlobRefresh        blobrefresh.Config          `yaml:"blobrefresh"`
+	LocalDB            localdb.Config              `yaml:"localdb"`
+	WriteBack          persistedretry.Config       `yaml:"writeback"`
+	Nginx              nginx.Config                `yaml:"nginx"`
+	TLS                httputil.TLSConfig          `yaml:"tls"`
+	GCSServiceAccounts []gcsbackend.ServiceAccount `yaml:"gcs_service_accounts"`
 }


### PR DESCRIPTION
**Why**
Currently, Kraken expects all authentication credentials for backend clients (e.g. S3 and GCS) to be in the .yaml config. This works well for S3 and other backends, whose authentication credentials are strings and thus can be easily inserted into a .yaml file. However, it does not work for clients like GCS, whose authentication credentials are whole files (e.g. GCS uses an "access_blob").

It would be more convenient to have the option of Kraken accepting a path to an access_blob that it could then parse, similar to how [parsing the TLS config](https://github.com/uber/kraken/blob/1a4993f1825708e4415c20e74e6c386a05a67349/utils/httputil/tls.go#L54) works.

**What**
- Edit origin and build-index config parsing, such that the GCS auth config can be optionally parsed differently -- instead of providing service accounts in the .yaml config, a path (and a name) can be passed. Kraken will then read the file with the service account.
- If GCS credentials are provided both through the .yaml config and as paths to files, the files have precedence.