### PR TITLE
Handling a silent error in HashedPeerID

### DIFF
--- a/core/peer_id.go
+++ b/core/peer_id.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -90,7 +90,9 @@ func HashedPeerID(s string) (PeerID, error) {
 		return p, errors.New("cannot generate peer id from empty string")
 	}
 	h := sha1.New()
-	io.WriteString(h, s)
+	if _, err := io.WriteString(h, s); err != nil {
+		return p, fmt.Errorf("failed to convert hash to string: %w", err)
+	}
 	copy(p[:], h.Sum(nil))
 	return p, nil
 }


### PR DESCRIPTION
`WriteString(w Writer, s string) (n int, err error)` has a signature that may technically return an error. With high probability, SHA1 should not fail. But silently ignoring errors may bring surprises during production usage.

I've also executed `go fmt` for a file.