### PR TITLE
Added Trivy Vulnerability scanner for the project

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,32 @@
+name: Trivy Scan
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  trivy_scan:
+    name: Trivy Vulnerability Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Trivy
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0
+        with:
+          scan-type: 'fs' 
+          scan-all-sub-directories: true
+          format: 'table' 
+          exit-code: '1' 
+          ignore-unfixed: true
+          security-checks: 'vuln,config,secret' # Customize based on needs
+
+      - name: Upload Trivy Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: trivy-report.*


### PR DESCRIPTION
## What 
- This diff adds a vulnerability scanner [trivy](https://github.com/aquasecurity/trivy) to the project with the use of github actions.

## Why 
- As per the conversation on the PR #392 The plan is to setup automated vulnerability scan of the repository  on every push and pull request to the master branch.

## How
- Uses github actions on every push and pull request to master branch.
 - Checks out the repository 
 - Sets up the trivy scanner from the [trivy-actions](https://github.com/aquasecurity/trivy-action) repository the sha points to the latest release.
 - Runs the scan and uploads the report to a file.
