### PR TITLE
Download/Upload/Replication/Metainfo timeouts increases

### DIFF
--- a/agent/agentserver/server.go
+++ b/agent/agentserver/server.go
@@ -43,6 +43,8 @@ import (
 type Config struct {
 	// How long a successful readiness check is valid for. If 0, disable caching successful readiness.
 	readinessCacheTTL time.Duration `yaml:"readiness_cache_ttl"`
+	// Timeout configurations
+	DownloadTimeout time.Duration `yaml:"download_timeout"`
 }
 
 // Server defines the agent HTTP server.
@@ -65,8 +67,8 @@ func New(
 	sched scheduler.ReloadableScheduler,
 	tags tagclient.Client,
 	ac announceclient.Client,
-	containerRuntime containerruntime.Factory) *Server {
-
+	containerRuntime containerruntime.Factory,
+) *Server {
 	stats = stats.Tagged(map[string]string{
 		"module": "agentserver",
 	})

--- a/agent/agentserver/server.go
+++ b/agent/agentserver/server.go
@@ -47,6 +47,13 @@ type Config struct {
 	DownloadTimeout time.Duration `yaml:"download_timeout"`
 }
 
+func (c Config) applyDefaults() Config {
+	if c.DownloadTimeout == 0 {
+		c.DownloadTimeout = 15 * time.Minute
+	}
+	return c
+}
+
 // Server defines the agent HTTP server.
 type Server struct {
 	config           Config
@@ -69,6 +76,8 @@ func New(
 	ac announceclient.Client,
 	containerRuntime containerruntime.Factory,
 ) *Server {
+	config = config.applyDefaults()
+
 	stats = stats.Tagged(map[string]string{
 		"module": "agentserver",
 	})

--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -243,13 +243,14 @@ func Run(flags *Flags, opts ...Option) {
 	go heartbeat(stats)
 
 	log.Fatal(nginx.Run(config.Nginx, map[string]interface{}{
-		"allowed_cidrs": config.AllowedCidrs,
-		"port":          flags.AgentRegistryPort,
-		"registry_server": nginx.GetServer(
-			config.Registry.Docker.HTTP.Net, config.Registry.Docker.HTTP.Addr),
+		"allowed_cidrs":   config.AllowedCidrs,
+		"port":            flags.AgentRegistryPort,
+		"registry_server": nginx.GetServer(config.Registry.Docker.HTTP.Net, config.Registry.Docker.HTTP.Addr),
 		"agent_server":    fmt.Sprintf("127.0.0.1:%d", flags.AgentServerPort),
-		"registry_backup": config.RegistryBackup},
-		nginx.WithTLS(config.TLS)))
+		"registry_backup": config.RegistryBackup,
+		// Pass timeout parameters from agent server config
+		"download_timeout": nginx.FormatDurationForNginx(config.AgentServer.DownloadTimeout),
+	}, nginx.WithTLS(config.TLS)))
 }
 
 // heartbeat periodically emits a counter metric which allows us to monitor the

--- a/config/agent/base.yaml
+++ b/config/agent/base.yaml
@@ -58,6 +58,10 @@ registry:
 
 peer_id_factory: addr_hash
 
+agentserver:
+  # Timeout configurations (also used by nginx)
+  download_timeout: 15m            # nginx proxy_read_timeout for downloads
+
 # Allow agent to only serve localhost and Docker default bridge requests.
 allowed_cidrs:
   - 127.0.0.1

--- a/config/origin/base.yaml
+++ b/config/origin/base.yaml
@@ -49,6 +49,12 @@ blobserver:
     net: unix
     addr: /tmp/kraken-origin.sock
 
+  # Timeout configurations (also used by nginx)
+  download_timeout: 15m      # nginx proxy_read_timeout for downloads
+  upload_timeout: 10m        # nginx proxy_read_timeout/send_timeout for uploads  
+  replication_timeout: 3m    # nginx timeout for replication operations
+  backend_timeout: 2m        # nginx proxy_connect_timeout
+
 nginx:
   name: kraken-origin
   cache_dir: /var/cache/kraken/kraken-origin/nginx/

--- a/config/tracker/base.yaml
+++ b/config/tracker/base.yaml
@@ -41,6 +41,10 @@ trackerserver:
     net: unix
     addr: /tmp/kraken-tracker.sock
 
+  # Timeout configurations (also used by nginx)
+  metainfo_timeout: 2m    # nginx proxy_read_timeout for metainfo requests to origins
+  readiness_timeout: 30s  # nginx timeout for health checks
+
 nginx:
   name: kraken-tracker
   cache_dir: /var/cache/kraken/kraken-tracker/nginx/

--- a/config/tracker/base.yaml
+++ b/config/tracker/base.yaml
@@ -43,7 +43,6 @@ trackerserver:
 
   # Timeout configurations (also used by nginx)
   metainfo_timeout: 2m    # nginx proxy_read_timeout for metainfo requests to origins
-  readiness_timeout: 30s  # nginx timeout for health checks
 
 nginx:
   name: kraken-tracker

--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -42,9 +42,22 @@ server {
 
 {{healthEndpoint "agent-server"}}
 
+  # Download operations
+  location ~ ^/namespace/.*/blobs/ {
+    proxy_pass http://agent-server;
+    
+    # Use download timeout for blob operations
+    proxy_read_timeout {{.download_timeout}};
+    proxy_send_timeout {{.download_timeout}};
+  }
+
   location / {
     proxy_pass http://registry-backend;
     proxy_next_upstream error timeout http_404 http_500;
+
+	# Standard timeouts for registry operations
+    proxy_read_timeout {{.download_timeout}};
+    proxy_send_timeout {{.download_timeout}};
   }
 }
 `

--- a/nginx/config/origin.go
+++ b/nginx/config/origin.go
@@ -30,8 +30,65 @@ server {
 
 {{healthEndpoint .server}}
 
+  # Timeout configurations from origin server config
+  proxy_connect_timeout {{.backend_timeout}};
+  proxy_send_timeout {{.upload_timeout}};
+  proxy_read_timeout {{.download_timeout}};
+  
+  # Disable buffering for large blob transfers
+  # 
+  # proxy_buffering off: Stream responses directly from upstream to client
+  # instead of buffering entire response in nginx memory/disk. Critical for
+  # large container image layers (multi-GB) to avoid memory exhaustion and
+  # provide immediate streaming to clients.
+  #
+  # proxy_request_buffering off: Stream request body directly to upstream
+  # instead of buffering entire request. Enables immediate upload streaming
+  # for large image pushes without requiring disk space for temporary files.
+  #
+  # Without these settings, nginx would buffer entire blobs before forwarding,
+  # causing high memory usage, storage requirements, and delayed transfers.
+  proxy_buffering off;
+  proxy_request_buffering off;
+
   location / {
     proxy_pass http://{{.server}};
+
+	# Pass original client info
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  # Special handling for upload operations with longer timeout
+  location ~ ^/namespace/.*/blobs/.*/uploads {
+    proxy_pass http://{{.server}};
+    
+    # Use upload timeout for these operations
+    proxy_read_timeout {{.upload_timeout}};
+    proxy_send_timeout {{.upload_timeout}};
+    
+    # Pass original client info
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  # Replication operations with their own timeout
+  location ~ ^/namespace/.*/blobs/.*/remote {
+    proxy_pass http://{{.server}};
+    
+    # Use replication timeout for these operations
+    proxy_read_timeout {{.replication_timeout}};
+    proxy_send_timeout {{.replication_timeout}};
+    
+    # Pass original client info
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 }
 `

--- a/nginx/config/tracker.go
+++ b/nginx/config/tracker.go
@@ -43,6 +43,10 @@ server {
     proxy_cache_valid   200 5m;
     proxy_cache_valid   any 1s;
     proxy_cache_lock    on;
+
+	# Use metainfo timeout for these operations
+    proxy_read_timeout {{.metainfo_timeout}};
+    proxy_send_timeout {{.metainfo_timeout}};
   }
 }
 `

--- a/origin/blobserver/config.go
+++ b/origin/blobserver/config.go
@@ -33,5 +33,17 @@ func (c Config) applyDefaults() Config {
 	if c.DuplicateWriteBackStagger == 0 {
 		c.DuplicateWriteBackStagger = 30 * time.Minute
 	}
+	if c.DownloadTimeout == 0 {
+		c.DownloadTimeout = 15 * time.Minute
+	}
+	if c.UploadTimeout == 0 {
+		c.UploadTimeout = 10 * time.Minute
+	}
+	if c.ReplicationTimeout == 0 {
+		c.ReplicationTimeout = 3 * time.Minute
+	}
+	if c.BackendTimeout == 0 {
+		c.BackendTimeout = 2 * time.Minute
+	}
 	return c
 }

--- a/origin/blobserver/config.go
+++ b/origin/blobserver/config.go
@@ -23,6 +23,10 @@ import (
 type Config struct {
 	Listener                  listener.Config `yaml:"listener"`
 	DuplicateWriteBackStagger time.Duration   `yaml:"duplicate_write_back_stagger"`
+	DownloadTimeout           time.Duration   `yaml:"download_timeout"`
+	UploadTimeout             time.Duration   `yaml:"upload_timeout"`
+	ReplicationTimeout        time.Duration   `yaml:"replication_timeout"`
+	BackendTimeout            time.Duration   `yaml:"backend_timeout"`
 }
 
 func (c Config) applyDefaults() Config {

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -284,8 +284,12 @@ func Run(flags *Flags, opts ...Option) {
 	log.Fatal(nginx.Run(
 		config.Nginx,
 		map[string]interface{}{
-			"port":   flags.BlobServerPort,
-			"server": nginx.GetServer(config.BlobServer.Listener.Net, config.BlobServer.Listener.Addr),
+			"port":                flags.BlobServerPort,
+			"server":              nginx.GetServer(config.BlobServer.Listener.Net, config.BlobServer.Listener.Addr),
+			"download_timeout":    nginx.FormatDurationForNginx(config.BlobServer.DownloadTimeout),
+			"upload_timeout":      nginx.FormatDurationForNginx(config.BlobServer.UploadTimeout),
+			"backend_timeout":     nginx.FormatDurationForNginx(config.BlobServer.BackendTimeout),
+			"replication_timeout": nginx.FormatDurationForNginx(config.BlobServer.ReplicationTimeout),
 		},
 		nginx.WithTLS(config.TLS)))
 }

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -148,16 +148,15 @@ func Run(flags *Flags, opts ...Option) {
 	r := blobclient.NewClientResolver(blobclient.NewProvider(blobclient.WithTLS(tls)), origins)
 	originCluster := blobclient.NewClusterClient(r)
 
-	server := trackerserver.New(
-		config.TrackerServer, stats, policy, peerStore, originStore, originCluster)
+	server := trackerserver.New(config.TrackerServer, stats, policy, peerStore, originStore, originCluster)
 	go func() {
 		log.Fatal(server.ListenAndServe())
 	}()
 
 	log.Info("Starting nginx...")
 	log.Fatal(nginx.Run(config.Nginx, map[string]interface{}{
-		"port": flags.Port,
-		"server": nginx.GetServer(
-			config.TrackerServer.Listener.Net, config.TrackerServer.Listener.Addr)},
-		nginx.WithTLS(config.TLS)))
+		"port":             flags.Port,
+		"server":           nginx.GetServer(config.TrackerServer.Listener.Net, config.TrackerServer.Listener.Addr),
+		"metainfo_timeout": nginx.FormatDurationForNginx(config.TrackerServer.MetaInfoTimeout),
+	}, nginx.WithTLS(config.TLS)))
 }

--- a/tracker/trackerserver/config.go
+++ b/tracker/trackerserver/config.go
@@ -29,7 +29,8 @@ type Config struct {
 
 	AnnounceInterval time.Duration `yaml:"announce_interval"`
 
-	Listener listener.Config `yaml:"listener"`
+	Listener        listener.Config `yaml:"listener"`
+	MetaInfoTimeout time.Duration   `yaml:"metainfo_timeout"` // Timeout for metainfo requests to origins
 }
 
 func (c Config) applyDefaults() Config {
@@ -41,6 +42,9 @@ func (c Config) applyDefaults() Config {
 	}
 	if c.AnnounceInterval == 0 {
 		c.AnnounceInterval = 3 * time.Second
+	}
+	if c.MetaInfoTimeout == 0 {
+		c.MetaInfoTimeout = 2 * time.Minute
 	}
 	return c
 }


### PR DESCRIPTION
Adding possibility to propagate timeout settings for:
1. Download - agent and origin side
2. Upload - origin
3. Replication - origin
4. metainfo - tracker
