### PR TITLE
Fixing 404 at uber-kraken.readthedocs.io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Kraken
 nav:
   - Home: index.md
   - Architecture: ARCHITECTURE.md
-  - Configuration: CONFIGURATIION.md
+  - Configuration: CONFIGURATION.md
   - Endpoints: ENDPOINTS.md
   - 'Harbor Integration': INTEGRATEWITHHARBOR.md
   - Contributing: CONTRIBUTING.md


### PR DESCRIPTION
The configuration file had a small typo. That was a reason for uber-kraken.readthedocs.io to return 404 for the configuration page.