### PR TITLE
fix(.github/labeler): improve labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Label the PR size
     steps:
-      - uses: codelytv/pr-size-labeler@v1
+      - uses: codelytv/pr-size-labeler@v1.10.3
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           s_label: 'size/s'
           s_max_size: '10'
           m_label: 'size/m'
@@ -20,7 +21,7 @@ jobs:
           l_label: 'size/l'
           l_max_size: '150'
           xl_label: 'size/xl'
-          fail_if_xl: 'true'
+          fail_if_xl: 'false'
           message_if_xl: >
             This PR exceeds the recommended size of 150 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
@@ -28,5 +29,4 @@ jobs:
           github_api_url: 'https://api.github.com'
           ignore_file_deletions: 'true'
           ignore_line_deletions: 'true'
-          files_to_ignore: ''
-
+          files_to_ignore: '**/*_test.go'


### PR DESCRIPTION
## What?
Improve labeler

## Why?
Currently the labeler brings noise, it has very low limits. It counts the test files and it fails if the PR is xl represeting something wrong in action rather than PR. Also, since it fails immediately, it doesn't post the comment intended.
Since, we are not blocking PRs on the size, we should let it just comment.

## How?
1. add GITHUB_TOKEN to add comment
2. make fail_if_xl = false
3. ignore go test files since they are always long and shouldn't count in PR length count.