### PR TITLE
feat(proxyserver): Add PrefetchImage V2 API that is idempotent

### DIFF
--- a/proxy/proxyserver/server.go
+++ b/proxy/proxyserver/server.go
@@ -48,7 +48,7 @@ func New(
 	return &Server{
 		stats,
 		NewPreheatHandler(client, synchronous),
-		NewPrefetchHandler(client, tagClient, &DefaultTagParser{}, stats, synchronous, int64(config.PrefetchMinBlobSize), int64(config.PrefetchMaxBlobSize)),
+		NewPrefetchHandler(client, tagClient, &DefaultTagParser{}, stats, int64(config.PrefetchMinBlobSize), int64(config.PrefetchMaxBlobSize), synchronous),
 		config,
 	}
 }
@@ -63,7 +63,8 @@ func (s *Server) Handler() http.Handler {
 	r.Get("/health", handler.Wrap(s.healthHandler))
 
 	r.Post("/registry/notifications", handler.Wrap(s.preheatHandler.Handle))
-	r.Post("/proxy/v1/registry/prefetch", s.prefetchHandler.Handle)
+	r.Post("/proxy/v1/registry/prefetch", s.prefetchHandler.HandleV1)
+	r.Post("/proxy/v2/registry/prefetch", s.prefetchHandler.HandleV2)
 
 	// Serves /debug/pprof endpoints.
 	r.Mount("/", http.DefaultServeMux)


### PR DESCRIPTION
In #402 , a new PrefetchImage API was added to proxy, which prefetches the image in the origin cluster, preheating it to serve the image to the agents. This PR adds a PrefetchImage v2 API that is more efficient, lightweight, and mostly idempotent.

The main improvement is that to trigger the origins to cache the blobs, v1 *downloaded* the blobs from origin, transferring them over the network and then discarding them in proxy using `io.Discard`. Instead, v2 uses the newly added PrefetchBlob API in origin (#459), which triggers a prefetch in the origins without transferring that data from origin to proxy, saving network IO, disk IO in origin, CPU and mem in both origin and proxy.