### PR TITLE
Add eth1 to supported interfaces

### DIFF
--- a/utils/netutil/netutil.go
+++ b/utils/netutil/netutil.go
@@ -22,7 +22,7 @@ import (
 
 // _supportedInterfaces is an ordered list of ip interfaces from which
 // host ip is determined.
-var _supportedInterfaces = []string{"eth0", "ib0", "eth2"}
+var _supportedInterfaces = []string{"eth0", "ib0", "eth1", "eth2"}
 
 func min(a, b time.Duration) time.Duration {
 	if a < b {


### PR DESCRIPTION
We have a docker container crashing in a loop with the following error.
```
github.com/uber/kraken/utils/log.Fatalf
	external/com_github_uber_kraken/utils/log/log.go:120
github.com/uber/kraken/agent/cmd.Run
	external/com_github_uber_kraken/agent/cmd/cmd.go:155
```
eth1 is th primary nic on these nodes. For technical reasons we are not able to rename this to interface to eth0 or eth2.

```
$ sudo ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000
    link/ether <redacted> brd ff:ff:ff:ff:ff:ff
    altname enp12s0np0
3: eth1: <BROADCAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether <redacted> brd ff:ff:ff:ff:ff:ff
    altname enp31s0np0
    altname ens1200np0
4: eth2: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether <redacted> brd ff:ff:ff:ff:ff:ff
    altname enp42s0np0
```