### PR TITLE
default time encoder

### DIFF
--- a/utils/log/logger.go
+++ b/utils/log/logger.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,6 +34,9 @@ func (c Config) applyDefaults() Config {
 	}
 	if c.Encoding == "" {
 		c.Encoding = "console"
+	}
+	if c.EncodeTime == nil {
+		c.EncodeTime = zapcore.ISO8601TimeEncoder
 	}
 	return c
 }


### PR DESCRIPTION
zap logger requires a encode timer. We should supply a default when operating without a config.