### PR TITLE
feat(utils/cache): add method to reserve cache space

### DIFF
--- a/lib/store/ca_store_test.go
+++ b/lib/store/ca_store_test.go
@@ -225,7 +225,7 @@ func TestCAStoreConfig_WithMemoryCache(t *testing.T) {
 	config, cleanup := CAStoreConfigFixture()
 	defer cleanup()
 
-	require.Equal(int64(0), config.MemoryCache.MaxSize)
+	require.Equal(uint64(0), config.MemoryCache.MaxSize)
 	require.Equal(0, config.MemoryCache.DrainWorkers)
 	require.Equal(0, config.MemoryCache.DrainMaxRetries)
 	require.Equal(time.Duration(0), config.MemoryCache.TTLInterval)
@@ -333,8 +333,7 @@ func TestCAStore_TTLCleanup(t *testing.T) {
 				Data:      []byte("test data"),
 				CreatedAt: now.Add(-tt.entryAge),
 			}
-			added, err := s.memCache.Add(entry)
-			require.NoError(t, err)
+			added := s.memCache.Add(entry)
 			require.True(t, added)
 
 			s.cleanupMemoryCacheExpiredEntries()

--- a/lib/store/config.go
+++ b/lib/store/config.go
@@ -28,7 +28,7 @@ type Volume struct {
 // MemoryCacheConfig defines memory cache configuration.
 type MemoryCacheConfig struct {
 	Enabled         bool          `yaml:"enabled"`
-	MaxSize         int64         `yaml:"max_size"`
+	MaxSize         uint64        `yaml:"max_size"`
 	DrainWorkers    int           `yaml:"drain_workers"`
 	DrainMaxRetries int           `yaml:"drain_max_retries"`
 	TTL             time.Duration `yaml:"ttl"`


### PR DESCRIPTION
## What?
Add methods to reserve space in cache before adding to cache

## Why?
Since there are strict memory constraints for the in-memory cache in CAStore, if we don't reserve the space first and ask the downloader to download to memory directly, we risk at facing OOM issues. To prevent this, the cache implementation can provide a method to try to reserve space in it and release it when the element is successfully added.

## How?
Use totalSize and implement 2 new functions for reserving and free. Also update Add function