### PR TITLE
ci: add trivy vulnerability scan to the repo

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -1,0 +1,60 @@
+name: Vulnerability Check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, reopened, synchronize ]
+  push:
+    branches: [ master ]
+
+
+jobs:
+  trivy_scan:
+    name: Trivy Vulnerability Scan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy to check CRITICAL dependencies
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          scan-type: 'fs'
+          scan-all-sub-directories: true
+          exit-code: '1'
+          severity: 'CRITICAL'  # only fail on CRITICAL vulnerabilities
+          ignore-unfixed: true
+          vuln-type: 'library' # only check libraries
+          scanners: 'vuln,license,secret,misconfig'
+          skip-version-check: true
+
+  trivy_report:
+    name: Trivy Vulnerability Report
+    runs-on: ubuntu-latest
+    # Since this is a report job, it should only run after merge to report all vulnerabilities
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy scan for all severities
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          scan-type: 'fs'
+          scan-all-sub-directories: true
+          format: 'sarif' # Sarif to report to github security tab
+          output: 'trivy-results.sarif'
+          exit-code: '0'  # Never fail
+          ignore-unfixed: true
+          vuln-type: 'os,library' # Report any os related vulnerabilities also in the report
+          scanners: 'vuln,license,secret,misconfig'
+          skip-version-check: true
+
+      # This step will make the vulns detected in the above step to be visible in the security tab in github.
+      - name: Upload comprehensive Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## What?
This PR adds a new action with two jobs that scans of vulnerabilities in the repo.

## Why?
There is a lot of toil and issues while checking for vulnerabilities manually. Also, when PRs were raised, the developer isnot forced to fix any potential vulnerabilities in the PR. This action will force to do that.
Ref: #392 

## How?
This PR adds two jobs:
1. `trivy_scan` job scans for critical vulnerabilities and fail if found any, the PR is blocked.
2. `trivy_master_report` job only runs during the merge step to report all vulnerabilities.