### PR TITLE
feat(lib/store): implement drain workers in castore

### DIFF
--- a/lib/store/fixtures.go
+++ b/lib/store/fixtures.go
@@ -16,6 +16,7 @@ package store
 import (
 	"os"
 
+	"github.com/andres-erbsen/clock"
 	"github.com/uber/kraken/utils/testutil"
 
 	"github.com/uber-go/tally"
@@ -54,6 +55,22 @@ func CAStoreFixture() (*CAStore, func()) {
 	cleanup.Add(c)
 
 	s, err := NewCAStore(config, tally.NoopScope)
+	if err != nil {
+		panic(err)
+	}
+	cleanup.Add(s.Close)
+
+	return s, cleanup.Run
+}
+
+// CAStoreFixtureWithClock returns a CAStore with a custom clock for testing purposes.
+// This is useful for tests that need to control time, such as preventing automatic
+// drain operations in memory cache tests.
+func CAStoreFixtureWithClock(config CAStoreConfig, clk clock.Clock) (*CAStore, func()) {
+	var cleanup testutil.Cleanup
+	defer cleanup.Recover()
+
+	s, err := newCAStore(config, tally.NoopScope, clk)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## What?
Implement drain workers that drain the memcache element into the disk.

## Why?
The in-mem cache was added in the download path in #477. Since now it is populating the cache, this PR aims to implement the drain mechanism which is intended to start draining the entry in-mem cache to disk

## How?
Start n drain workers (configured with `drain_workers` config, each worker will pickup items from `drainQueue`, try to write the blob and the metainfo to disk. The entry is re-added into the queue if there are failures, eventually stopping re-adding which is specified by `drain_max_retry` config.
As soon as the entry is successfully drained to the disk, the empty is removed from the in-mem cache.