### PR TITLE
Add agent readiness endpoint

### DIFF
--- a/agent/agentserver/server_test.go
+++ b/agent/agentserver/server_test.go
@@ -231,21 +231,28 @@ func TestReadinessCheckHandler(t *testing.T) {
 			probeErr:              errors.New("test scheduler error"),
 			buildIndexErr:         nil,
 			trackerErr:            nil,
-			expectedErrMsgPattern: `GET http://127\.0\.0\.1:\d+/readiness 503: agent not ready, scheduler error: test scheduler error\nbuild index error: <nil>\ntracker error: <nil>`,
+			expectedErrMsgPattern: `GET http://127\.0\.0\.1:\d+/readiness 503: agent not ready: test scheduler error`,
 		},
 		{
 			desc:                  "failure (build index not ready)",
 			probeErr:              nil,
 			buildIndexErr:         errors.New("build index not ready"),
 			trackerErr:            nil,
-			expectedErrMsgPattern: `GET http://127\.0\.0\.1:\d+/readiness 503: agent not ready, scheduler error: <nil>\nbuild index error: build index not ready\ntracker error: <nil>`,
+			expectedErrMsgPattern: `GET http://127\.0\.0\.1:\d+/readiness 503: agent not ready: build index not ready`,
 		},
 		{
 			desc:                  "failure (tracker not ready)",
 			probeErr:              nil,
 			buildIndexErr:         nil,
 			trackerErr:            errors.New("tracker not ready"),
-			expectedErrMsgPattern: `GET http://127\.0\.0\.1:\d+/readiness 503: agent not ready, scheduler error: <nil>\nbuild index error: <nil>\ntracker error: tracker not ready`,
+			expectedErrMsgPattern: `GET http://127\.0\.0\.1:\d+/readiness 503: agent not ready: tracker not ready`,
+		},
+		{
+			desc:                  "failure (all conditions fail)",
+			probeErr:              errors.New("test scheduler error"),
+			buildIndexErr:         errors.New("build index not ready"),
+			trackerErr:            errors.New("tracker not ready"),
+			expectedErrMsgPattern: `GET http://127\.0\.0\.1:\d+/readiness 503: agent not ready: test scheduler error\nbuild index not ready\ntracker not ready`,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,6 +30,7 @@ import (
 	"github.com/uber/kraken/lib/torrent/scheduler"
 	"github.com/uber/kraken/metrics"
 	"github.com/uber/kraken/nginx"
+	"github.com/uber/kraken/tracker/announceclient"
 	"github.com/uber/kraken/utils/configutil"
 	"github.com/uber/kraken/utils/log"
 	"github.com/uber/kraken/utils/netutil"
@@ -183,8 +184,9 @@ func Run(flags *Flags, opts ...Option) {
 		log.Fatalf("Error building client tls config: %s", err)
 	}
 
+	announceClient := announceclient.New(pctx, trackers, tls)
 	sched, err := scheduler.NewAgentScheduler(
-		config.Scheduler, stats, pctx, cads, netevents, trackers, tls)
+		config.Scheduler, stats, pctx, cads, netevents, trackers, announceClient, tls)
 	if err != nil {
 		log.Fatalf("Error creating scheduler: %s", err)
 	}
@@ -216,7 +218,7 @@ func Run(flags *Flags, opts ...Option) {
 	}
 
 	agentServer := agentserver.New(
-		config.AgentServer, stats, cads, sched, tagClient, containerRuntimeFactory)
+		config.AgentServer, stats, cads, sched, tagClient, announceClient, containerRuntimeFactory)
 	addr := fmt.Sprintf(":%d", flags.AgentServerPort)
 	log.Infof("Starting agent server on %s", addr)
 	go func() {

--- a/lib/torrent/scheduler/constructors.go
+++ b/lib/torrent/scheduler/constructors.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,6 +39,7 @@ func NewAgentScheduler(
 	cads *store.CADownloadStore,
 	netevents networkevent.Producer,
 	trackers hashring.PassiveRing,
+	announceClient announceclient.Client,
 	tls *tls.Config) (ReloadableScheduler, error) {
 
 	s, err := newScheduler(
@@ -46,7 +47,7 @@ func NewAgentScheduler(
 		agentstorage.NewTorrentArchive(stats, cads, metainfoclient.New(trackers, tls)),
 		stats,
 		pctx,
-		announceclient.New(pctx, trackers, tls),
+		announceClient,
 		netevents)
 	if err != nil {
 		return nil, fmt.Errorf("new scheduler: %s", err)


### PR DESCRIPTION
As described in #371, all services should implement a "readiness" endpoint, which checks whether the service is ready to serve traffic, i.e. whether it can reach all of its dependencies.

- Add readiness endpoint for agent. It calls both build-index and tracker's readiness endpoints. They in turn call the origin's readiness endpoint. The endpoint succeeding provides a strong signal that an agent on a host is ready to provide images.

Stacked on top of https://github.com/uber/kraken/pull/380