### PR TITLE
fix(ci): allow CI to run for non-master branch PRs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
 
 env:
   GO_VERSION: '1.23'


### PR DESCRIPTION
## What?
Allow CI to be run when PR is raised towards any branch

## Why?
This helps in stacked PRs, since it is not running currently

## How?
add `'**'` in `pull_request` section