### PR TITLE
feat(util/cache): add blob memory cache implementation

### DIFF
--- a/utils/cache/blob_memory_cache.go
+++ b/utils/cache/blob_memory_cache.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2016-2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/uber-go/tally"
+	"github.com/uber/kraken/core"
+)
+
+// MemoryEntry represents a blob stored in memory cache.
+type MemoryEntry struct {
+	Name      string
+	Data      []byte
+	MetaInfo  *core.MetaInfo
+	Size      int64
+	CreatedAt time.Time
+}
+
+// BlobMemoryCacheConfig defines configuration for BlobMemoryCache.
+type BlobMemoryCacheConfig struct {
+	MaxSize int64 // Maximum memory in bytes
+}
+
+// BlobMemoryCache provides a simple in-memory cache for blob data with capacity management.
+// It uses RWMutex for optimal concurrent access patterns.
+type BlobMemoryCache struct {
+	config BlobMemoryCacheConfig
+	stats  tally.Scope
+
+	// Storage
+	mu        sync.RWMutex
+	entries   map[string]*MemoryEntry
+	totalSize int64
+}
+
+// NewBlobMemoryCache creates a new BlobMemoryCache with the specified configuration.
+func NewBlobMemoryCache(
+	config BlobMemoryCacheConfig,
+	stats tally.Scope,
+) *BlobMemoryCache {
+	return &BlobMemoryCache{
+		config:  config,
+		stats:   stats.Tagged(map[string]string{"component": "blob_memory_cache"}),
+		entries: make(map[string]*MemoryEntry),
+	}
+}
+
+// Add attempts to add an entry to the memory cache.
+// Returns true if successfully added, false if insufficient space.
+// This operation uses a write lock for exclusive access.
+func (c *BlobMemoryCache) Add(entry *MemoryEntry) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check if already exists
+	if _, exists := c.entries[entry.Name]; exists {
+		return true, nil // Already in cache, success
+	}
+
+	// Check capacity
+	if c.totalSize+entry.Size > c.config.MaxSize {
+		return false, nil // Not enough space, return
+	}
+
+	// Add to cache
+	c.entries[entry.Name] = entry
+	c.totalSize += entry.Size
+
+	c.stats.Counter("entries_added").Inc(1)
+	c.stats.Gauge("total_size_bytes").Update(float64(c.totalSize))
+
+	return true, nil
+}
+
+// Get retrieves an entry from the memory cache.
+// Returns nil if not present.
+// This operation uses a read lock, allowing concurrent access.
+func (c *BlobMemoryCache) Get(name string) *MemoryEntry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, exists := c.entries[name]
+	if !exists {
+		return nil
+	}
+
+	c.stats.Counter("get_hit").Inc(1)
+	return entry
+}
+
+// Remove removes an entry from the memory cache.
+// No-op if entry is not present.
+// This operation uses a write lock for exclusive access.
+func (c *BlobMemoryCache) Remove(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, exists := c.entries[name]
+	if !exists {
+		return // No-op
+	}
+
+	delete(c.entries, name)
+	c.totalSize -= entry.Size
+
+	c.stats.Gauge("total_size_bytes").Update(float64(c.totalSize))
+}
+
+// Size returns the current number of entries in the cache.
+func (c *BlobMemoryCache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+// TotalBytes returns the current total size in bytes.
+func (c *BlobMemoryCache) TotalBytes() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.totalSize
+}

--- a/utils/cache/blob_memory_cache_test.go
+++ b/utils/cache/blob_memory_cache_test.go
@@ -1,0 +1,429 @@
+// Copyright (c) 2016-2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"github.com/uber/kraken/core"
+)
+
+func TestBlobMemoryCache_Add_Success(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	entry := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 500),
+		Size:      500,
+		CreatedAt: time.Now(),
+	}
+
+	added, err := cache.Add(entry)
+
+	require.NoError(t, err)
+	assert.True(t, added)
+	assert.Equal(t, int64(500), cache.TotalBytes())
+	assert.Equal(t, 1, cache.Size())
+}
+
+func TestBlobMemoryCache_Add_InsufficientSpace(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	entry := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 1500),
+		Size:      1500,
+		CreatedAt: time.Now(),
+	}
+
+	added, err := cache.Add(entry)
+
+	require.NoError(t, err)
+	assert.False(t, added, "Should return false when insufficient space")
+	assert.Equal(t, int64(0), cache.TotalBytes())
+	assert.Equal(t, 0, cache.Size())
+}
+
+func TestBlobMemoryCache_Add_AlreadyExists(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 2000},
+		tally.NoopScope,
+	)
+
+	entry1 := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 500),
+		Size:      500,
+		CreatedAt: time.Now(),
+	}
+
+	// Add first time
+	added, err := cache.Add(entry1)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	// Add again - should return true without adding duplicate
+	entry2 := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 500),
+		Size:      500,
+		CreatedAt: time.Now(),
+	}
+
+	added, err = cache.Add(entry2)
+	require.NoError(t, err)
+	assert.True(t, added, "Should return true when entry already exists")
+	assert.Equal(t, int64(500), cache.TotalBytes(), "Size should not change")
+	assert.Equal(t, 1, cache.Size(), "Should still have only 1 entry")
+}
+
+func TestBlobMemoryCache_Add_MultipleBlobs(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 2000},
+		tally.NoopScope,
+	)
+
+	// Add multiple blobs
+	for i := 0; i < 3; i++ {
+		entry := &MemoryEntry{
+			Name:      fmt.Sprintf("blob%d", i),
+			Data:      make([]byte, 500),
+			Size:      500,
+			CreatedAt: time.Now(),
+		}
+
+		added, err := cache.Add(entry)
+		require.NoError(t, err)
+		assert.True(t, added)
+	}
+
+	assert.Equal(t, int64(1500), cache.TotalBytes())
+	assert.Equal(t, 3, cache.Size())
+
+	// Try to add one more that exceeds capacity
+	entry := &MemoryEntry{
+		Name:      "blob4",
+		Data:      make([]byte, 600),
+		Size:      600,
+		CreatedAt: time.Now(),
+	}
+
+	added, err := cache.Add(entry)
+	require.NoError(t, err)
+	assert.False(t, added, "Should fail when total would exceed capacity")
+	assert.Equal(t, int64(1500), cache.TotalBytes(), "Size should not change")
+	assert.Equal(t, 3, cache.Size())
+}
+
+func TestBlobMemoryCache_Get_Hit(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	data := []byte("test data")
+	entry := &MemoryEntry{
+		Name:      "blob1",
+		Data:      data,
+		Size:      int64(len(data)),
+		CreatedAt: time.Now(),
+	}
+	_, err := cache.Add(entry)
+	require.NoError(t, err)
+
+	result := cache.Get("blob1")
+
+	require.NotNil(t, result)
+	assert.Equal(t, "blob1", result.Name)
+	assert.Equal(t, data, result.Data)
+	assert.Equal(t, int64(len(data)), result.Size)
+}
+
+func TestBlobMemoryCache_Get_Miss(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	result := cache.Get("nonexistent")
+
+	assert.Nil(t, result)
+}
+
+func TestBlobMemoryCache_Get_WithMetaInfo(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	digest := core.DigestFixture()
+	metaInfo := core.MetaInfoFixture()
+	entry := &MemoryEntry{
+		Name:      digest.Hex(),
+		Data:      []byte("test data"),
+		MetaInfo:  metaInfo,
+		Size:      9,
+		CreatedAt: time.Now(),
+	}
+	_, err := cache.Add(entry)
+	require.NoError(t, err)
+
+	result := cache.Get(digest.Hex())
+
+	require.NotNil(t, result)
+	assert.Equal(t, metaInfo, result.MetaInfo)
+}
+
+func TestBlobMemoryCache_Remove(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	entry := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 500),
+		Size:      500,
+		CreatedAt: time.Now(),
+	}
+	_, err := cache.Add(entry)
+	require.NoError(t, err)
+
+	cache.Remove("blob1")
+
+	assert.Nil(t, cache.Get("blob1"))
+	assert.Equal(t, int64(0), cache.TotalBytes())
+	assert.Equal(t, 0, cache.Size())
+}
+
+func TestBlobMemoryCache_Remove_NonExistent(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	// Should not panic or error
+	cache.Remove("nonexistent")
+
+	assert.Equal(t, int64(0), cache.TotalBytes())
+	assert.Equal(t, 0, cache.Size())
+}
+
+func TestBlobMemoryCache_Remove_AllowsReAdd(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	entry1 := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 600),
+		Size:      600,
+		CreatedAt: time.Now(),
+	}
+	added, err := cache.Add(entry1)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	// Try to add another blob - should fail due to capacity
+	entry2 := &MemoryEntry{
+		Name:      "blob2",
+		Data:      make([]byte, 500),
+		Size:      500,
+		CreatedAt: time.Now(),
+	}
+	added, err = cache.Add(entry2)
+	require.NoError(t, err)
+	assert.False(t, added)
+
+	// Remove first blob
+	cache.Remove("blob1")
+
+	// Now second blob should fit
+	added, err = cache.Add(entry2)
+	require.NoError(t, err)
+	assert.True(t, added)
+	assert.Equal(t, int64(500), cache.TotalBytes())
+}
+
+func TestBlobMemoryCache_ConcurrentAdd(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 100000},
+		tally.NoopScope,
+	)
+
+	var wg sync.WaitGroup
+	numGoroutines := 50
+	entriesPerGoroutine := 10
+
+	// Concurrent adds
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < entriesPerGoroutine; j++ {
+				entry := &MemoryEntry{
+					Name:      fmt.Sprintf("blob-%d-%d", id, j),
+					Data:      make([]byte, 100),
+					Size:      100,
+					CreatedAt: time.Now(),
+				}
+				_, err := cache.Add(entry)
+				require.NoError(t, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All entries should be added (no race conditions)
+	assert.Equal(t, numGoroutines*entriesPerGoroutine, cache.Size())
+	assert.Equal(t, int64(numGoroutines*entriesPerGoroutine*100), cache.TotalBytes())
+}
+
+func TestBlobMemoryCache_ConcurrentReadWrite(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 10000},
+		tally.NoopScope,
+	)
+
+	// Pre-populate cache
+	for i := 0; i < 10; i++ {
+		entry := &MemoryEntry{
+			Name:      fmt.Sprintf("blob%d", i),
+			Data:      make([]byte, 100),
+			Size:      100,
+			CreatedAt: time.Now(),
+		}
+		_, err := cache.Add(entry)
+		require.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+
+	// Concurrent reads
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				cache.Get(fmt.Sprintf("blob%d", id))
+			}
+		}(i)
+	}
+
+	// Concurrent writes
+	for i := 10; i < 20; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			entry := &MemoryEntry{
+				Name:      fmt.Sprintf("blob%d", id),
+				Data:      make([]byte, 100),
+				Size:      100,
+				CreatedAt: time.Now(),
+			}
+			_, err := cache.Add(entry)
+			require.NoError(t, err)
+		}(i)
+	}
+
+	// Concurrent removes
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			cache.Remove(fmt.Sprintf("blob%d", id))
+		}(i)
+	}
+
+	wg.Wait()
+	// No race conditions, test passes
+}
+
+func TestBlobMemoryCache_SizeAndTotalBytes(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 5000},
+		tally.NoopScope,
+	)
+
+	entries := []*MemoryEntry{
+		{Name: "blob1", Data: make([]byte, 100), Size: 100},
+		{Name: "blob2", Data: make([]byte, 200), Size: 200},
+		{Name: "blob3", Data: make([]byte, 300), Size: 300},
+	}
+
+	for _, entry := range entries {
+		_, err := cache.Add(entry)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 3, cache.Size())
+	assert.Equal(t, int64(600), cache.TotalBytes())
+
+	cache.Remove("blob2")
+
+	assert.Equal(t, 2, cache.Size())
+	assert.Equal(t, int64(400), cache.TotalBytes())
+}
+
+func TestBlobMemoryCache_ZeroMaxSize(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 0},
+		tally.NoopScope,
+	)
+
+	entry := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 100),
+		Size:      100,
+		CreatedAt: time.Now(),
+	}
+
+	added, err := cache.Add(entry)
+	require.NoError(t, err)
+	assert.False(t, added, "Should not add when max size is 0")
+}
+
+func TestBlobMemoryCache_ExactCapacity(t *testing.T) {
+	cache := NewBlobMemoryCache(
+		BlobMemoryCacheConfig{MaxSize: 1000},
+		tally.NoopScope,
+	)
+
+	entry := &MemoryEntry{
+		Name:      "blob1",
+		Data:      make([]byte, 1000),
+		Size:      1000,
+		CreatedAt: time.Now(),
+	}
+
+	added, err := cache.Add(entry)
+	require.NoError(t, err)
+	assert.True(t, added, "Should add when exactly at capacity")
+	assert.Equal(t, int64(1000), cache.TotalBytes())
+}


### PR DESCRIPTION
## What?
Add a new in-memory cache implementation `BlobMemoryCache` that can cache blobs into memory.

## Why?
This is first PR for a multi-part implementation of adding a write-though cache for kraken-origin. This cache implementation creates an in-memory map which can store blobs in memory upto the max size. If the blob can't be added (memory is full), return error

## Observability
3 new metrics are also introduced:
1. `get_hit`: cache's get hit count
2. `total_size_bytes`: total size of the cache in bytes
3. `entried_added`: count of entries added in the cache