### PR TITLE
Add origin readiness endpoint

### DIFF
--- a/core/digest.go
+++ b/core/digest.go
@@ -23,11 +23,6 @@ import (
 	"strings"
 )
 
-const (
-	// DigestEmptyTar is the sha256 digest of an empty tar file.
-	DigestEmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-)
-
 // DigestList is a list of digests.
 type DigestList []Digest
 

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -30,6 +30,9 @@ var (
 	ErrNamespaceNotFound = errors.New("no matches for namespace")
 )
 
+const isReadyNamespace = "isReadyNamespace"
+const isReadyName = "38a03d499119bc417b8a6a016f2cb4540b9f9cc0c13e4da42a73867120d3e908"
+
 type backend struct {
 	regexp    *regexp.Regexp
 	client    Client

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -30,9 +30,6 @@ var (
 	ErrNamespaceNotFound = errors.New("no matches for namespace")
 )
 
-const isReadyNamespace = "isReadyNamespace"
-const isReadyName = "38a03d499119bc417b8a6a016f2cb4540b9f9cc0c13e4da42a73867120d3e908"
-
 type backend struct {
 	regexp    *regexp.Regexp
 	client    Client

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -143,7 +143,7 @@ func (m *Manager) GetClient(namespace string) (Client, error) {
 	return nil, ErrNamespaceNotFound
 }
 
-// IsReady returns whether the backends are ready (reachable).
+// CheckReadiness returns whether the backends are ready (available).
 // A backend must be explicitly configured as required for readiness to be checked.
 func (m *Manager) CheckReadiness() error {
 	for _, b := range m.backends {

--- a/lib/backend/manager_test.go
+++ b/lib/backend/manager_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
-	"github.com/uber/kraken/lib/backend"
 	. "github.com/uber/kraken/lib/backend"
 	"github.com/uber/kraken/lib/backend/backenderrors"
 	"github.com/uber/kraken/lib/backend/namepath"
@@ -222,8 +221,8 @@ func TestManagerCheckReadiness(t *testing.T) {
 				mockStat2 = nil
 			}
 
-			c1.EXPECT().Stat(backend.ReadinessCheckNamespace, backend.ReadinessCheckName).Return(mockStat1, tc.mockStat1Err).AnyTimes()
-			c2.EXPECT().Stat(backend.ReadinessCheckNamespace, backend.ReadinessCheckName).Return(mockStat2, tc.mockStat2Err).AnyTimes()
+			c1.EXPECT().Stat(ReadinessCheckNamespace, ReadinessCheckName).Return(mockStat1, tc.mockStat1Err).AnyTimes()
+			c2.EXPECT().Stat(ReadinessCheckNamespace, ReadinessCheckName).Return(mockStat2, tc.mockStat2Err).AnyTimes()
 
 			require.NoError(m.Register(n1, c1, tc.mustReady1))
 			require.NoError(m.Register(n2, c2, tc.mustReady2))

--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -130,6 +130,7 @@ func (s *Server) Handler() http.Handler {
 	// Public endpoints:
 
 	r.Get("/health", handler.Wrap(s.healthCheckHandler))
+	r.Get("/readiness", handler.Wrap(s.readinessCheckHandler))
 
 	r.Get("/blobs/{digest}/locations", handler.Wrap(s.getLocationsHandler))
 
@@ -175,6 +176,15 @@ func (s *Server) ListenAndServe(h http.Handler) error {
 }
 
 func (s *Server) healthCheckHandler(w http.ResponseWriter, r *http.Request) error {
+	fmt.Fprintln(w, "OK")
+	return nil
+}
+
+func (s *Server) readinessCheckHandler(w http.ResponseWriter, r *http.Request) error {
+	err := s.backends.CheckReadiness()
+	if err != nil {
+		return handler.Errorf("not ready to serve traffic: %s", err).Status(http.StatusServiceUnavailable)
+	}
 	fmt.Fprintln(w, "OK")
 	return nil
 }

--- a/origin/blobserver/testutils_test.go
+++ b/origin/blobserver/testutils_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -158,9 +158,9 @@ func newTestServer(
 	}
 }
 
-func (s *testServer) backendClient(namespace string) *mockbackend.MockClient {
+func (s *testServer) backendClient(namespace string, mustReady bool) *mockbackend.MockClient {
 	client := mockbackend.NewMockClient(s.ctrl)
-	if err := s.backendManager.Register(namespace, client, false); err != nil {
+	if err := s.backendManager.Register(namespace, client, mustReady); err != nil {
 		panic(err)
 	}
 	return client


### PR DESCRIPTION
As described in #371, all services should implement a "readiness" endpoint, which checks whether the service is ready to serve traffic, i.e. whether it can reach all of its dependencies.

Add readiness endpoint for origin, which checks whether all its backends are reachable.

Stacked on top of #372 