### PR TITLE
Updating The CI pipeline test step behaviour

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -64,6 +64,11 @@ jobs:
         run: go test $(go list ./...) -cover
         env:
           CGO_CFLAGS: "-Wno-return-local-addr"
+      - name: Run Benchmarks
+        run: |
+          go test $(go list ./...) -bench=. -benchmem -run=^$
+        env:
+          CGO_CFLAGS: "-Wno-return-local-addr"
 
   integration_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR does the following things

- Removes the "upload unit tests" artifact step from CI
- Replaces verbose/json test step with a single go test … -cover command.