### PR TITLE
fix: remove usage of ioutil

### DIFF
--- a/agent/agentclient/client.go
+++ b/agent/agentclient/client.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 
 	"github.com/uber/kraken/core"
@@ -56,7 +55,7 @@ func (c *HTTPClient) GetTag(tag string) (core.Digest, error) {
 		return core.Digest{}, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return core.Digest{}, fmt.Errorf("read body: %s", err)
 	}

--- a/agent/agentserver/server_test.go
+++ b/agent/agentserver/server_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strings"
 	"testing"
@@ -140,7 +140,7 @@ func TestDownload(t *testing.T) {
 
 	r, err := c.Download(namespace, blob.Digest)
 	require.NoError(err)
-	result, err := ioutil.ReadAll(r)
+	result, err := io.ReadAll(r)
 	require.NoError(err)
 	require.Equal(string(blob.Content), string(result))
 }

--- a/build-index/tagclient/client.go
+++ b/build-index/tagclient/client.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strconv"
 	"time"
@@ -107,7 +106,7 @@ func (c *singleClient) Get(tag string) (core.Digest, error) {
 		return core.Digest{}, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return core.Digest{}, fmt.Errorf("read body: %s", err)
 	}
@@ -285,7 +284,7 @@ func (c *singleClient) Origin() (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("read body: %s", err)
 	}

--- a/build-index/tagserver/server_test.go
+++ b/build-index/tagserver/server_test.go
@@ -16,7 +16,7 @@ package tagserver
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -146,7 +146,7 @@ func TestHealth(t *testing.T) {
 		fmt.Sprintf("http://%s/health", addr))
 	defer resp.Body.Close()
 	require.NoError(err)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(err)
 	require.Equal("OK\n", string(b))
 }

--- a/core/digester_test.go
+++ b/core/digester_test.go
@@ -16,7 +16,6 @@ package core
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -71,7 +70,7 @@ func TestTeeReader(t *testing.T) {
 
 	_, err := io.Copy(w, tr)
 	require.NoError(err)
-	b, err := ioutil.ReadAll(w)
+	b, err := io.ReadAll(w)
 	require.NoError(err)
 	require.Equal(_testStr, string(b))
 

--- a/lib/backend/hdfsbackend/webhdfs/client_test.go
+++ b/lib/backend/hdfsbackend/webhdfs/client_test.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -63,7 +63,7 @@ func writeResponse(status int, body []byte) http.HandlerFunc {
 
 func checkBody(t *testing.T, expected []byte) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, string(expected), string(b))
 		w.WriteHeader(http.StatusCreated)
@@ -141,7 +141,7 @@ func TestClientOpenErrBlobNotFound(t *testing.T) {
 
 	client := newClient(addr)
 
-	f, err := ioutil.TempFile("", "hdfs3test")
+	f, err := os.CreateTemp("", "hdfs3test")
 	require.NoError(err)
 	defer os.Remove(f.Name())
 

--- a/lib/backend/testfs/server.go
+++ b/lib/backend/testfs/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ type Server struct {
 
 // NewServer creates a new Server.
 func NewServer() *Server {
-	dir, err := ioutil.TempDir("/tmp", "kraken-testfs")
+	dir, err := os.MkdirTemp("/tmp", "kraken-testfs")
 	if err != nil {
 		panic(err)
 	}

--- a/lib/blobrefresh/refresher_test.go
+++ b/lib/blobrefresh/refresher_test.go
@@ -14,7 +14,7 @@
 package blobrefresh
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -92,7 +92,7 @@ func TestRefresh(t *testing.T) {
 
 	f, err := mocks.cas.GetCacheFileReader(blob.Digest.Hex())
 	require.NoError(err)
-	result, err := ioutil.ReadAll(f)
+	result, err := io.ReadAll(f)
 	require.Equal(string(blob.Content), string(result))
 
 	var tm metadata.TorrentMeta

--- a/lib/containerruntime/dockerdaemon/cli.go
+++ b/lib/containerruntime/dockerdaemon/cli.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -138,7 +138,7 @@ func (cli *dockerClient) PullImage(ctx context.Context, repo, tag string) error 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		errMsg, err := ioutil.ReadAll(resp.Body)
+		errMsg, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("read error resp: %s", err)
 		}
@@ -146,7 +146,7 @@ func (cli *dockerClient) PullImage(ctx context.Context, repo, tag string) error 
 	}
 
 	// Docker daemon returns 200 early. Close resp.Body after reading all.
-	if _, err := ioutil.ReadAll(resp.Body); err != nil {
+	if _, err := io.ReadAll(resp.Body); err != nil {
 		return fmt.Errorf("read resp body: %s", err)
 	}
 

--- a/lib/dockerregistry/blobs.go
+++ b/lib/dockerregistry/blobs.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -88,7 +87,7 @@ func (b *blobs) getContent(ctx context.Context, path string) ([]byte, error) {
 		return nil, err
 	}
 	defer r.Close()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (b *blobs) getCacheReaderHelper(

--- a/lib/dockerregistry/storage_driver_test.go
+++ b/lib/dockerregistry/storage_driver_test.go
@@ -16,7 +16,7 @@ package dockerregistry
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"testing"
@@ -98,7 +98,7 @@ func TestStorageDriverReader(t *testing.T) {
 				require.Equal(tc.err, err)
 				return
 			}
-			data, err := ioutil.ReadAll(reader)
+			data, err := io.ReadAll(reader)
 			require.Equal(tc.data, data)
 			require.Equal(tc.err, err)
 		})
@@ -171,7 +171,7 @@ func TestStorageDriverWriter(t *testing.T) {
 			r, err := sd.Reader(contextFixture(), tc.input, 0)
 			require.NoError(err)
 			defer r.Close()
-			data, err := ioutil.ReadAll(r)
+			data, err := io.ReadAll(r)
 			require.NoError(err)
 			require.Equal(content, data)
 		})
@@ -250,7 +250,7 @@ func TestStorageDriverMove(t *testing.T) {
 
 	reader, err := td.cas.GetCacheFileReader(d.Hex())
 	require.NoError(err)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	require.NoError(err)
 	require.Equal(uploadContent, string(data))
 }

--- a/lib/dockerregistry/transfer/ro_transferer_test.go
+++ b/lib/dockerregistry/transfer/ro_transferer_test.go
@@ -16,7 +16,6 @@ package transfer
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -81,7 +80,7 @@ func TestReadOnlyTransfererDownloadCachesBlob(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, err := transferer.Download(namespace, blob.Digest)
 		require.NoError(err)
-		b, err := ioutil.ReadAll(result)
+		b, err := io.ReadAll(result)
 		require.NoError(err)
 		require.Equal(blob.Content, b)
 	}
@@ -189,7 +188,7 @@ func TestReadOnlyTransfererMultipleDownloadsOfSameBlob(t *testing.T) {
 			defer wg.Done()
 			result, err := transferer.Download(namespace, blob.Digest)
 			require.NoError(err)
-			b, err := ioutil.ReadAll(result)
+			b, err := io.ReadAll(result)
 			require.NoError(err)
 			require.Equal(blob.Content, b)
 		}()

--- a/lib/dockerregistry/transfer/rw_transferer_test.go
+++ b/lib/dockerregistry/transfer/rw_transferer_test.go
@@ -16,7 +16,7 @@ package transfer
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/uber/kraken/build-index/tagclient"
@@ -77,7 +77,7 @@ func TestReadWriteTransfererDownloadCachesBlob(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, err := transferer.Download(namespace, blob.Digest)
 		require.NoError(err)
-		b, err := ioutil.ReadAll(result)
+		b, err := io.ReadAll(result)
 		require.NoError(err)
 		require.Equal(blob.Content, b)
 	}

--- a/lib/store/base/file_entry.go
+++ b/lib/store/base/file_entry.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -127,7 +126,7 @@ func (f *localFileEntryFactory) ListNames(state FileState) ([]string, error) {
 
 	var readNames func(string) error
 	readNames = func(dir string) error {
-		infos, err := ioutil.ReadDir(dir)
+		infos, err := os.ReadDir(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil
@@ -195,7 +194,7 @@ func (f *casFileEntryFactory) ListNames(state FileState) ([]string, error) {
 
 	var readNames func(string, int) error
 	readNames = func(dir string, depth int) error {
-		infos, err := ioutil.ReadDir(dir)
+		infos, err := os.ReadDir(dir)
 		if err != nil {
 			return err
 		}
@@ -311,7 +310,7 @@ func (entry *localFileEntry) Reload() error {
 	}
 
 	// Load metadata.
-	files, err := ioutil.ReadDir(filepath.Dir(entry.GetPath()))
+	files, err := os.ReadDir(filepath.Dir(entry.GetPath()))
 	if err != nil {
 		return err
 	}
@@ -382,7 +381,7 @@ func (entry *localFileEntry) Move(targetState FileState) error {
 		if md.Movable() {
 			sourceMetadataPath := entry.getMetadataPath(md)
 			targetMetadataPath := filepath.Join(filepath.Dir(targetPath), md.GetSuffix())
-			bytes, err := ioutil.ReadFile(sourceMetadataPath)
+			bytes, err := os.ReadFile(sourceMetadataPath)
 			if err != nil {
 				return err
 			}
@@ -487,7 +486,7 @@ func (entry *localFileEntry) AddMetadata(md metadata.Metadata) error {
 // GetMetadata reads and unmarshals metadata into md.
 func (entry *localFileEntry) GetMetadata(md metadata.Metadata) error {
 	filePath := entry.getMetadataPath(md)
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
@@ -591,7 +590,7 @@ func compareAndWriteFile(filePath string, b []byte) (bool, error) {
 			return false, err
 		}
 
-		if err := ioutil.WriteFile(filePath, b, 0775); err != nil {
+		if err := os.WriteFile(filePath, b, 0775); err != nil {
 			return false, err
 		}
 		return true, nil

--- a/lib/store/base/file_entry_test.go
+++ b/lib/store/base/file_entry_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package base
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -259,7 +258,7 @@ func testMoveFrom(require *require.Assertions, bundle *fileEntryTestBundle) {
 	s3 := bundle.state3
 
 	fp := fe.GetPath()
-	testSourceFile, err := ioutil.TempFile(s3.GetDirectory(), "")
+	testSourceFile, err := os.CreateTemp(s3.GetDirectory(), "")
 	require.NoError(err)
 
 	// MoveFrom succeeds with correct state and source path.
@@ -275,7 +274,7 @@ func testMoveFromExisting(require *require.Assertions, bundle *fileEntryTestBund
 	s3 := bundle.state3
 
 	fp := fe.GetPath()
-	testSourceFile, err := ioutil.TempFile(s3.GetDirectory(), "")
+	testSourceFile, err := os.CreateTemp(s3.GetDirectory(), "")
 	require.NoError(err)
 
 	// MoveFrom succeeds with correct state and source path.
@@ -285,7 +284,7 @@ func testMoveFromExisting(require *require.Assertions, bundle *fileEntryTestBund
 	require.NoError(err)
 
 	// MoveFrom fails with existing file.
-	testSourceFile2, err := ioutil.TempFile(s3.GetDirectory(), "")
+	testSourceFile2, err := os.CreateTemp(s3.GetDirectory(), "")
 	err = fe.MoveFrom(s1, testSourceFile2.Name())
 	require.True(os.IsExist(err))
 	_, err = os.Stat(fp)
@@ -298,7 +297,7 @@ func testMoveFromWrongState(require *require.Assertions, bundle *fileEntryTestBu
 	s3 := bundle.state3
 
 	fp := fe.GetPath()
-	testSourceFile, err := ioutil.TempFile(s3.GetDirectory(), "")
+	testSourceFile, err := os.CreateTemp(s3.GetDirectory(), "")
 	require.NoError(err)
 
 	// MoveFrom fails with wrong state.

--- a/lib/store/base/file_op_test.go
+++ b/lib/store/base/file_op_test.go
@@ -14,7 +14,7 @@
 package base
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -206,9 +206,9 @@ func testMoveFile(require *require.Assertions, storeBundle *fileStoreTestBundle)
 	readWriterState1, err := store.NewFileOp().AcceptState(s2).GetFileReadWriter(fn, partSize, partSize)
 	require.NoError(err)
 	// Check content
-	dataState1, err := ioutil.ReadAll(readWriterState1)
+	dataState1, err := io.ReadAll(readWriterState1)
 	require.NoError(err)
-	dataState2, err := ioutil.ReadAll(readWriterState2)
+	dataState2, err := io.ReadAll(readWriterState2)
 	require.NoError(err)
 	require.Equal(dataState1, dataState2)
 	require.Equal([]byte{'t', 'e', 's', 't', '\n'}, dataState1)
@@ -218,9 +218,9 @@ func testMoveFile(require *require.Assertions, storeBundle *fileStoreTestBundle)
 	// Check content again
 	readWriterState1.Seek(0, 0)
 	readWriterState2.Seek(0, 0)
-	dataState1, err = ioutil.ReadAll(readWriterState1)
+	dataState1, err = io.ReadAll(readWriterState1)
 	require.NoError(err)
-	dataState2, err = ioutil.ReadAll(readWriterState2)
+	dataState2, err = io.ReadAll(readWriterState2)
 	require.NoError(err)
 	require.Equal(dataState1, dataState2)
 	require.Equal([]byte{'1', 'e', 's', 't', '\n'}, dataState1)
@@ -234,7 +234,7 @@ func testMoveFile(require *require.Assertions, storeBundle *fileStoreTestBundle)
 	// Check content again
 	readWriterStateMoved, err := store.NewFileOp().AcceptState(s2).GetFileReadWriter(fn, partSize, partSize)
 	require.NoError(err)
-	dataMoved, err := ioutil.ReadAll(readWriterStateMoved)
+	dataMoved, err := io.ReadAll(readWriterStateMoved)
 	require.NoError(err)
 	require.Equal([]byte{'1', 'e', 's', 't', '\n'}, dataMoved)
 	readWriterStateMoved.Close()
@@ -285,13 +285,13 @@ func testDeleteFile(require *require.Assertions, storeBundle *fileStoreTestBundl
 
 	// Existing readwriter should still work after deletion
 	rw.Seek(0, 0)
-	data, err := ioutil.ReadAll(rw)
+	data, err := io.ReadAll(rw)
 	require.NoError(err)
 	require.Equal(content, string(data))
 
 	rw.Write([]byte(content))
 	rw.Seek(0, 0)
-	data, err = ioutil.ReadAll(rw)
+	data, err = io.ReadAll(rw)
 	require.NoError(err)
 	require.Equal(content+content, string(data))
 

--- a/lib/store/base/fixtures.go
+++ b/lib/store/base/fixtures.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package base
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -29,23 +28,23 @@ func fileStatesFixture() (state1, state2, state3 FileState, run func()) {
 	cleanup := &testutil.Cleanup{}
 	defer cleanup.Recover()
 
-	root, err := ioutil.TempDir("/tmp", "store_test")
+	root, err := os.MkdirTemp("/tmp", "store_test")
 	if err != nil {
 		log.Fatal(err)
 	}
 	cleanup.Add(func() { os.RemoveAll(root) })
 
-	state1Dir, err := ioutil.TempDir(root, "state1")
+	state1Dir, err := os.MkdirTemp(root, "state1")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	state2Dir, err := ioutil.TempDir(root, "state2")
+	state2Dir, err := os.MkdirTemp(root, "state2")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	state3Dir, err := ioutil.TempDir(root, "state3")
+	state3Dir, err := os.MkdirTemp(root, "state3")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lib/store/ca_store_test.go
+++ b/lib/store/ca_store_test.go
@@ -15,7 +15,7 @@ package store
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -32,15 +32,15 @@ func TestCAStoreInitVolumes(t *testing.T) {
 	config, cleanup := CAStoreConfigFixture()
 	defer cleanup()
 
-	volume1, err := ioutil.TempDir("/tmp", "volume")
+	volume1, err := os.MkdirTemp("/tmp", "volume")
 	require.NoError(err)
 	defer os.RemoveAll(volume1)
 
-	volume2, err := ioutil.TempDir("/tmp", "volume")
+	volume2, err := os.MkdirTemp("/tmp", "volume")
 	require.NoError(err)
 	defer os.RemoveAll(volume2)
 
-	volume3, err := ioutil.TempDir("/tmp", "volume")
+	volume3, err := os.MkdirTemp("/tmp", "volume")
 	require.NoError(err)
 	defer os.RemoveAll(volume3)
 
@@ -53,11 +53,11 @@ func TestCAStoreInitVolumes(t *testing.T) {
 	_, err = NewCAStore(config, tally.NoopScope)
 	require.NoError(err)
 
-	v1Files, err := ioutil.ReadDir(path.Join(volume1, path.Base(config.CacheDir)))
+	v1Files, err := os.ReadDir(path.Join(volume1, path.Base(config.CacheDir)))
 	require.NoError(err)
-	v2Files, err := ioutil.ReadDir(path.Join(volume2, path.Base(config.CacheDir)))
+	v2Files, err := os.ReadDir(path.Join(volume2, path.Base(config.CacheDir)))
 	require.NoError(err)
-	v3Files, err := ioutil.ReadDir(path.Join(volume3, path.Base(config.CacheDir)))
+	v3Files, err := os.ReadDir(path.Join(volume3, path.Base(config.CacheDir)))
 	require.NoError(err)
 	n1 := len(v1Files)
 	n2 := len(v2Files)
@@ -76,15 +76,15 @@ func TestCAStoreInitVolumesAfterChangingVolumes(t *testing.T) {
 	config, cleanup := CAStoreConfigFixture()
 	defer cleanup()
 
-	volume1, err := ioutil.TempDir("/tmp", "volume")
+	volume1, err := os.MkdirTemp("/tmp", "volume")
 	require.NoError(err)
 	defer os.RemoveAll(volume1)
 
-	volume2, err := ioutil.TempDir("/tmp", "volume")
+	volume2, err := os.MkdirTemp("/tmp", "volume")
 	require.NoError(err)
 	defer os.RemoveAll(volume2)
 
-	volume3, err := ioutil.TempDir("/tmp", "volume")
+	volume3, err := os.MkdirTemp("/tmp", "volume")
 	require.NoError(err)
 	defer os.RemoveAll(volume3)
 
@@ -99,7 +99,7 @@ func TestCAStoreInitVolumesAfterChangingVolumes(t *testing.T) {
 
 	// Add one more volume, recreate file store.
 
-	volume4, err := ioutil.TempDir("/tmp", "volume")
+	volume4, err := os.MkdirTemp("/tmp", "volume")
 	require.NoError(err)
 	defer os.RemoveAll(volume3)
 
@@ -109,7 +109,7 @@ func TestCAStoreInitVolumesAfterChangingVolumes(t *testing.T) {
 	require.NoError(err)
 
 	var n1, n2, n3, n4 int
-	links, err := ioutil.ReadDir(config.CacheDir)
+	links, err := os.ReadDir(config.CacheDir)
 	require.NoError(err)
 	for _, link := range links {
 		source, err := os.Readlink(path.Join(config.CacheDir, link.Name()))
@@ -213,6 +213,6 @@ func TestCAStoreCreateCacheFile(t *testing.T) {
 	require.NoError(err)
 	r2, err := s.GetCacheFileReader(computedDigest.Hex())
 	require.NoError(err)
-	b2, err := ioutil.ReadAll(r2)
+	b2, err := io.ReadAll(r2)
 	require.Equal(s1, string(b2))
 }

--- a/lib/store/cleanup_test.go
+++ b/lib/store/cleanup_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package store
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -34,7 +33,7 @@ func fileOpFixture(clk clock.Clock) (base.FileState, base.FileOp, func()) {
 	var cleanup testutil.Cleanup
 	defer cleanup.Recover()
 
-	dir, err := ioutil.TempDir("/tmp", "cleanup_test")
+	dir, err := os.MkdirTemp("/tmp", "cleanup_test")
 	if err != nil {
 		panic(err)
 	}

--- a/lib/store/fixtures.go
+++ b/lib/store/fixtures.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/uber/kraken/utils/testutil"
@@ -23,7 +22,7 @@ import (
 )
 
 func tempdir(cleanup *testutil.Cleanup, name string) string {
-	d, err := ioutil.TempDir("/tmp", name)
+	d, err := os.MkdirTemp("/tmp", name)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/store/simple_store_test.go
+++ b/lib/store/simple_store_test.go
@@ -15,7 +15,7 @@ package store
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/uber/kraken/core"
@@ -36,7 +36,7 @@ func TestSimpleStoreCreateCacheFile(t *testing.T) {
 
 	f, err := s.GetCacheFileReader(tag)
 	require.NoError(err)
-	result, err := ioutil.ReadAll(f)
+	result, err := io.ReadAll(f)
 	require.NoError(err)
 	require.Equal(d, string(result))
 }

--- a/lib/store/testing.go
+++ b/lib/store/testing.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package store
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/uber/kraken/core"
@@ -47,7 +46,7 @@ func NewMockFileReadWriter(content []byte) (*MockFileReadWriter, func()) {
 	cleanup := new(testutil.Cleanup)
 	defer cleanup.Recover()
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}

--- a/lib/store/utils.go
+++ b/lib/store/utils.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package store
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -64,7 +63,7 @@ func walkDirectory(rootDir string, depth int, f func(string) error) error {
 			}
 		}
 	} else {
-		infos, err := ioutil.ReadDir(rootDir)
+		infos, err := os.ReadDir(rootDir)
 		if err != nil {
 			return err
 		}

--- a/lib/torrent/networkevent/producer_test.go
+++ b/lib/torrent/networkevent/producer_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package networkevent
 import (
 	"bufio"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +32,7 @@ func TestProducerCreatesAndReusesFile(t *testing.T) {
 	peer1 := core.PeerIDFixture()
 	peer2 := core.PeerIDFixture()
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	require.NoError(err)
 	defer os.RemoveAll(dir)
 

--- a/lib/torrent/scheduler/testutils_test.go
+++ b/lib/torrent/scheduler/testutils_test.go
@@ -15,7 +15,7 @@ package scheduler
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"reflect"
@@ -185,7 +185,7 @@ func (p *testPeer) checkTorrent(t *testing.T, namespace string, blob *core.BlobF
 		pr, err := tor.GetPieceReader(i)
 		require.NoError(err)
 		defer pr.Close()
-		pieceData, err := ioutil.ReadAll(pr)
+		pieceData, err := io.ReadAll(pr)
 		require.NoError(err)
 		copy(cursor, pieceData)
 		cursor = cursor[tor.PieceLength(i):]

--- a/lib/torrent/storage/agentstorage/torrent_test.go
+++ b/lib/torrent/storage/agentstorage/torrent_test.go
@@ -16,7 +16,7 @@ package agentstorage
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"sync"
 	"testing"
@@ -107,7 +107,7 @@ func TestTorrentWriteComplete(t *testing.T) {
 	r, err := tor.GetPieceReader(0)
 	require.NoError(err)
 	defer r.Close()
-	result, err := ioutil.ReadAll(r)
+	result, err := io.ReadAll(r)
 	require.NoError(err)
 	require.Equal(blob.Content, result)
 
@@ -152,7 +152,7 @@ func TestTorrentWriteMultiplePieceConcurrent(t *testing.T) {
 	// Check content
 	reader, err := cads.Cache().GetFileReader(blob.MetaInfo.Digest().Hex())
 	require.NoError(err)
-	torrentBytes, err := ioutil.ReadAll(reader)
+	torrentBytes, err := io.ReadAll(reader)
 	require.NoError(err)
 	require.Equal(blob.Content, torrentBytes)
 }
@@ -202,7 +202,7 @@ func TestTorrentWriteSamePieceConcurrent(t *testing.T) {
 				}
 				defer r.Close()
 
-				result, err := ioutil.ReadAll(r)
+				result, err := io.ReadAll(r)
 				require.NoError(err)
 				require.Equal(1, len(result))
 				require.Equal(1, len(result))
@@ -216,7 +216,7 @@ func TestTorrentWriteSamePieceConcurrent(t *testing.T) {
 
 	reader, err := cads.Cache().GetFileReader(blob.MetaInfo.Digest().Hex())
 	require.NoError(err)
-	torrentBytes, err := ioutil.ReadAll(reader)
+	torrentBytes, err := io.ReadAll(reader)
 	require.NoError(err)
 	require.Equal(blob.Content, torrentBytes)
 }

--- a/lib/torrent/storage/originstorage/torrent_test.go
+++ b/lib/torrent/storage/originstorage/torrent_test.go
@@ -15,7 +15,7 @@ package originstorage
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 
@@ -79,7 +79,7 @@ func TestTorrentGetPieceReaderConcurrent(t *testing.T) {
 			r, err := tor.GetPieceReader(i)
 			require.NoError(err)
 			defer r.Close()
-			result, err := ioutil.ReadAll(r)
+			result, err := io.ReadAll(r)
 			require.NoError(err)
 			require.Equal(blob.Content[start:end], result)
 		}(i)

--- a/localdb/fixtures.go
+++ b/localdb/fixtures.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,6 @@
 package localdb
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -28,7 +27,7 @@ func Fixture() (*sqlx.DB, func()) {
 	var cleanup testutil.Cleanup
 	defer cleanup.Recover()
 
-	tmpdir, err := ioutil.TempDir(".", "test-db-")
+	tmpdir, err := os.MkdirTemp(".", "test-db-")
 	if err != nil {
 		panic(err)
 	}

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -99,7 +98,7 @@ func (c *Config) inject(params map[string]interface{}) error {
 // GetTemplate returns the template content.
 func (c *Config) getTemplate() (string, error) {
 	if c.TemplatePath != "" {
-		b, err := ioutil.ReadFile(c.TemplatePath)
+		b, err := os.ReadFile(c.TemplatePath)
 		if err != nil {
 			return "", fmt.Errorf("read template: %s", err)
 		}
@@ -211,7 +210,7 @@ func Run(config Config, params map[string]interface{}, opts ...Option) error {
 	}
 
 	conf := filepath.Join(_genDir, config.Name)
-	if err := ioutil.WriteFile(conf, src, 0o755); err != nil {
+	if err := os.WriteFile(conf, src, 0o755); err != nil {
 		return fmt.Errorf("write src: %s", err)
 	}
 

--- a/origin/blobclient/client.go
+++ b/origin/blobclient/client.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -241,7 +240,7 @@ func (c *HTTPClient) GetMetaInfo(namespace string, d core.Digest) (*core.MetaInf
 		return nil, err
 	}
 	defer r.Body.Close()
-	raw, err := ioutil.ReadAll(r.Body)
+	raw, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read body: %s", err)
 	}

--- a/origin/blobserver/cluster_client_test.go
+++ b/origin/blobserver/cluster_client_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@ package blobserver
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"sort"
 	"testing"
 	"time"
@@ -108,7 +108,7 @@ func TestClusterClientReturnsErrorOnNoAvailability(t *testing.T) {
 	_, err = cc.GetMetaInfo(backend.NoopNamespace, blob.Digest)
 	require.Error(err)
 
-	require.Error(cc.DownloadBlob(backend.NoopNamespace, blob.Digest, ioutil.Discard))
+	require.Error(cc.DownloadBlob(backend.NoopNamespace, blob.Digest, io.Discard))
 
 	_, err = cc.Owners(blob.Digest)
 	require.Error(err)

--- a/origin/blobserver/server_test.go
+++ b/origin/blobserver/server_test.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -50,7 +50,7 @@ func TestHealth(t *testing.T) {
 		fmt.Sprintf("http://%s/health", s.addr))
 	defer resp.Body.Close()
 	require.NoError(err)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(err)
 	require.Equal("OK\n", string(b))
 }
@@ -240,7 +240,7 @@ func TestDownloadBlobNotFound(t *testing.T) {
 	backendClient := s.backendClient(namespace, false)
 	backendClient.EXPECT().Stat(namespace, d.Hex()).Return(nil, backenderrors.ErrBlobNotFound)
 
-	err := cp.Provide(master1).DownloadBlob(namespace, d, ioutil.Discard)
+	err := cp.Provide(master1).DownloadBlob(namespace, d, io.Discard)
 	require.Error(err)
 	require.Equal(http.StatusNotFound, err.(httputil.StatusError).Status)
 }

--- a/proxy/proxyserver/prefetch.go
+++ b/proxy/proxyserver/prefetch.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -208,7 +208,7 @@ func (ph *PrefetchHandler) prefetchBlobs(logger *zap.SugaredLogger, namespace st
 		go func(digest core.Digest) {
 			defer wg.Done()
 			blobStart := time.Now()
-			err := ph.clusterClient.DownloadBlob(namespace, digest, ioutil.Discard)
+			err := ph.clusterClient.DownloadBlob(namespace, digest, io.Discard)
 			blobDuration := time.Since(blobStart)
 			ph.metrics.Timer("blob_download_time").Record(blobDuration)
 			ph.metrics.Counter("bytes_downloaded").Inc(size)

--- a/proxy/proxyserver/server_test.go
+++ b/proxy/proxyserver/server_test.go
@@ -15,7 +15,7 @@ package proxyserver
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -44,7 +44,7 @@ func TestHealth(t *testing.T) {
 		fmt.Sprintf("http://%s/health", addr))
 	defer resp.Body.Close()
 	require.NoError(err)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(err)
 	require.Equal("OK\n", string(b))
 }
@@ -201,8 +201,8 @@ func TestPrefetch(t *testing.T) {
 	tagRequest := url.QueryEscape(fmt.Sprintf("%s/%s", namespace, tag))
 	mocks.tagClient.EXPECT().Get(tagRequest).Return(manifest, nil)
 	mocks.originClient.EXPECT().DownloadBlob(namespace, manifest, mockutil.MatchWriter(bs)).Return(nil)
-	mocks.originClient.EXPECT().DownloadBlob(namespace, layers[1], ioutil.Discard).Return(nil)
-	mocks.originClient.EXPECT().DownloadBlob(namespace, layers[2], ioutil.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(namespace, layers[1], io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(namespace, layers[2], io.Discard).Return(nil)
 	_, err := httputil.Post(
 		fmt.Sprintf("http://%s/proxy/v1/registry/prefetch", addr),
 		httputil.SendBody(bytes.NewReader(b)))

--- a/tools/bin/puller/pull.go
+++ b/tools/bin/puller/pull.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os/exec"
@@ -120,7 +119,7 @@ func pullManifest(client http.Client, source string, name string, reference stri
 	}
 
 	version := resp.Header.Get("Content-Type")
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/lib/image/image.go
+++ b/tools/lib/image/image.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -41,7 +40,7 @@ func run(name string, args ...string) error {
 
 // Generate creates a random image.
 func Generate(size uint64, numLayers int) (name string, err error) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", fmt.Errorf("temp dir: %s", err)
 	}

--- a/tools/lib/tlsutil.go
+++ b/tools/lib/tlsutil.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ package lib
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/uber/kraken/utils/httputil"
 
@@ -29,7 +29,7 @@ func ReadTLSFile(path *string) (*tls.Config, error) {
 	if path == nil {
 		return nil, nil
 	}
-	data, err := ioutil.ReadFile(*path)
+	data, err := os.ReadFile(*path)
 	if err != nil {
 		return nil, fmt.Errorf("read tls config: %s", err)
 	}

--- a/tracker/metainfoclient/client.go
+++ b/tracker/metainfoclient/client.go
@@ -17,7 +17,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -80,7 +80,7 @@ func (c *client) Download(namespace string, d core.Digest) (*core.MetaInfo, erro
 			return nil, err
 		}
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("read body: %s", err)
 		}

--- a/utils/configutil/config.go
+++ b/utils/configutil/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,42 +22,41 @@
 // There is no multiple inheritance supported. Dependency tree suppossed to
 // form a linked list.
 //
-//
-// Values from multiple configurations within the same hierarchy are deep merged
+// # Values from multiple configurations within the same hierarchy are deep merged
 //
 // Note regarding configuration merging:
-//   Array defined in YAML will be overriden based on load sequence.
-//   e.g. in the base.yaml:
-//        sports:
-//           - football
-//        in the development.yaml:
-//        extends: base.yaml
-//        sports:
-//           - basketball
-//        after the merge:
-//        sports:
-//           - basketball  // only keep the latest one
 //
-//   Map defined in YAML will be merged together based on load sequence.
-//   e.g. in the base.yaml:
-//        sports:
-//           football: true
-//        in the development.yaml:
-//        extends: base.yaml
-//        sports:
-//           basketball: true
-//        after the merge:
-//        sports:  // combine all the map fields
-//           football: true
-//           basketball: true
+//	Array defined in YAML will be overriden based on load sequence.
+//	e.g. in the base.yaml:
+//	     sports:
+//	        - football
+//	     in the development.yaml:
+//	     extends: base.yaml
+//	     sports:
+//	        - basketball
+//	     after the merge:
+//	     sports:
+//	        - basketball  // only keep the latest one
 //
+//	Map defined in YAML will be merged together based on load sequence.
+//	e.g. in the base.yaml:
+//	     sports:
+//	        football: true
+//	     in the development.yaml:
+//	     extends: base.yaml
+//	     sports:
+//	        basketball: true
+//	     after the merge:
+//	     sports:  // combine all the map fields
+//	        football: true
+//	        basketball: true
 package configutil
 
 import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -145,7 +144,7 @@ func resolveExtends(filename string, extendReader getExtend) ([]string, error) {
 }
 
 func readExtend(configFile string) (string, error) {
-	data, err := ioutil.ReadFile(configFile)
+	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return "", err
 	}
@@ -160,7 +159,7 @@ func readExtend(configFile string) (string, error) {
 // loadFiles loads a list of files, deep-merging values.
 func loadFiles(config interface{}, fnames []string) error {
 	for _, fname := range fnames {
-		data, err := ioutil.ReadFile(fname)
+		data, err := os.ReadFile(fname)
 		if err != nil {
 			return err
 		}

--- a/utils/configutil/config_test.go
+++ b/utils/configutil/config_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package configutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -89,7 +88,7 @@ type Zconfig struct {
 func writeFile(t *testing.T, contents string) string {
 	require := require.New(t)
 
-	f, err := ioutil.TempFile("", "configtest")
+	f, err := os.CreateTemp("", "configtest")
 	require.NoError(err)
 
 	defer f.Close()
@@ -276,13 +275,13 @@ func TestExtendsConfigDeep(t *testing.T) {
 func TestExtendsConfigCircularRef(t *testing.T) {
 	require := require.New(t)
 
-	f1, err := ioutil.TempFile("", "configtest")
+	f1, err := os.CreateTemp("", "configtest")
 	require.NoError(err)
 
-	f2, err := ioutil.TempFile("", "configtest")
+	f2, err := os.CreateTemp("", "configtest")
 	require.NoError(err)
 
-	f3, err := ioutil.TempFile("", "configtest")
+	f3, err := os.CreateTemp("", "configtest")
 	require.NoError(err)
 
 	defer f1.Close()

--- a/utils/dockerutil/dockerutil.go
+++ b/utils/dockerutil/dockerutil.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
@@ -29,7 +28,7 @@ const _v2ManifestType = "application/vnd.docker.distribution.manifest.v2+json"
 const _v2ManifestListType = "application/vnd.docker.distribution.manifest.list.v2+json"
 
 func ParseManifest(r io.Reader) (distribution.Manifest, core.Digest, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, core.Digest{}, fmt.Errorf("read: %s", err)
 	}

--- a/utils/httputil/httputil.go
+++ b/utils/httputil/httputil.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -53,7 +52,7 @@ type StatusError struct {
 // NewStatusError returns a new StatusError.
 func NewStatusError(resp *http.Response) StatusError {
 	defer resp.Body.Close()
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	respDump := string(respBytes)
 	if err != nil {
 		respDump = fmt.Sprintf("failed to dump response: %s", err)

--- a/utils/httputil/tls.go
+++ b/utils/httputil/tls.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/uber/kraken/utils/log"
 )
@@ -142,7 +142,7 @@ func concatSecrets(secrets []Secret) ([]byte, error) {
 }
 
 func parseCert(path string) ([]byte, error) {
-	certBytes, err := ioutil.ReadFile(path)
+	certBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read file: %s", err)
 	}
@@ -151,12 +151,12 @@ func parseCert(path string) ([]byte, error) {
 
 // parseKey reads key from file and decrypts if passphrase is provided.
 func parseKey(path, passphrasePath string) ([]byte, error) {
-	keyPEM, err := ioutil.ReadFile(path)
+	keyPEM, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read file: %s", err)
 	}
 	if passphrasePath != "" {
-		passphrase, err := ioutil.ReadFile(passphrasePath)
+		passphrase, err := os.ReadFile(passphrasePath)
 		if err != nil {
 			return nil, fmt.Errorf("read passphrase file: %s", err)
 		}

--- a/utils/mockutil/mockutil.go
+++ b/utils/mockutil/mockutil.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package mockutil
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"regexp"
 )
 
@@ -61,7 +60,7 @@ func (m *ReaderMatcher) Matches(x interface{}) bool {
 	if !ok {
 		return false
 	}
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}

--- a/utils/mockutil/mockutil_test.go
+++ b/utils/mockutil/mockutil_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@ package mockutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -36,7 +36,7 @@ func TestMatchReader(t *testing.T) {
 		t.Run(fmt.Sprintf("%q==%q", test.expected, test.actual), func(t *testing.T) {
 			require := require.New(t)
 
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			require.NoError(err)
 			defer os.Remove(f.Name())
 
@@ -64,7 +64,7 @@ func TestMatchReaderTypeCheck(t *testing.T) {
 func TestMatchWriter(t *testing.T) {
 	require := require.New(t)
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(err)
 	defer os.Remove(f.Name())
 
@@ -79,7 +79,7 @@ func TestMatchWriter(t *testing.T) {
 	require.NoError(err)
 
 	// WriterMatcher should write to the file.
-	result, err := ioutil.ReadAll(f)
+	result, err := io.ReadAll(f)
 	require.Equal(string(b), string(result))
 }
 
@@ -93,7 +93,7 @@ func TestMatchWriterTypeCheck(t *testing.T) {
 func TestMatchWriterAt(t *testing.T) {
 	require := require.New(t)
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(err)
 	defer os.Remove(f.Name())
 
@@ -108,7 +108,7 @@ func TestMatchWriterAt(t *testing.T) {
 	require.NoError(err)
 
 	// WriterAtMatcher should write to the file.
-	result, err := ioutil.ReadAll(f)
+	result, err := io.ReadAll(f)
 	require.Equal(string(b), string(result))
 }
 

--- a/utils/randutil/randutil.go
+++ b/utils/randutil/randutil.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@ package randutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"time"
 )
@@ -46,7 +45,7 @@ func Blob(n uint64) []byte {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	lr := io.LimitReader(r, int64(n))
-	b, _ := ioutil.ReadAll(lr)
+	b, _ := io.ReadAll(lr)
 
 	return b
 }

--- a/utils/testutil/testutil.go
+++ b/utils/testutil/testutil.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -94,7 +93,7 @@ func TempFile(data []byte) (string, func()) {
 	var cleanup Cleanup
 	defer cleanup.Recover()
 
-	f, err := ioutil.TempFile(".", "")
+	f, err := os.CreateTemp(".", "")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## What?
Migrated `ioutil` usages to relevant updated methods

## Why?
`ioutil` package is deprecated from go1.15 

## How?
☒ ioutil.ReadFile to os.ReadFile
☒ ioutil.WriteFile to os.WriteFile
☒ ioutil.TempFile to os.CreateTemp
☒ ioutil.TempDir to os.MkdirTemp
☒ ioutil.ReadAll to io.ReadAll
 ☒ ioutil.Discard to io.Discard