### PR TITLE
fix(util): change error to debug level for closer

### DIFF
--- a/utils/closers/closer.go
+++ b/utils/closers/closer.go
@@ -13,7 +13,7 @@ func Close(closer io.Closer) {
 	if closer != nil {
 		err := closer.Close()
 		if err != nil {
-			log.Desugar().Error(
+			log.Desugar().Debug(
 				"failed to close a closer",
 				zap.Error(err),
 				zap.Stack("stack"),

--- a/utils/closers/closer_test.go
+++ b/utils/closers/closer_test.go
@@ -44,7 +44,7 @@ func TestClose_LogsError(t *testing.T) {
 		zapcore.NewCore(
 			zapcore.NewConsoleEncoder(zap.NewProductionEncoderConfig()),
 			zapcore.AddSync(&buf),
-			zapcore.ErrorLevel,
+			zapcore.DebugLevel,
 		),
 	).Sugar()
 	log.SetGlobalLogger(logger)


### PR DESCRIPTION
## What?
Change log level of `closer` to `DEBUG`from `ERROR`.

## Why?
Too much noise in logs for closer in error, leading in difficulty to debug other errors.

## How?
change log level