### PR TITLE
Fix Configuration section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Kraken
 nav:
   - Home: index.md
   - Architecture: ARCHITECTURE.md
-  - Configuration: CONFIGURATIION.md
+  - Configuration: CONFIGURATION.md
   - Endpoints: ENDPOINTS.md
   - 'Harbor Integration': INTEGRATEWITHHARBOR.md
   - Contributing: CONTRIBUTING.md


### PR DESCRIPTION
There is a typo in mkdocs.yml, thus https://uber-kraken.readthedocs.io/en/latest/CONFIGURATIION.md returns 404. This PR fixes it.