### PR TITLE
Split `DiskSpaceUtil` function to improve reusability

### DIFF
--- a/utils/diskspaceutil/diskspaceutil.go
+++ b/utils/diskspaceutil/diskspaceutil.go
@@ -17,10 +17,14 @@ import (
 	"syscall"
 )
 
-const path = "/"
 
 // Helper method to get disk util.
 func DiskSpaceUtil() (int, error) {
+	path := "/"
+	return DiskSpaceAtPathUtil(path)
+}
+
+func DiskSpaceAtPathUtil(path string) (int, error) {
 	fs := syscall.Statfs_t{}
 	err := syscall.Statfs(path, &fs)
 	if err != nil {
@@ -31,5 +35,4 @@ func DiskSpaceUtil() (int, error) {
 	diskFree := fs.Bfree * uint64(fs.Bsize)
 	diskUsed := diskAll - diskFree
 	return int(diskUsed * 100 / diskAll), nil
-
 }


### PR DESCRIPTION
In order for kraken services to know when to clean up their cache, they monitor how much of the disk space on their hosts is utilized with the `DiskSpaceUtil` function. Currently, that function calculates the disk utilization for the whole host.

In the future, we want to specifically check the cache directory's disk space utilization, instead of the whole host's. The reason is that cache cleanup should be done close to the cache filling up. While this might be correlated to the host's disk filling up, they are not the same. For example, if the host has a separate file system for the cache, that might be 90% full, whereas the host's overall disk space might be only 20% full. 

To allow for checking the disk utilization for a specific directory (and thus the disk it is mounted on), the `DiskSpaceUtil` function is split into two -- one that still does the same thing and another that takes a `path` as an argument, to allow for reusability.