### PR TITLE
feat(lib/backend): add functionality to close clients

### DIFF
--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -144,6 +144,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Error creating backend manager: %s", err)
 	}
+	defer closers.Close(backends)
 
 	tls, err := config.TLS.BuildClient()
 	if err != nil {

--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -65,4 +65,7 @@ type Client interface {
 
 	// List lists entries whose names start with prefix.
 	List(prefix string, opts ...ListOption) (*ListResult, error)
+
+	// Close can be used to close any resources held by the client.
+	Close() error
 }

--- a/lib/backend/gcsbackend/client.go
+++ b/lib/backend/gcsbackend/client.go
@@ -74,6 +74,7 @@ type Client struct {
 	pather namepath.Pather
 	stats  tally.Scope
 	gcs    GCS
+	sClient *storage.Client
 }
 
 // Option allows setting optional Client parameters.
@@ -111,7 +112,7 @@ func NewClient(
 
 	if len(opts) > 0 {
 		// For mock.
-		client := &Client{config, pather, stats, nil}
+		client := &Client{config, pather, stats, nil, nil}
 		for _, opt := range opts {
 			opt(client)
 		}
@@ -126,7 +127,7 @@ func NewClient(
 	}
 
 	client := &Client{config, pather, stats,
-		NewGCS(ctx, sClient.Bucket(config.Bucket), &config)}
+		NewGCS(ctx, sClient.Bucket(config.Bucket), &config), sClient}
 
 	log.Infof("Initalized GCS backend with config: %s", config)
 	return client, nil
@@ -214,6 +215,10 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 		result.ContinuationToken = ""
 	}
 	return result, nil
+}
+
+func (c *Client) Close() error {
+	return c.sClient.Close()
 }
 
 // isObjectNotFound is helper function for identify non-existing object error.

--- a/lib/backend/hdfsbackend/client.go
+++ b/lib/backend/hdfsbackend/client.go
@@ -274,3 +274,9 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 		Names: files,
 	}, nil
 }
+
+// Close closes the client and releases any held resources.
+func (c *Client) Close() error {
+	// No resources to close for HDFS client
+	return nil
+}

--- a/lib/backend/httpbackend/http.go
+++ b/lib/backend/httpbackend/http.go
@@ -123,3 +123,9 @@ func (c *Client) Upload(namespace, name string, src io.Reader) error {
 func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }
+
+// Close closes the client and releases any held resources.
+func (c *Client) Close() error {
+	// No resources to close for http client
+	return nil
+}

--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -168,3 +168,16 @@ func (m *Manager) CheckReadiness() error {
 	}
 	return nil
 }
+
+func (m *Manager) Close() error {
+	totalErrors := make([]error, 0)
+	for _, b := range m.backends {
+		if err := b.client.Close(); err != nil {
+			totalErrors = append(totalErrors, fmt.Errorf("closing backend for namespace '%s': %s", b.regexp.String(), err))
+		}
+	}
+	if len(totalErrors) > 0 {
+		return fmt.Errorf("encountered errors closing backends: %v", totalErrors)
+	}
+	return nil
+}

--- a/lib/backend/noop.go
+++ b/lib/backend/noop.go
@@ -48,3 +48,9 @@ func (c NoopClient) Download(namespace, name string, dst io.Writer) error {
 func (c NoopClient) List(prefix string, opts ...ListOption) (*ListResult, error) {
 	return nil, nil
 }
+
+// Close closes the client and releases any held resources.
+func (c NoopClient) Close() error {
+	// No resources to close for noop client
+	return nil
+}

--- a/lib/backend/registrybackend/blobclient.go
+++ b/lib/backend/registrybackend/blobclient.go
@@ -164,3 +164,8 @@ func (c *BlobClient) Upload(namespace, name string, src io.Reader) error {
 func (c *BlobClient) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }
+
+func (c *BlobClient) Close() error {
+	// no resources to close
+	return nil
+}

--- a/lib/backend/registrybackend/tagclient.go
+++ b/lib/backend/registrybackend/tagclient.go
@@ -163,3 +163,8 @@ func (c *TagClient) Upload(namespace, name string, src io.Reader) error {
 func (c *TagClient) List(prefix string, opts ...backend.ListOption) (*backend.ListResult, error) {
 	return nil, errors.New("not supported")
 }
+
+func (c *TagClient) Close() error {
+	// no resources to close
+	return nil
+}

--- a/lib/backend/s3backend/client.go
+++ b/lib/backend/s3backend/client.go
@@ -301,3 +301,9 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 		ContinuationToken: nextContinuationToken,
 	}, nil
 }
+
+// Close closes the client and releases any held resources.
+func (c *Client) Close() error {
+	// No resources to close for S3 client
+	return nil
+}

--- a/lib/backend/shadowbackend/client.go
+++ b/lib/backend/shadowbackend/client.go
@@ -269,3 +269,21 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 	}
 	return res, nil
 }
+
+// Close closes the client and releases any held resources.
+func (c *Client) Close() error {
+	// Close both active and shadow clients
+	var activeErr, shadowErr error
+	if c.active != nil {
+		activeErr = c.active.Close()
+	}
+	if c.shadow != nil {
+		shadowErr = c.shadow.Close()
+	}
+
+	// Return the first error encountered, if any
+	if activeErr != nil {
+		return activeErr
+	}
+	return shadowErr
+}

--- a/lib/backend/sqlbackend/client.go
+++ b/lib/backend/sqlbackend/client.go
@@ -281,3 +281,8 @@ func dockerTagsQuery(c *Client, prefix string) (*backend.ListResult, error) {
 		Names: names,
 	}, nil
 }
+
+// Close closes the client and releases any held resources.
+func (c *Client) Close() error {
+	return c.db.Close()
+}

--- a/lib/backend/testfs/client.go
+++ b/lib/backend/testfs/client.go
@@ -167,3 +167,9 @@ func (c *Client) List(prefix string, opts ...backend.ListOption) (*backend.ListR
 		Names: names,
 	}, nil
 }
+
+// Close closes the client and releases any held resources.
+func (c *Client) Close() error {
+	// No resources to close for testfs client
+	return nil
+}

--- a/mocks/lib/backend/client.go
+++ b/mocks/lib/backend/client.go
@@ -13,30 +13,44 @@ import (
 	backend "github.com/uber/kraken/lib/backend"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Download mocks base method
+// Close mocks base method.
+func (m *MockClient) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockClientMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close))
+}
+
+// Download mocks base method.
 func (m *MockClient) Download(arg0, arg1 string, arg2 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Download", arg0, arg1, arg2)
@@ -44,13 +58,13 @@ func (m *MockClient) Download(arg0, arg1 string, arg2 io.Writer) error {
 	return ret0
 }
 
-// Download indicates an expected call of Download
+// Download indicates an expected call of Download.
 func (mr *MockClientMockRecorder) Download(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockClient)(nil).Download), arg0, arg1, arg2)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockClient) List(arg0 string, arg1 ...backend.ListOption) (*backend.ListResult, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -63,14 +77,14 @@ func (m *MockClient) List(arg0 string, arg1 ...backend.ListOption) (*backend.Lis
 	return ret0, ret1
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockClientMockRecorder) List(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
-// Stat mocks base method
+// Stat mocks base method.
 func (m *MockClient) Stat(arg0, arg1 string) (*core.BlobInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", arg0, arg1)
@@ -79,13 +93,13 @@ func (m *MockClient) Stat(arg0, arg1 string) (*core.BlobInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat
+// Stat indicates an expected call of Stat.
 func (mr *MockClientMockRecorder) Stat(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockClient)(nil).Stat), arg0, arg1)
 }
 
-// Upload mocks base method
+// Upload mocks base method.
 func (m *MockClient) Upload(arg0, arg1 string, arg2 io.Reader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upload", arg0, arg1, arg2)
@@ -93,7 +107,7 @@ func (m *MockClient) Upload(arg0, arg1 string, arg2 io.Reader) error {
 	return ret0
 }
 
-// Upload indicates an expected call of Upload
+// Upload indicates an expected call of Upload.
 func (mr *MockClientMockRecorder) Upload(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockClient)(nil).Upload), arg0, arg1, arg2)

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/kraken/nginx"
 	"github.com/uber/kraken/origin/blobclient"
 	"github.com/uber/kraken/origin/blobserver"
+	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/configutil"
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/log"
@@ -190,6 +191,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Error creating backend manager: %s", err)
 	}
+	defer closers.Close(backendManager)
 
 	localDB, err := localdb.New(config.LocalDB)
 	if err != nil {


### PR DESCRIPTION
### What?
This PR aims to add functionality to close the clients and it's resources in case the resources have closers.

### Why?
There are use cases in for gcsbacknd using `storage.transfermanager` to close the single downloader it creates. If we don't close it, there's a possibility of leaking resources.

### How?
Add `Close` to client interface and implement the method for each client.\
Then `backend.Manager` will use them to expose a `Close()` method that can be used by build-index and origin to close them.