### PR TITLE
feat: Add ctx to the origin prefetch client

### DIFF
--- a/mocks/origin/blobclient/client.go
+++ b/mocks/origin/blobclient/client.go
@@ -187,17 +187,17 @@ func (mr *MockClientMockRecorder) OverwriteMetaInfo(d, pieceLength any) *gomock.
 }
 
 // PrefetchBlob mocks base method.
-func (m *MockClient) PrefetchBlob(namespace string, d core.Digest) error {
+func (m *MockClient) PrefetchBlob(ctx context.Context, namespace string, d core.Digest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrefetchBlob", namespace, d)
+	ret := m.ctrl.Call(m, "PrefetchBlob", ctx, namespace, d)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PrefetchBlob indicates an expected call of PrefetchBlob.
-func (mr *MockClientMockRecorder) PrefetchBlob(namespace, d any) *gomock.Call {
+func (mr *MockClientMockRecorder) PrefetchBlob(ctx, namespace, d any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchBlob", reflect.TypeOf((*MockClient)(nil).PrefetchBlob), namespace, d)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchBlob", reflect.TypeOf((*MockClient)(nil).PrefetchBlob), ctx, namespace, d)
 }
 
 // ReplicateToRemote mocks base method.

--- a/mocks/origin/blobclient/clusterclient.go
+++ b/mocks/origin/blobclient/clusterclient.go
@@ -115,17 +115,17 @@ func (mr *MockClusterClientMockRecorder) Owners(d any) *gomock.Call {
 }
 
 // PrefetchBlob mocks base method.
-func (m *MockClusterClient) PrefetchBlob(namespace string, d core.Digest) error {
+func (m *MockClusterClient) PrefetchBlob(ctx context.Context, namespace string, d core.Digest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrefetchBlob", namespace, d)
+	ret := m.ctrl.Call(m, "PrefetchBlob", ctx, namespace, d)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PrefetchBlob indicates an expected call of PrefetchBlob.
-func (mr *MockClusterClientMockRecorder) PrefetchBlob(namespace, d any) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) PrefetchBlob(ctx, namespace, d any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchBlob", reflect.TypeOf((*MockClusterClient)(nil).PrefetchBlob), namespace, d)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchBlob", reflect.TypeOf((*MockClusterClient)(nil).PrefetchBlob), ctx, namespace, d)
 }
 
 // ReplicateToRemote mocks base method.

--- a/origin/blobserver/server_test.go
+++ b/origin/blobserver/server_test.go
@@ -209,7 +209,7 @@ func TestPrefetchHandler(t *testing.T) {
 
 	ensureHasBlob(t, cp.Provide(s.host), namespace, blob)
 
-	err := cp.Provide(master1).PrefetchBlob(namespace, blob.Digest)
+	err := cp.Provide(master1).PrefetchBlob(context.Background(), namespace, blob.Digest)
 	require.NoError(err)
 }
 

--- a/proxy/proxyserver/prefetch.go
+++ b/proxy/proxyserver/prefetch.go
@@ -476,8 +476,6 @@ func (ph *PrefetchHandler) triggerPrefetchBlobs(input *prefetchInput) error {
 	)
 	defer span.End()
 
-	_ = ctx // PrefetchBlob doesn't accept context yet
-
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errList []error
@@ -490,7 +488,7 @@ func (ph *PrefetchHandler) triggerPrefetchBlobs(input *prefetchInput) error {
 		wg.Add(1)
 		go func(digest core.Digest) {
 			defer wg.Done()
-			err := ph.clusterClient.PrefetchBlob(input.namespace, digest)
+			err := ph.clusterClient.PrefetchBlob(ctx, input.namespace, digest)
 			if err != nil {
 				mu.Lock()
 				errList = append(errList, fmt.Errorf("digest %q, namespace %q, blob prefetch failure: %w", digest, input.namespace, err))

--- a/proxy/proxyserver/server_test.go
+++ b/proxy/proxyserver/server_test.go
@@ -234,8 +234,8 @@ func TestPrefetchV2(t *testing.T) {
 	mocks.tagClient.EXPECT().Get(tagRequest).Return(manifest, nil)
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, manifest, mockutil.MatchWriter(bs)).Return(nil)
 
-	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[1]).Return(nil)
-	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[2]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(gomock.Any(), namespace, layers[1]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(gomock.Any(), namespace, layers[2]).Return(nil)
 	res, err := httputil.Post(
 		fmt.Sprintf("http://%s/proxy/v2/registry/prefetch", addr),
 		httputil.SendBody(bytes.NewReader(b)))
@@ -278,8 +278,8 @@ func TestPrefetchV2OriginError(t *testing.T) {
 	mocks.tagClient.EXPECT().Get(tagRequest).Return(manifest, nil)
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, manifest, mockutil.MatchWriter(bs)).Return(nil)
 
-	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[1]).Return(errors.New("foo err"))
-	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[2]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(gomock.Any(), namespace, layers[1]).Return(errors.New("foo err"))
+	mocks.originClient.EXPECT().PrefetchBlob(gomock.Any(), namespace, layers[2]).Return(nil)
 	_, err := httputil.Post(
 		fmt.Sprintf("http://%s/proxy/v2/registry/prefetch", addr),
 		httputil.SendBody(bytes.NewReader(b)))


### PR DESCRIPTION
This PR adds context support to the PrefetchBlob method across the origin blob client infrastructure, enabling proper distributed tracing and request cancellation for blob prefetching operations.

Changes:

Updated PrefetchBlob interface signatures to accept context.Context as the first parameter
Added comprehensive OpenTelemetry tracing instrumentation to prefetch operations
Updated all call sites and tests to pass context appropriately
