### PR TITLE
Change Go version in CICD pipeline

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21', '1.22', '1.23']
+        go-version: ['1.14']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go ${{ matrix.go-version }}


### PR DESCRIPTION
Currently, each time a PR is created/updated, tests are run on the 1.21, 1.22, and 1.23 Go versions. However, Kraken is currently using Go 1.14. To have the tests reflect how Kraken will be used in production and thus make them stronger, we are adding Go 1.14 to the CICD.

Additionally, due to an unknown reason, the pipeline is flaky. To reduce flakiness, we will only run one Go version (1.14) instead of multiple ones, as running the pipeline in multiple versions does not increase confidence in the code's correctness. We are also planning to investigate why the CICD is flaky and fix it in a separate PR.