### PR TITLE
feat: Tracing agent -> tracker -> origin

### DIFF
--- a/lib/torrent/scheduler/events_test.go
+++ b/lib/torrent/scheduler/events_test.go
@@ -120,7 +120,7 @@ func (m *stateMocks) newTorrent() storage.Torrent {
 	mi := core.MetaInfoFixture()
 
 	m.metainfoClient.EXPECT().
-		Download(_testNamespace, mi.Digest()).
+		Download(gomock.Any(), _testNamespace, mi.Digest()).
 		Return(mi, nil)
 
 	t, err := m.torrentArchive.CreateTorrent(_testNamespace, mi.Digest())

--- a/lib/torrent/scheduler/scheduler_test.go
+++ b/lib/torrent/scheduler/scheduler_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/hashring"
 	"github.com/uber/kraken/lib/hostlist"
@@ -47,7 +49,7 @@ func TestDownloadTorrentWithSeederAndLeecher(t *testing.T) {
 	namespace := core.TagFixture()
 
 	mocks.metaInfoClient.EXPECT().Download(
-		namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
+		gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
 
 	seeder.writeTorrent(namespace, blob)
 	require.NoError(seeder.scheduler.Download(namespace, blob.Digest))
@@ -73,7 +75,7 @@ func TestDownloadManyTorrentsWithSeederAndLeecher(t *testing.T) {
 		blob := core.NewBlobFixture()
 
 		mocks.metaInfoClient.EXPECT().Download(
-			namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
+			gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
 
 		wg.Add(1)
 		go func() {
@@ -108,7 +110,7 @@ func TestDownloadManyTorrentsWithSeederAndManyLeechers(t *testing.T) {
 		blobs[i] = blob
 
 		mocks.metaInfoClient.EXPECT().Download(
-			namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(6)
+			gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(6)
 
 		seeder.writeTorrent(namespace, blob)
 		require.NoError(seeder.scheduler.Download(namespace, blob.Digest))
@@ -143,7 +145,7 @@ func TestDownloadTorrentWhenPeersAllHaveDifferentPiece(t *testing.T) {
 	blob := core.SizedBlobFixture(uint64(len(peers)*pieceLength), uint64(pieceLength))
 
 	mocks.metaInfoClient.EXPECT().Download(
-		namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(len(peers))
+		gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(len(peers))
 
 	var wg sync.WaitGroup
 	for i, p := range peers {
@@ -178,7 +180,7 @@ func TestSeederTTI(t *testing.T) {
 	namespace := core.TagFixture()
 
 	mocks.metaInfoClient.EXPECT().Download(
-		namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
+		gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
 
 	clk := clock.NewMock()
 	w := newEventWatcher()
@@ -230,7 +232,7 @@ func TestLeecherTTI(t *testing.T) {
 	blob := core.NewBlobFixture()
 	namespace := core.TagFixture()
 
-	mocks.metaInfoClient.EXPECT().Download(namespace, blob.Digest).Return(blob.MetaInfo, nil)
+	mocks.metaInfoClient.EXPECT().Download(gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil)
 
 	p := mocks.newPeer(config, withEventLoop(w), withClock(clk))
 	errc := make(chan error)
@@ -260,7 +262,7 @@ func TestMultipleDownloadsForSameTorrentSucceed(t *testing.T) {
 
 	// Allow any number of downloads due to concurrency below.
 	mocks.metaInfoClient.EXPECT().Download(
-		namespace, blob.Digest).Return(blob.MetaInfo, nil).AnyTimes()
+		gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).AnyTimes()
 
 	config := configFixture()
 
@@ -319,7 +321,7 @@ func TestNetworkEvents(t *testing.T) {
 	namespace := core.TagFixture()
 
 	mocks.metaInfoClient.EXPECT().Download(
-		namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
+		gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
 
 	seeder.writeTorrent(namespace, blob)
 	require.NoError(seeder.scheduler.Download(namespace, blob.Digest))
@@ -373,7 +375,7 @@ func TestPullInactiveTorrent(t *testing.T) {
 	namespace := core.TagFixture()
 
 	mocks.metaInfoClient.EXPECT().Download(
-		namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
+		gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
 
 	seeder := mocks.newPeer(config)
 
@@ -407,7 +409,7 @@ func TestSchedulerReload(t *testing.T) {
 		blob := core.NewBlobFixture()
 
 		mocks.metaInfoClient.EXPECT().Download(
-			namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
+			gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil).Times(2)
 
 		seeder.writeTorrent(namespace, blob)
 		require.NoError(seeder.scheduler.Download(namespace, blob.Digest))
@@ -440,7 +442,7 @@ func TestSchedulerRemoveTorrent(t *testing.T) {
 	namespace := core.TagFixture()
 
 	mocks.metaInfoClient.EXPECT().Download(
-		namespace, blob.Digest).Return(blob.MetaInfo, nil)
+		gomock.Any(), namespace, blob.Digest).Return(blob.MetaInfo, nil)
 
 	errc := make(chan error)
 	go func() { errc <- p.scheduler.Download(namespace, blob.Digest) }()

--- a/lib/torrent/storage/agentstorage/torrent_archive_test.go
+++ b/lib/torrent/storage/agentstorage/torrent_archive_test.go
@@ -68,7 +68,7 @@ func TestTorrentArchiveStatBitfield(t *testing.T) {
 	blob := core.SizedBlobFixture(4, 1)
 	mi := blob.MetaInfo
 
-	mocks.metaInfoClient.EXPECT().Download(namespace, mi.Digest()).Return(mi, nil).Times(1)
+	mocks.metaInfoClient.EXPECT().Download(gomock.Any(), namespace, mi.Digest()).Return(mi, nil).Times(1)
 
 	tor, err := archive.CreateTorrent(namespace, mi.Digest())
 	require.NoError(err)
@@ -107,7 +107,7 @@ func TestTorrentArchiveCreateTorrent(t *testing.T) {
 	mi := core.MetaInfoFixture()
 	namespace := core.TagFixture()
 
-	mocks.metaInfoClient.EXPECT().Download(namespace, mi.Digest()).Return(mi, nil)
+	mocks.metaInfoClient.EXPECT().Download(gomock.Any(), namespace, mi.Digest()).Return(mi, nil)
 
 	tor, err := archive.CreateTorrent(namespace, mi.Digest())
 	require.NoError(err)
@@ -135,7 +135,7 @@ func TestTorrentArchiveCreateTorrentNotFound(t *testing.T) {
 	mi := core.MetaInfoFixture()
 	namespace := core.TagFixture()
 
-	mocks.metaInfoClient.EXPECT().Download(namespace, mi.Digest()).Return(nil, metainfoclient.ErrNotFound)
+	mocks.metaInfoClient.EXPECT().Download(gomock.Any(), namespace, mi.Digest()).Return(nil, metainfoclient.ErrNotFound)
 
 	_, err := archive.CreateTorrent(namespace, mi.Digest())
 	require.Equal(storage.ErrNotFound, err)
@@ -152,7 +152,7 @@ func TestTorrentArchiveDeleteTorrent(t *testing.T) {
 	mi := core.MetaInfoFixture()
 	namespace := core.TagFixture()
 
-	mocks.metaInfoClient.EXPECT().Download(namespace, mi.Digest()).Return(mi, nil)
+	mocks.metaInfoClient.EXPECT().Download(gomock.Any(), namespace, mi.Digest()).Return(mi, nil)
 
 	tor, err := archive.CreateTorrent(namespace, mi.Digest())
 	require.NoError(err)
@@ -176,7 +176,7 @@ func TestTorrentArchiveConcurrentGet(t *testing.T) {
 	namespace := core.TagFixture()
 
 	// Allow any times for concurrency below.
-	mocks.metaInfoClient.EXPECT().Download(namespace, mi.Digest()).Return(mi, nil).AnyTimes()
+	mocks.metaInfoClient.EXPECT().Download(gomock.Any(), namespace, mi.Digest()).Return(mi, nil).AnyTimes()
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
@@ -206,7 +206,7 @@ func TestTorrentArchiveGetTorrent(t *testing.T) {
 	_, err := archive.GetTorrent(namespace, mi.Digest())
 	require.Error(err)
 
-	mocks.metaInfoClient.EXPECT().Download(namespace, mi.Digest()).Return(mi, nil)
+	mocks.metaInfoClient.EXPECT().Download(gomock.Any(), namespace, mi.Digest()).Return(mi, nil)
 
 	_, err = archive.CreateTorrent(namespace, mi.Digest())
 	require.NoError(err)

--- a/mocks/origin/blobclient/client.go
+++ b/mocks/origin/blobclient/client.go
@@ -128,18 +128,18 @@ func (mr *MockClientMockRecorder) ForceCleanup(ttl any) *gomock.Call {
 }
 
 // GetMetaInfo mocks base method.
-func (m *MockClient) GetMetaInfo(namespace string, d core.Digest) (*core.MetaInfo, error) {
+func (m *MockClient) GetMetaInfo(arg0 context.Context, arg1 string, arg2 core.Digest) (*core.MetaInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetaInfo", namespace, d)
+	ret := m.ctrl.Call(m, "GetMetaInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*core.MetaInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetaInfo indicates an expected call of GetMetaInfo.
-func (mr *MockClientMockRecorder) GetMetaInfo(namespace, d any) *gomock.Call {
+func (mr *MockClientMockRecorder) GetMetaInfo(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaInfo", reflect.TypeOf((*MockClient)(nil).GetMetaInfo), namespace, d)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaInfo", reflect.TypeOf((*MockClient)(nil).GetMetaInfo), arg0, arg1, arg2)
 }
 
 // GetPeerContext mocks base method.

--- a/mocks/origin/blobclient/clusterclient.go
+++ b/mocks/origin/blobclient/clusterclient.go
@@ -71,18 +71,18 @@ func (mr *MockClusterClientMockRecorder) DownloadBlob(arg0, arg1, arg2, arg3 any
 }
 
 // GetMetaInfo mocks base method.
-func (m *MockClusterClient) GetMetaInfo(namespace string, d core.Digest) (*core.MetaInfo, error) {
+func (m *MockClusterClient) GetMetaInfo(arg0 context.Context, arg1 string, arg2 core.Digest) (*core.MetaInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetaInfo", namespace, d)
+	ret := m.ctrl.Call(m, "GetMetaInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*core.MetaInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetaInfo indicates an expected call of GetMetaInfo.
-func (mr *MockClusterClientMockRecorder) GetMetaInfo(namespace, d any) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) GetMetaInfo(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaInfo", reflect.TypeOf((*MockClusterClient)(nil).GetMetaInfo), namespace, d)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaInfo", reflect.TypeOf((*MockClusterClient)(nil).GetMetaInfo), arg0, arg1, arg2)
 }
 
 // OverwriteMetaInfo mocks base method.

--- a/mocks/tracker/metainfoclient/client.go
+++ b/mocks/tracker/metainfoclient/client.go
@@ -5,6 +5,7 @@
 package mockmetainfoclient
 
 import (
+	"context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,16 +36,16 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Download mocks base method
-func (m *MockClient) Download(arg0 string, arg1 core.Digest) (*core.MetaInfo, error) {
+func (m *MockClient) Download(ctx context.Context, arg0 string, arg1 core.Digest) (*core.MetaInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Download", arg0, arg1)
+	ret := m.ctrl.Call(m, "Download", ctx, arg0, arg1)
 	ret0, _ := ret[0].(*core.MetaInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Download indicates an expected call of Download
-func (mr *MockClientMockRecorder) Download(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Download(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockClient)(nil).Download), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockClient)(nil).Download), arg0, arg1, arg2)
 }

--- a/nginx/config/tracker.go
+++ b/nginx/config/tracker.go
@@ -29,6 +29,10 @@ server {
   access_log {{.access_log_path}};
   error_log {{.error_log_path}};
 
+  proxy_set_header traceparent $http_traceparent;
+  proxy_set_header tracestate $http_tracestate;
+  proxy_set_header jaeger-debug-id $http_jaeger_debug_id;
+
 {{healthEndpoint "tracker"}}
 
   location / {

--- a/origin/blobserver/cluster_client_test.go
+++ b/origin/blobserver/cluster_client_test.go
@@ -64,7 +64,7 @@ func TestClusterClientResilientToUnavailableMasters(t *testing.T) {
 		require.NotNil(bi)
 		require.Equal(int64(256), bi.Size)
 
-		mi, err := cc.GetMetaInfo(backend.NoopNamespace, blob.Digest)
+		mi, err := cc.GetMetaInfo(context.Background(), backend.NoopNamespace, blob.Digest)
 		require.NoError(err)
 		require.NotNil(mi)
 
@@ -97,7 +97,7 @@ func TestClusterClientReturnsErrorOnNoAvailability(t *testing.T) {
 	_, err := cc.Stat(backend.NoopNamespace, blob.Digest)
 	require.Error(err)
 
-	_, err = cc.GetMetaInfo(backend.NoopNamespace, blob.Digest)
+	_, err = cc.GetMetaInfo(context.Background(), backend.NoopNamespace, blob.Digest)
 	require.Error(err)
 
 	require.Error(cc.DownloadBlob(context.Background(), backend.NoopNamespace, blob.Digest, io.Discard))
@@ -205,10 +205,10 @@ func TestClusterClientReturnsErrorOnNoAvailableOrigins(t *testing.T) {
 	mockClient2 := mockblobclient.NewMockClient(ctrl)
 	mockResolver.EXPECT().Resolve(blob.Digest).Return([]blobclient.Client{mockClient1, mockClient2}, nil)
 
-	mockClient1.EXPECT().GetMetaInfo(namespace, blob.Digest).Return(nil, httputil.NetworkError{})
-	mockClient2.EXPECT().GetMetaInfo(namespace, blob.Digest).Return(nil, httputil.NetworkError{})
+	mockClient1.EXPECT().GetMetaInfo(gomock.Any(), namespace, blob.Digest).Return(nil, httputil.NetworkError{})
+	mockClient2.EXPECT().GetMetaInfo(gomock.Any(), namespace, blob.Digest).Return(nil, httputil.NetworkError{})
 
-	_, err := cc.GetMetaInfo(namespace, blob.Digest)
+	_, err := cc.GetMetaInfo(context.Background(), namespace, blob.Digest)
 	require.Error(err)
 }
 

--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -172,7 +172,7 @@ func (s *Server) Handler() http.Handler {
 
 	r.Head("/internal/namespace/{namespace}/blobs/{digest}", handler.Wrap(s.statHandler))
 
-	r.Get("/internal/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
+	r.With(tracingMiddleware).Get("/internal/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
 
 	r.Put(
 		"/internal/duplicate/namespace/{namespace}/blobs/{digest}/uploads/{uid}",
@@ -439,25 +439,49 @@ func (s *Server) getPeerContextHandler(w http.ResponseWriter, r *http.Request) e
 }
 
 func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, span := s.tracer.Start(r.Context(), "origin.get_metainfo",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("component", "origin"),
+			attribute.String("operation", "get_metainfo"),
+		),
+	)
+	defer span.End()
+
 	namespace, err := httputil.ParseParam(r, "namespace")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse namespace failed")
 		return err
 	}
 	d, err := httputil.ParseDigest(r, "digest")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse digest failed")
 		return err
 	}
-	log.With("namespace", namespace, "digest", d.Hex()).Debug("Getting metainfo")
+
+	span.SetAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("blob.digest", d.Hex()),
+	)
+	log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex()).Debug("Getting metainfo")
+
 	raw, err := s.getMetaInfo(namespace, d)
 	if err != nil {
-		log.With("namespace", namespace, "digest", d.Hex(), "error", err).
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "get metainfo failed")
+		log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex(), "error", err).
 			Debug("getMetaInfo returned non-nil error")
 		return err
 	}
 	if _, err := w.Write(raw); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "write response failed")
 		return fmt.Errorf("write response: %s", err)
 	}
-	log.With("namespace", namespace, "digest", d.Hex()).Debug("Successfully retrieved metainfo")
+	span.SetStatus(codes.Ok, "metainfo retrieved")
+	log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex()).Debug("Successfully retrieved metainfo")
 	return nil
 }
 

--- a/origin/blobserver/server_test.go
+++ b/origin/blobserver/server_test.go
@@ -351,16 +351,16 @@ func TestGetMetaInfoDownloadsBlobAndReplicates(t *testing.T) {
 		blob.Digest.Hex()).Return(core.NewBlobInfo(int64(len(blob.Content))), nil).AnyTimes()
 	backendClient.EXPECT().Download(namespace, blob.Digest.Hex(), mockutil.MatchWriter(blob.Content)).Return(nil)
 
-	mi, err := cp.Provide(master1).GetMetaInfo(namespace, blob.Digest)
+	mi, err := cp.Provide(master1).GetMetaInfo(context.Background(), namespace, blob.Digest)
 	require.True(httputil.IsAccepted(err))
 	require.Nil(mi)
 
 	require.NoError(testutil.PollUntilTrue(5*time.Second, func() bool {
-		_, err := cp.Provide(master1).GetMetaInfo(namespace, blob.Digest)
+		_, err := cp.Provide(master1).GetMetaInfo(context.Background(), namespace, blob.Digest)
 		return !httputil.IsAccepted(err)
 	}))
 
-	mi, err = cp.Provide(master1).GetMetaInfo(namespace, blob.Digest)
+	mi, err = cp.Provide(master1).GetMetaInfo(context.Background(), namespace, blob.Digest)
 	require.NoError(err)
 	require.NotNil(mi)
 	require.Equal(len(blob.Content), int(mi.Length()))
@@ -386,7 +386,7 @@ func TestGetMetaInfoBlobNotFound(t *testing.T) {
 	backendClient := s.backendClient(namespace, false)
 	backendClient.EXPECT().Stat(namespace, d.Hex()).Return(nil, backenderrors.ErrBlobNotFound)
 
-	mi, err := cp.Provide(master1).GetMetaInfo(namespace, d)
+	mi, err := cp.Provide(master1).GetMetaInfo(context.Background(), namespace, d)
 	require.True(httputil.IsNotFound(err))
 	require.Nil(mi)
 }
@@ -569,14 +569,14 @@ func TestOverwriteMetainfo(t *testing.T) {
 	err := cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content))
 	require.NoError(err)
 
-	mi, err := cp.Provide(master1).GetMetaInfo(namespace, blob.Digest)
+	mi, err := cp.Provide(master1).GetMetaInfo(context.Background(), namespace, blob.Digest)
 	require.NoError(err)
 	require.Equal(int64(4), mi.PieceLength())
 
 	err = cp.Provide(master1).OverwriteMetaInfo(blob.Digest, 16)
 	require.NoError(err)
 
-	mi, err = cp.Provide(master1).GetMetaInfo(namespace, blob.Digest)
+	mi, err = cp.Provide(master1).GetMetaInfo(context.Background(), namespace, blob.Digest)
 	require.NoError(err)
 	require.Equal(int64(16), mi.PieceLength())
 }

--- a/proxy/proxyserver/preheat.go
+++ b/proxy/proxyserver/preheat.go
@@ -79,7 +79,7 @@ func (ph *PreheatHandler) process(repo, digest string) error {
 		}
 		f := func() {
 			log.With("repo", repo).Debugf("trigger origin cache: %+v", d)
-			_, err = ph.clusterClient.GetMetaInfo(repo, d)
+			_, err = ph.clusterClient.GetMetaInfo(context.Background(), repo, d)
 			if err != nil && !httputil.IsAccepted(err) {
 				log.With("repo", repo, "digest", digest).Errorf("notify origin cache: %s", err)
 			}

--- a/proxy/proxyserver/server_test.go
+++ b/proxy/proxyserver/server_test.go
@@ -139,9 +139,9 @@ func TestPreheat(t *testing.T) {
 	b, _ := json.Marshal(notification)
 
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), repo, manifest, mockutil.MatchWriter(bs)).Return(nil)
-	mocks.originClient.EXPECT().GetMetaInfo(repo, layers[0]).Return(nil, nil)
-	mocks.originClient.EXPECT().GetMetaInfo(repo, layers[1]).Return(nil, nil)
-	mocks.originClient.EXPECT().GetMetaInfo(repo, layers[2]).Return(nil, nil)
+	mocks.originClient.EXPECT().GetMetaInfo(gomock.Any(), repo, layers[0]).Return(nil, nil)
+	mocks.originClient.EXPECT().GetMetaInfo(gomock.Any(), repo, layers[1]).Return(nil, nil)
+	mocks.originClient.EXPECT().GetMetaInfo(gomock.Any(), repo, layers[2]).Return(nil, nil)
 	_, err := httputil.Post(
 		fmt.Sprintf("http://%s/registry/notifications", addr),
 		httputil.SendBody(bytes.NewReader(b)))

--- a/tracker/metainfoclient/testing.go
+++ b/tracker/metainfoclient/testing.go
@@ -14,6 +14,7 @@
 package metainfoclient
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -44,7 +45,7 @@ func (c *TestClient) Upload(mi *core.MetaInfo) error {
 }
 
 // Download returns the metainfo for digest. Ignores namespace.
-func (c *TestClient) Download(namespace string, d core.Digest) (*core.MetaInfo, error) {
+func (c *TestClient) Download(ctx context.Context, namespace string, d core.Digest) (*core.MetaInfo, error) {
 	c.Lock()
 	defer c.Unlock()
 	mi, ok := c.m[d]

--- a/tracker/trackerserver/metainfo.go
+++ b/tracker/trackerserver/metainfo.go
@@ -19,48 +19,21 @@ import (
 
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/httputil"
-	"github.com/uber/kraken/utils/log"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) error {
-	ctx, span := otel.Tracer("kraken-tracker").Start(r.Context(), "tracker.get_metainfo",
-		trace.WithSpanKind(trace.SpanKindServer),
-		trace.WithAttributes(
-			attribute.String("component", "tracker"),
-			attribute.String("operation", "get_metainfo"),
-		),
-	)
-	defer span.End()
-
 	namespace, err := httputil.ParseParam(r, "namespace")
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "parse namespace failed")
 		return err
 	}
 	d, err := httputil.ParseDigest(r, "digest")
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "parse digest failed")
 		return handler.Errorf("parse digest: %s", err).Status(http.StatusBadRequest)
 	}
 
-	span.SetAttributes(
-		attribute.String("namespace", namespace),
-		attribute.String("blob.digest", d.Hex()),
-	)
-	log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex()).Debug("Getting metainfo from origin")
-
 	timer := s.stats.Timer("get_metainfo").Start()
-	mi, err := s.originCluster.GetMetaInfo(ctx, namespace, d)
+	mi, err := s.originCluster.GetMetaInfo(r.Context(), namespace, d)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "get metainfo from origin failed")
 		if serr, ok := err.(httputil.StatusError); ok {
 			// Propagate errors received from origin.
 			return handler.Errorf("origin: %s", serr.ResponseDump).Status(serr.Status)
@@ -71,16 +44,11 @@ func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) erro
 
 	b, err := mi.Serialize()
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "serialize metainfo failed")
 		return fmt.Errorf("serialize metainfo: %s", err)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(b); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "write response failed")
 		return fmt.Errorf("write response: %s", err)
 	}
-	span.SetStatus(codes.Ok, "metainfo retrieved")
 	return nil
 }

--- a/tracker/trackerserver/metainfo.go
+++ b/tracker/trackerserver/metainfo.go
@@ -19,21 +19,48 @@ import (
 
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/httputil"
+	"github.com/uber/kraken/utils/log"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, span := otel.Tracer("kraken-tracker").Start(r.Context(), "tracker.get_metainfo",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("component", "tracker"),
+			attribute.String("operation", "get_metainfo"),
+		),
+	)
+	defer span.End()
+
 	namespace, err := httputil.ParseParam(r, "namespace")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse namespace failed")
 		return err
 	}
 	d, err := httputil.ParseDigest(r, "digest")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse digest failed")
 		return handler.Errorf("parse digest: %s", err).Status(http.StatusBadRequest)
 	}
 
+	span.SetAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("blob.digest", d.Hex()),
+	)
+	log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex()).Debug("Getting metainfo from origin")
+
 	timer := s.stats.Timer("get_metainfo").Start()
-	mi, err := s.originCluster.GetMetaInfo(namespace, d)
+	mi, err := s.originCluster.GetMetaInfo(ctx, namespace, d)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "get metainfo from origin failed")
 		if serr, ok := err.(httputil.StatusError); ok {
 			// Propagate errors received from origin.
 			return handler.Errorf("origin: %s", serr.ResponseDump).Status(serr.Status)
@@ -44,11 +71,16 @@ func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) erro
 
 	b, err := mi.Serialize()
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "serialize metainfo failed")
 		return fmt.Errorf("serialize metainfo: %s", err)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(b); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "write response failed")
 		return fmt.Errorf("write response: %s", err)
 	}
+	span.SetStatus(codes.Ok, "metainfo retrieved")
 	return nil
 }

--- a/tracker/trackerserver/metainfo_test.go
+++ b/tracker/trackerserver/metainfo_test.go
@@ -14,7 +14,10 @@
 package trackerserver
 
 import (
+	"context"
 	"testing"
+
+	"github.com/golang/mock/gomock"
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/hashring"
@@ -42,11 +45,11 @@ func TestGetMetaInfoHandlerFetchesFromOrigin(t *testing.T) {
 	namespace := core.TagFixture()
 	mi := core.MetaInfoFixture()
 
-	mocks.originCluster.EXPECT().GetMetaInfo(namespace, mi.Digest()).Return(mi, nil)
+	mocks.originCluster.EXPECT().GetMetaInfo(gomock.Any(), namespace, mi.Digest()).Return(mi, nil)
 
 	client := newMetaInfoClient(addr)
 
-	result, err := client.Download(namespace, mi.Digest())
+	result, err := client.Download(context.Background(), namespace, mi.Digest())
 	require.NoError(err)
 	require.Equal(mi, result)
 }
@@ -64,11 +67,11 @@ func TestGetMetaInfoHandlerPropagatesOriginError(t *testing.T) {
 	mi := core.MetaInfoFixture()
 
 	mocks.originCluster.EXPECT().GetMetaInfo(
-		namespace, mi.Digest()).Return(nil, httputil.StatusError{Status: 599}).MinTimes(1)
+		gomock.Any(), namespace, mi.Digest()).Return(nil, httputil.StatusError{Status: 599}).MinTimes(1)
 
 	client := newMetaInfoClient(addr)
 
-	_, err := client.Download(namespace, mi.Digest())
+	_, err := client.Download(context.Background(), namespace, mi.Digest())
 	require.Error(err)
 	require.True(httputil.IsStatus(err, 599))
 }

--- a/tracker/trackerserver/server.go
+++ b/tracker/trackerserver/server.go
@@ -30,9 +30,6 @@ import (
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/listener"
 	"github.com/uber/kraken/utils/log"
-
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel"
 )
 
 // Server serves Tracker endpoints.
@@ -79,15 +76,12 @@ func (s *Server) Handler() http.Handler {
 	r.Use(middleware.StatusCounter(s.stats))
 	r.Use(middleware.LatencyTimer(s.stats))
 
-	tracingMiddleware := otelhttp.NewMiddleware("kraken-tracker",
-		otelhttp.WithTracerProvider(otel.GetTracerProvider()))
-
 	r.Get("/health", handler.Wrap(s.healthHandler))
 	r.Get("/readiness", handler.Wrap(s.readinessCheckHandler))
 
 	r.Get("/announce", handler.Wrap(s.announceHandlerV1))
 	r.Post("/announce/{infohash}", handler.Wrap(s.announceHandlerV2))
-	r.With(tracingMiddleware).Get("/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
+	r.Get("/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
 
 	r.Mount("/debug", chimiddleware.Profiler())
 

--- a/tracker/trackerserver/server.go
+++ b/tracker/trackerserver/server.go
@@ -30,6 +30,9 @@ import (
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/listener"
 	"github.com/uber/kraken/utils/log"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
 )
 
 // Server serves Tracker endpoints.
@@ -51,8 +54,8 @@ func New(
 	policy *peerhandoutpolicy.PriorityPolicy,
 	peerStore peerstore.Store,
 	originStore originstore.Store,
-	originCluster blobclient.ClusterClient) *Server {
-
+	originCluster blobclient.ClusterClient,
+) *Server {
 	config = config.applyDefaults()
 
 	stats = stats.Tagged(map[string]string{
@@ -76,12 +79,15 @@ func (s *Server) Handler() http.Handler {
 	r.Use(middleware.StatusCounter(s.stats))
 	r.Use(middleware.LatencyTimer(s.stats))
 
+	tracingMiddleware := otelhttp.NewMiddleware("kraken-tracker",
+		otelhttp.WithTracerProvider(otel.GetTracerProvider()))
+
 	r.Get("/health", handler.Wrap(s.healthHandler))
 	r.Get("/readiness", handler.Wrap(s.readinessCheckHandler))
 
 	r.Get("/announce", handler.Wrap(s.announceHandlerV1))
 	r.Post("/announce/{infohash}", handler.Wrap(s.announceHandlerV2))
-	r.Get("/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
+	r.With(tracingMiddleware).Get("/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
 
 	r.Mount("/debug", chimiddleware.Profiler())
 


### PR DESCRIPTION
This PR adds distributed tracing support for the metainfo retrieval path from agent through tracker to origin, enabling end-to-end observability of blob metadata requests.

Changes:

- Added context parameter to GetMetaInfo and Download methods throughout the codebase to enable trace context propagation
- Implemented OpenTelemetry tracing spans in origin cluster client, origin client, and agent storage components
- Added trace header propagation in tracker nginx configuration