### PR TITLE
Add disk utilization percent metrics

### DIFF
--- a/lib/store/cleanup_test.go
+++ b/lib/store/cleanup_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,20 +14,19 @@
 package store
 
 import (
-	"errors"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/andres-erbsen/clock"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/store/base"
 	"github.com/uber/kraken/lib/store/metadata"
 	"github.com/uber/kraken/utils/testutil"
-
-	"github.com/andres-erbsen/clock"
-	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 )
 
 func fileOpFixture(clk clock.Clock) (base.FileState, base.FileOp, func()) {
@@ -231,31 +230,46 @@ func TestCleanupManageDiskUsage(t *testing.T) {
 }
 
 func TestCleanupManagerAggressive(t *testing.T) {
-	require := require.New(t)
-
-	config := CleanupConfig{
+	aggressiveOnConfig := CleanupConfig{
 		AggressiveThreshold: 80,
 		TTL:                 10 * time.Second,
 		AggressiveTTL:       5 * time.Second,
 	}
+	aggressiveOffConfig := CleanupConfig{
+		TTL: 10 * time.Second,
+	}
 
-	clk := clock.NewMock()
-	m, err := newCleanupManager(clk, tally.NoopScope)
-	require.NoError(err)
-	defer m.stop()
+	for _, tc := range []struct {
+		config       CleanupConfig
+		usagePercent int
+		expectedTTL  time.Duration
+	}{
+		{
+			config:       aggressiveOnConfig,
+			usagePercent: aggressiveOnConfig.AggressiveThreshold,
+			expectedTTL:  aggressiveOnConfig.AggressiveTTL,
+		},
+		{
+			config:       aggressiveOnConfig,
+			usagePercent: aggressiveOnConfig.AggressiveThreshold - 20,
+			expectedTTL:  aggressiveOnConfig.TTL,
+		},
+		{
+			config:       aggressiveOffConfig,
+			usagePercent: rand.Intn(101),
+			expectedTTL:  aggressiveOffConfig.TTL,
+		},
+	} {
+		require := require.New(t)
 
-	_, op, cleanup := fileOpFixture(clk)
-	defer cleanup()
+		clk := clock.NewMock()
+		m, err := newCleanupManager(clk, tally.NoopScope)
+		require.NoError(err)
+		defer m.stop()
 
-	require.Equal(m.checkAggressiveCleanup(op, config, func() (int, error) {
-		return 90, nil
-	}), 5*time.Second)
+		_, op, cleanup := fileOpFixture(clk)
+		defer cleanup()
 
-	require.Equal(m.checkAggressiveCleanup(op, config, func() (int, error) {
-		return 60, nil
-	}), 10*time.Second)
-
-	require.Equal(m.checkAggressiveCleanup(op, config, func() (int, error) {
-		return 0, errors.New("fake error")
-	}), 10*time.Second)
+		require.Equal(m.calculateCleanupTTL(op, tc.config, tc.usagePercent), tc.expectedTTL)
+	}
 }


### PR DESCRIPTION
Currently, when we perform cache cleanup, we emit metrics on the size of the cache. However, it's useful to know the % of the cache being used, as well. More specifically, this metric is important when Kraken runs on hosts with different disk sizes. For instance, assume two hosts both have 90GB of blobs in their cache, but host A only has 100GB disk, while host B has 1TB. Since we currently only emit metrics on the size of cached blobs, we would see that these two hosts have the same metrics, thus their cache health/state is the same. However, this would not be true -- one host's cache would be dangerously close to full at 90%, whereas host B would be safe at 9% utilization.

- Emit cache store percent utilization metrics, in addition to the already present absolute size metrics
- Refactor the code and tests for readability