### PR TITLE
feat(lib/store): integrate memcache in read paths

### DIFF
--- a/lib/store/metadata/torrentmeta.go
+++ b/lib/store/metadata/torrentmeta.go
@@ -65,3 +65,7 @@ func (m *TorrentMeta) Deserialize(b []byte) error {
 	m.MetaInfo = mi
 	return nil
 }
+
+func GetTorrentMetadataSuffix() string {
+	return _torrentMetaSuffix
+}

--- a/utils/cache/blob_memory_cache.go
+++ b/utils/cache/blob_memory_cache.go
@@ -196,3 +196,15 @@ func (c *BlobMemoryCache) RemoveBatch(names []string) {
 	}
 	c.stats.Gauge("total_size_bytes").Update(float64(c.totalSize))
 }
+
+// ListNames returns all entry names in the cache.
+func (c *BlobMemoryCache) ListNames() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	names := make([]string, 0, len(c.entries))
+	for name := range c.entries {
+		names = append(names, name)
+	}
+	return names
+}


### PR DESCRIPTION
## What?
Add all the read disk cache paths to first check in in-mem cache

## Why?
After https://github.com/uber/kraken/pull/477 and #478 , the download path is covered by the in-mem cache. Now while the entry is being drained to disk, the blob and it's metainfo can be served from the cache. This ensures we don't loose availability of blobs. This PR aims to integrate the in-mem cache in all the read paths.

## How?
Override mainly  methods
1. GetCacheFileReader
2. GetCacheMetadata
3. GetFileStat
4. ListBlobs