### PR TITLE
feat: getMetaInfoHander tracing tracker + origin

### DIFF
--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -172,7 +172,7 @@ func (s *Server) Handler() http.Handler {
 
 	r.Head("/internal/namespace/{namespace}/blobs/{digest}", handler.Wrap(s.statHandler))
 
-	r.Get("/internal/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
+	r.With(tracingMiddleware).Get("/internal/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
 
 	r.Put(
 		"/internal/duplicate/namespace/{namespace}/blobs/{digest}/uploads/{uid}",
@@ -439,25 +439,49 @@ func (s *Server) getPeerContextHandler(w http.ResponseWriter, r *http.Request) e
 }
 
 func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, span := s.tracer.Start(r.Context(), "origin.get_metainfo",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("component", "origin"),
+			attribute.String("operation", "get_metainfo"),
+		),
+	)
+	defer span.End()
+
 	namespace, err := httputil.ParseParam(r, "namespace")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse namespace failed")
 		return err
 	}
 	d, err := httputil.ParseDigest(r, "digest")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse digest failed")
 		return err
 	}
-	log.With("namespace", namespace, "digest", d.Hex()).Debug("Getting metainfo")
+
+	span.SetAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("blob.digest", d.Hex()),
+	)
+	log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex()).Debug("Getting metainfo")
+
 	raw, err := s.getMetaInfo(namespace, d)
 	if err != nil {
-		log.With("namespace", namespace, "digest", d.Hex(), "error", err).
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "get metainfo failed")
+		log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex(), "error", err).
 			Debug("getMetaInfo returned non-nil error")
 		return err
 	}
 	if _, err := w.Write(raw); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "write response failed")
 		return fmt.Errorf("write response: %s", err)
 	}
-	log.With("namespace", namespace, "digest", d.Hex()).Debug("Successfully retrieved metainfo")
+	span.SetStatus(codes.Ok, "metainfo retrieved")
+	log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex()).Debug("Successfully retrieved metainfo")
 	return nil
 }
 

--- a/tracker/trackerserver/metainfo.go
+++ b/tracker/trackerserver/metainfo.go
@@ -19,21 +19,48 @@ import (
 
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/httputil"
+	"github.com/uber/kraken/utils/log"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, span := otel.Tracer("kraken-tracker").Start(r.Context(), "tracker.get_metainfo",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("component", "tracker"),
+			attribute.String("operation", "get_metainfo"),
+		),
+	)
+	defer span.End()
+
 	namespace, err := httputil.ParseParam(r, "namespace")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse namespace failed")
 		return err
 	}
 	d, err := httputil.ParseDigest(r, "digest")
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "parse digest failed")
 		return handler.Errorf("parse digest: %s", err).Status(http.StatusBadRequest)
 	}
 
+	span.SetAttributes(
+		attribute.String("namespace", namespace),
+		attribute.String("blob.digest", d.Hex()),
+	)
+	log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex()).Debug("Getting metainfo from origin")
+
 	timer := s.stats.Timer("get_metainfo").Start()
-	mi, err := s.originCluster.GetMetaInfo(r.Context(), namespace, d)
+	mi, err := s.originCluster.GetMetaInfo(ctx, namespace, d)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "get metainfo from origin failed")
 		if serr, ok := err.(httputil.StatusError); ok {
 			// Propagate errors received from origin.
 			return handler.Errorf("origin: %s", serr.ResponseDump).Status(serr.Status)
@@ -44,11 +71,16 @@ func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) erro
 
 	b, err := mi.Serialize()
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "serialize metainfo failed")
 		return fmt.Errorf("serialize metainfo: %s", err)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(b); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "write response failed")
 		return fmt.Errorf("write response: %s", err)
 	}
+	span.SetStatus(codes.Ok, "metainfo retrieved")
 	return nil
 }

--- a/tracker/trackerserver/server.go
+++ b/tracker/trackerserver/server.go
@@ -30,6 +30,9 @@ import (
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/listener"
 	"github.com/uber/kraken/utils/log"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
 )
 
 // Server serves Tracker endpoints.
@@ -76,12 +79,15 @@ func (s *Server) Handler() http.Handler {
 	r.Use(middleware.StatusCounter(s.stats))
 	r.Use(middleware.LatencyTimer(s.stats))
 
+	tracingMiddleware := otelhttp.NewMiddleware("kraken-tracker",
+		otelhttp.WithTracerProvider(otel.GetTracerProvider()))
+
 	r.Get("/health", handler.Wrap(s.healthHandler))
 	r.Get("/readiness", handler.Wrap(s.readinessCheckHandler))
 
 	r.Get("/announce", handler.Wrap(s.announceHandlerV1))
 	r.Post("/announce/{infohash}", handler.Wrap(s.announceHandlerV2))
-	r.Get("/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
+	r.With(tracingMiddleware).Get("/namespace/{namespace}/blobs/{digest}/metainfo", handler.Wrap(s.getMetaInfoHandler))
 
 	r.Mount("/debug", chimiddleware.Profiler())
 


### PR DESCRIPTION
This PR adds OpenTelemetry distributed tracing to the getMetaInfoHandler in both the tracker and origin servers. The changes enhance observability by instrumenting the metainfo retrieval flow with spans, error tracking, and trace context propagation in logs.

Changes:

- Added tracing middleware to the metainfo endpoints in both tracker and origin servers
- Instrumented getMetaInfoHandler functions with OpenTelemetry spans including error handling and status codes
- Updated logging calls to use log.WithTraceContext(ctx) for trace-aware logging
