### PR TITLE
fix: fix upload step unit_test job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -24,7 +24,6 @@ jobs:
           version: latest
           # Only run on new issues in pull requests
           only-new-issues: true
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +47,6 @@ jobs:
         run: go build ./...
         env:
           CGO_CFLAGS: "-Wno-return-local-addr"
-
   unit_tests:
     runs-on: ubuntu-latest
     steps:
@@ -59,15 +57,15 @@ jobs:
 
       - name: Test with the Go CLI
         run: |
+
           set -o pipefail
-          go test $(go list ./...) -cover
+          go test $(go list ./...) -v -json > TestResults-${{ env.GO_VERSION }}.json
         env:
           CGO_CFLAGS: "-Wno-return-local-addr"
-
       - name: Upload Go test results
         uses: actions/upload-artifact@v4
         with:
-          name: Go-results-${{ env.GO_VERSION }}
+          name: unit-test-results-${{ env.GO_VERSION }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: TestResults-${{ env.GO_VERSION }}.json
 
   integration_tests:


### PR DESCRIPTION
The upload step of the unit test CI job was failing due to the fact that
the go test commad was not even emitting json. This change aims to fix
that also.