### PR TITLE
Partial resolving of the existing lint issues by removing unused consts, errors and methods.

### DIFF
--- a/lib/torrent/scheduler/dispatch/dispatcher.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher.go
@@ -36,10 +36,7 @@ import (
 )
 
 var (
-	errPeerAlreadyDispatched   = errors.New("peer is already dispatched for the torrent")
-	errPieceOutOfBounds        = errors.New("piece index out of bounds")
-	errChunkNotSupported       = errors.New("reading / writing chunk of piece not supported")
-	errRepeatedBitfieldMessage = errors.New("received repeated bitfield message")
+	errChunkNotSupported = errors.New("reading / writing chunk of piece not supported")
 )
 
 // Events defines Dispatcher events.

--- a/lib/torrent/scheduler/torrentlog/logger.go
+++ b/lib/torrent/scheduler/torrentlog/logger.go
@@ -14,21 +14,14 @@
 package torrentlog
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/utils/log"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-)
-
-var (
-	errEmptyReceivedPieces    = errors.New("empty received piece counts")
-	errNegativeReceivedPieces = errors.New("negative value in received piece counts")
 )
 
 // Logger wraps structured log entries for important torrent events. These events

--- a/lib/torrent/storage/agentstorage/torrent_archive_test.go
+++ b/lib/torrent/storage/agentstorage/torrent_archive_test.go
@@ -33,8 +33,6 @@ import (
 	"github.com/uber-go/tally"
 )
 
-const pieceLength = 4
-
 type archiveMocks struct {
 	cads           *store.CADownloadStore
 	metaInfoClient *mockmetainfoclient.MockClient

--- a/tools/bin/visualization/server.go
+++ b/tools/bin/visualization/server.go
@@ -79,9 +79,3 @@ func (s *server) getEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
-
-type byTime []networkevent.Event
-
-func (s byTime) Len() int           { return len(s) }
-func (s byTime) Less(i, j int) bool { return s[i].Time.Before(s[j].Time) }
-func (s byTime) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }

--- a/utils/httputil/httputil.go
+++ b/utils/httputil/httputil.go
@@ -466,10 +466,3 @@ func fallbackToHTTP(
 
 	return client.Do(req)
 }
-
-func min(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
**What:**
The kraken codebase has 130 unresolved lint issues.
```
130 issues:
* copyloopvar: 4
* errcheck: 50
* goimports: 3
* ineffassign: 5
* staticcheck: 41
* unused: 27
```

**Why:**
The diff starts a long journey of cleaning out these issues. It sounds reasonable to cut them into smaller PRs for the ease of the refactorings that should lead to a less error-prone codebase.

**Usage:**
Nothing should be done to start using the changes given that PR is a cleanup PR.