### PR TITLE
Expose agent readiness endpoint on nginx port

### DIFF
--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,7 +40,7 @@ server {
   gzip on;
   gzip_types text/plain test/csv application/json;
 
-  location /health {
+  location ~ ^/(health|readiness)$ {
     proxy_pass http://agent-server;
   }
 


### PR DESCRIPTION
Currently, all services except the agent and tracker have their health and readiness endpoints exposed on their nginx port. The agent's readiness endpoint is exposed by the agent server (a different server, not the nginx server!). To reach consistency across services, the agent's readiness endpoint should be exposed by its nginx server (on the nginx port).

To expose the readiness endpoint on the nginx server, we can reroute any requests to the nginx `/readiness` API to the agentserver, exactly like we already do for the `/health` endpoint.

Tested locally by building the devcluster: (16000 is the nginx port)
```
root@9234fcfc2af8:/etc/kraken# curl http://localhost:16000/readiness
OKroot@9234fcfc2af8:/etc/kraken# 
```