### PR TITLE
test(test): add integ tests for mem cache

### DIFF
--- a/config/origin/base.yaml
+++ b/config/origin/base.yaml
@@ -33,16 +33,18 @@ scheduler:
   torrentlog:
     disable: true
 
-metrics:
-  m3:
-    service: kraken-origin
-
 localdb:
   source: /var/cache/kraken/kraken-origin/origin.db
 
 castore:
   upload_dir: /var/cache/kraken/kraken-origin/upload/
   cache_dir:  /var/cache/kraken/kraken-origin/cache/
+  memory_cache:
+    enabled: true
+    max_size: 1048576
+    ttl: 2s
+    drain_workers: 2
+    drain_max_retries: 3
 
 blobserver:
   listener:

--- a/config/origin/test.template
+++ b/config/origin/test.template
@@ -25,6 +25,12 @@ writeback:
   retry_interval: 100ms
   poll_retries_interval: 250ms
 
+metrics:
+  backend: statsd
+  statsd:
+    host_port: {statsd_host_port}
+    prefix: kraken.origin
+
 tls:
   name: kraken
   cas:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,3 +2,4 @@ pytest>=7.0.0
 pytest-timeout>=2.1.0
 requests>=2.31.0
 setuptools>=69.0.0
+polling2>=0.5.0

--- a/test/python/components.py
+++ b/test/python/components.py
@@ -363,18 +363,24 @@ class Origin(Component):
         def addr(self):
             return '{}:{}'.format(self.hostname, self.port)
 
-    def __init__(self, zone, instances, name, testfs):
+    def __init__(self, zone, instances, name, testfs, statsd_host_port=None):
         self.zone = zone
         self.instance = instances[name]
         self.testfs = testfs
         self.config_file = 'test-{zone}.yaml'.format(zone=zone)
         self.name = '{name}-{zone}'.format(name=self.instance.name, zone=zone)
 
+        if statsd_host_port is None:
+            statsd_host_port = '{bridge}:{port}'.format(
+                bridge=get_docker_bridge(),
+                port=find_free_port())
+
         populate_config_template(
             'origin',
             self.config_file,
             origins=yaml_list([i.addr for i in instances.values()]),
-            testfs=self.testfs.addr)
+            testfs=self.testfs.addr,
+            statsd_host_port=statsd_host_port)
 
         self.volumes = create_volumes('origin', self.name)
 

--- a/test/python/test_memory_cache.py
+++ b/test/python/test_memory_cache.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2016-2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for memory cache feature in origin servers."""
+from __future__ import absolute_import
+
+import hashlib
+import os
+
+import polling2
+import requests
+
+
+def _generate_blob(size_bytes=1024):
+    """Generate a test blob of specified size."""
+    blob = os.urandom(size_bytes)
+    name = hashlib.sha256(blob).hexdigest()
+    return name, blob
+
+
+def _get_metric_value(statsd_port, metric_name):
+    """Fetch a specific metric value from statsd_exporter metrics endpoint."""
+    url = 'http://localhost:{port}/metrics'.format(port=statsd_port)
+    try:
+        res = requests.get(url)
+        res.raise_for_status()
+        metrics_text = res.text
+
+        # Metric names in tally with tags are formatted as:
+        # prefix.component_tag.metric_name -> kraken_origin_blob_memory_cache_entries_added
+        # StatsD converts dots to underscores
+        full_metric_name = 'kraken_origin_blob_memory_cache_{}'.format(metric_name)
+
+        for line in metrics_text.split('\n'):
+            if line.startswith('#'):
+                continue
+            if full_metric_name in line:
+                parts = line.split()
+                if len(parts) >= 2:
+                    try:
+                        return float(parts[1])
+                    except ValueError:
+                        continue
+
+        return 0.0
+    except Exception as e:
+        return 0.0
+
+
+def test_memory_cache_write_and_read(origin_cluster, statsd_exporter, agent):
+    """Test that blobs downloaded from backend are cached in memory and served from cache."""
+    http_port, statsd_port = statsd_exporter
+
+    name, blob = _generate_blob(size_bytes=10 * 1024)
+
+    testfs = origin_cluster.origins[0].testfs
+
+    initial_entries_added = _get_metric_value(http_port, 'entries_added')
+    initial_get_hits = _get_metric_value(http_port, 'get_hit')
+
+    testfs.upload(name, blob)
+
+    agent.download(name, blob)
+
+    # Poll until entries_added metric increases
+    polling2.poll(
+        lambda: _get_metric_value(http_port, 'entries_added') > initial_entries_added,
+        step=0.2,
+        timeout=5
+    )
+
+    agent.download(name, blob)
+
+    # Poll until get_hit metric increases
+    polling2.poll(
+        lambda: _get_metric_value(http_port, 'get_hit') > initial_get_hits,
+        step=0.2,
+        timeout=5
+    )
+
+
+def test_memory_cache_drain_to_disk(origin_cluster, statsd_exporter, agent):
+    """Test that blobs in memory cache are asynchronously drained to disk."""
+    http_port, _ = statsd_exporter
+
+    name, blob = _generate_blob(size_bytes=10 * 1024)
+
+    testfs = origin_cluster.origins[0].testfs
+
+    testfs.upload(name, blob)
+
+    # Record initial metrics
+    initial_entries = _get_metric_value(http_port, 'entries_added')
+
+    agent.download(name, blob)
+
+    # Poll until blob is added to memory cache
+    polling2.poll(
+        lambda: _get_metric_value(http_port, 'entries_added') > initial_entries,
+        step=0.2,
+        timeout=5
+    )
+
+    # Poll until blob is drained to disk (total_size_bytes becomes 0)
+    polling2.poll(
+        lambda: _get_metric_value(http_port, 'total_size_bytes') == 0,
+        step=0.2,
+        timeout=10
+    )
+
+    # Verify we can still download it (should come from disk now)
+    agent.download(name, blob)
+
+
+def test_memory_cache_large_blob_fallback(origin_cluster, statsd_exporter, agent):
+    """Test that blobs larger than memory cache capacity fallback to disk."""
+    http_port, _ = statsd_exporter
+
+    name, blob = _generate_blob(size_bytes=2 * 1024 * 1024)
+
+    testfs = origin_cluster.origins[0].testfs
+
+    initial_entries_added = _get_metric_value(http_port, 'entries_added')
+
+    testfs.upload(name, blob)
+
+    agent.download(name, blob)
+
+
+    try:
+        polling2.poll(
+            lambda: _get_metric_value(http_port, 'entries_added') > initial_entries_added,
+            step=0.2,
+            timeout=2
+        )
+        assert False, "Large blob should NOT be cached in memory"
+    except polling2.TimeoutException:
+        pass
+
+
+def test_memory_cache_ttl_expiration(origin_cluster, statsd_exporter, agent):
+    """Test that blobs are removed from memory cache after TTL expires."""
+    http_port, _ = statsd_exporter
+
+    name, blob = _generate_blob(size_bytes=5 * 1024)
+
+    testfs = origin_cluster.origins[0].testfs
+
+    testfs.upload(name, blob)
+
+    # Record initial metrics
+    initial_entries = _get_metric_value(http_port, 'entries_added')
+
+    agent.download(name, blob)
+
+    # Poll until blob is added to memory cache
+    polling2.poll(
+        lambda: _get_metric_value(http_port, 'entries_added') > initial_entries,
+        step=0.2,
+        timeout=5
+    )
+
+    # Poll until blob is removed from memory (TTL is 2s)
+    polling2.poll(
+        lambda: _get_metric_value(http_port, 'total_size_bytes') == 0,
+        step=0.2,
+        timeout=5
+    )
+
+    # Verify we can still download it
+    agent.download(name, blob)


### PR DESCRIPTION
## What?
This PR implements the python integration tests with mem cache enabled in origin.

## Why?
This is to ensure we don't lose our current functionalities and we increase our integration test code coverage.

## How?
Update config, exports statsd for metrics and write overall  new integ tests