### PR TITLE
feat(lib): use in-memory cache in blob download

### DIFF
--- a/lib/metainfogen/generator.go
+++ b/lib/metainfogen/generator.go
@@ -59,6 +59,11 @@ func (g *Generator) Generate(d core.Digest) error {
 	return nil
 }
 
+// Get the piece length for the blob
+func (g *Generator) GetPieceLength(size int64) int64 {
+	return g.pieceLengthConfig.get(size)
+}
+
 // GenerateFromBuffer generates metainfo from the buffer
 func (g *Generator) GenerateFromBuffer(name string, data []byte) (*core.MetaInfo, error) {
 	digest, err := core.NewSHA256DigestFromHex(name)

--- a/lib/store/base/buffer_readwriter.go
+++ b/lib/store/base/buffer_readwriter.go
@@ -130,3 +130,8 @@ func (b *BufferReadWriter) Cancel() error {
 func (b *BufferReadWriter) Commit() error {
 	return nil
 }
+
+// Bytes returns the full buffer
+func (b *BufferReadWriter) Bytes() []byte {
+	return b.buf.Bytes()
+}


### PR DESCRIPTION
## What?
Start using the in-memory cache in the download path.

## Why?
As part of implementing an in-mem cache in kraken.

## How?
Use the in-mem cache that was initialised in #473 to try to first download to the cache, and if not possible failback to disk.
This implementation also makes sure we try to reserve space in the cache before we try to download anything in the cach. This is done to avoid OOM issues when the cache is full. 
The metainfo is generated by using the method that is exposed in #474 in memory and it is stored in cache itself.
