### PR TITLE
feat(agent): add config to tune origin to agent multiplexing level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .tmp
 .vscode
+.claude/settings.local.json
 *.test
 *.go~
 vendor/

--- a/lib/torrent/scheduler/conn/conn.go
+++ b/lib/torrent/scheduler/conn/conn.go
@@ -47,11 +47,12 @@ type Events interface {
 // Conn manages peer communication over a connection for multiple torrents. Inbound
 // messages are multiplexed based on the torrent they pertain to.
 type Conn struct {
-	peerID      core.PeerID
-	infoHash    core.InfoHash
-	createdAt   time.Time
-	localPeerID core.PeerID
-	bandwidth   *bandwidth.Limiter
+	peerID       core.PeerID
+	isPeerOrigin bool
+	infoHash     core.InfoHash
+	createdAt    time.Time
+	localPeerID  core.PeerID
+	bandwidth    *bandwidth.Limiter
 
 	events Events
 
@@ -87,6 +88,7 @@ func newConn(
 	nc net.Conn,
 	localPeerID core.PeerID,
 	remotePeerID core.PeerID,
+	isRemotePeerOrigin bool,
 	info *storage.TorrentInfo,
 	openedByRemote bool,
 	logger *zap.SugaredLogger) (*Conn, error) {
@@ -99,6 +101,7 @@ func newConn(
 
 	c := &Conn{
 		peerID:         remotePeerID,
+		isPeerOrigin:   isRemotePeerOrigin,
 		infoHash:       info.InfoHash(),
 		createdAt:      clk.Now(),
 		localPeerID:    localPeerID,
@@ -134,6 +137,11 @@ func (c *Conn) Start() {
 // PeerID returns the remote peer id.
 func (c *Conn) PeerID() core.PeerID {
 	return c.peerID
+}
+
+// IsPeerOrigin whether the remote peer is an agent or an origin.
+func (c *Conn) IsPeerOrigin() bool {
+	return c.isPeerOrigin
 }
 
 // InfoHash returns the info hash for the torrent being transmitted over this

--- a/lib/torrent/scheduler/conn/conn.go
+++ b/lib/torrent/scheduler/conn/conn.go
@@ -139,7 +139,7 @@ func (c *Conn) PeerID() core.PeerID {
 	return c.peerID
 }
 
-// IsPeerOrigin whether the remote peer is an agent or an origin.
+// IsPeerOrigin returns whether the remote peer is an origin instead of an agent.
 func (c *Conn) IsPeerOrigin() bool {
 	return c.isPeerOrigin
 }

--- a/lib/torrent/scheduler/conn/fake_peer_test.go
+++ b/lib/torrent/scheduler/conn/fake_peer_test.go
@@ -19,7 +19,7 @@ func TestFakePeer(t *testing.T) {
 
 	info := storage.TorrentInfoFixture(32, 4)
 
-	res, err := h.Initialize(p.PeerID(), p.Addr(), info, nil, "noexist")
+	res, err := h.Initialize(p.PeerID(), false, p.Addr(), info, nil, "noexist")
 	require.NoError(err)
 
 	require.Equal(p.PeerID(), res.Conn.PeerID())

--- a/lib/torrent/scheduler/conn/fixtures.go
+++ b/lib/torrent/scheduler/conn/fixtures.go
@@ -56,14 +56,14 @@ func PipeFixture(
 	var err error
 
 	local, err = HandshakerFixture(config).newConn(
-		noopDeadline{nc1}, core.PeerIDFixture(), info, false)
+		noopDeadline{nc1}, core.PeerIDFixture(), false, info, false)
 	if err != nil {
 		panic(err)
 	}
 	local.Start()
 
 	remote, err = HandshakerFixture(config).newConn(
-		noopDeadline{nc2}, core.PeerIDFixture(), info, true)
+		noopDeadline{nc2}, core.PeerIDFixture(), false, info, true)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/torrent/scheduler/conn/handshaker.go
+++ b/lib/torrent/scheduler/conn/handshaker.go
@@ -248,7 +248,10 @@ func (h *Handshaker) Establish(
 	if err := h.sendHandshake(pc.nc, info, remoteBitfields, ""); err != nil {
 		return nil, fmt.Errorf("send handshake: %s", err)
 	}
-	c, err := h.newConn(pc.nc, pc.handshake.peerID, info, true)
+	// This code is only executed when a peer initiates a handshake with us. Origins don't
+	// initiate handshakes, so we can conclude that the peer is not an origin.
+	isPeerOrigin := false
+	c, err := h.newConn(pc.nc, pc.handshake.peerID, isPeerOrigin, info, true)
 	if err != nil {
 		return nil, fmt.Errorf("new conn: %s", err)
 	}
@@ -260,6 +263,7 @@ func (h *Handshaker) Establish(
 // its connections for the torrent.
 func (h *Handshaker) Initialize(
 	peerID core.PeerID,
+	isPeerOrigin bool,
 	addr string,
 	info *storage.TorrentInfo,
 	remoteBitfields RemoteBitfields,
@@ -269,7 +273,7 @@ func (h *Handshaker) Initialize(
 	if err != nil {
 		return nil, fmt.Errorf("dial: %s", err)
 	}
-	r, err := h.fullHandshake(nc, peerID, info, remoteBitfields, namespace)
+	r, err := h.fullHandshake(nc, peerID, isPeerOrigin, info, remoteBitfields, namespace)
 	if err != nil {
 		closers.Close(nc)
 		return nil, err
@@ -313,6 +317,7 @@ func (h *Handshaker) readHandshake(nc net.Conn) (*handshake, error) {
 func (h *Handshaker) fullHandshake(
 	nc net.Conn,
 	peerID core.PeerID,
+	isPeerOrigin bool,
 	info *storage.TorrentInfo,
 	remoteBitfields RemoteBitfields,
 	namespace string) (*HandshakeResult, error) {
@@ -327,7 +332,7 @@ func (h *Handshaker) fullHandshake(
 	if hs.peerID != peerID {
 		return nil, errors.New("unexpected peer id")
 	}
-	c, err := h.newConn(nc, peerID, info, false)
+	c, err := h.newConn(nc, peerID, isPeerOrigin, info, false)
 	if err != nil {
 		return nil, fmt.Errorf("new conn: %s", err)
 	}
@@ -337,6 +342,7 @@ func (h *Handshaker) fullHandshake(
 func (h *Handshaker) newConn(
 	nc net.Conn,
 	peerID core.PeerID,
+	isPeerOrigin bool,
 	info *storage.TorrentInfo,
 	openedByRemote bool) (*Conn, error) {
 
@@ -350,6 +356,7 @@ func (h *Handshaker) newConn(
 		nc,
 		h.peerID,
 		peerID,
+		isPeerOrigin,
 		info,
 		openedByRemote,
 		zap.NewNop().Sugar())

--- a/lib/torrent/scheduler/conn/handshaker_test.go
+++ b/lib/torrent/scheduler/conn/handshaker_test.go
@@ -78,7 +78,7 @@ func TestHandshakerSetsConnFieldsProperly(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		r, err := h2.Initialize(h1.peerID, l1.Addr().String(), info, emptyRemoteBitfields, namespace)
+		r, err := h2.Initialize(h1.peerID, false, l1.Addr().String(), info, emptyRemoteBitfields, namespace)
 		require.NoError(err)
 		require.Equal(h1.peerID, r.Conn.PeerID())
 		require.Equal(info.InfoHash(), r.Conn.InfoHash())

--- a/lib/torrent/scheduler/dispatch/config.go
+++ b/lib/torrent/scheduler/dispatch/config.go
@@ -36,9 +36,12 @@ type Config struct {
 	// from a peer.
 	PieceRequestPolicy string `yaml:"piece_request_policy"`
 
-	// PipelineLimit limits the total number of requests can be sent to a peer
+	// AgentPipelineLimit limits the total number of requests can be sent to an agent peer
 	// at the same time.
-	PipelineLimit int `yaml:"pipeline_limit"`
+	AgentPipelineLimit int `yaml:"pipeline_limit"`
+	// OriginPipelineLimit limits the total number of requests can be sent to an origin peer
+	// at the same time.
+	OriginPipelineLimit int `yaml:"origin_pipeline_limit"`
 
 	// EndgameThreshold is the number pieces required to complete the torrent
 	// before the torrent enters "endgame", where we start overloading piece
@@ -58,11 +61,14 @@ func (c Config) applyDefaults() Config {
 	if c.PieceRequestTimeoutPerMb == 0 {
 		c.PieceRequestTimeoutPerMb = 4 * time.Second
 	}
-	if c.PipelineLimit == 0 {
-		c.PipelineLimit = 3
+	if c.AgentPipelineLimit == 0 {
+		c.AgentPipelineLimit = 3
+	}
+	if c.OriginPipelineLimit == 0 {
+		c.OriginPipelineLimit = 5
 	}
 	if c.EndgameThreshold == 0 {
-		c.EndgameThreshold = c.PipelineLimit
+		c.EndgameThreshold = c.AgentPipelineLimit
 	}
 	return c
 }

--- a/lib/torrent/scheduler/dispatch/dispatcher.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher.go
@@ -125,7 +125,7 @@ func newDispatcher(
 
 	pieceRequestTimeout := config.calcPieceRequestTimeout(t.MaxPieceLength())
 	pieceRequestManager, err := piecerequest.NewManager(
-		clk, pieceRequestTimeout, config.PieceRequestPolicy, config.PipelineLimit)
+		clk, pieceRequestTimeout, config.PieceRequestPolicy, config.AgentPipelineLimit, config.OriginPipelineLimit)
 	if err != nil {
 		return nil, fmt.Errorf("piece request manager: %s", err)
 	}
@@ -246,9 +246,9 @@ func (d *Dispatcher) RemoteBitfields() conn.RemoteBitfields {
 
 // AddPeer registers a new peer with the Dispatcher.
 func (d *Dispatcher) AddPeer(
-	peerID core.PeerID, b *bitset.BitSet, messages Messages) error {
+	peerID core.PeerID, isPeerOrigin bool, b *bitset.BitSet, messages Messages) error {
 
-	p, err := d.addPeer(peerID, b, messages)
+	p, err := d.addPeer(peerID, isPeerOrigin, b, messages)
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func (d *Dispatcher) AddPeer(
 // addPeer creates and inserts a new peer into the Dispatcher. Split from AddPeer
 // with no goroutine side-effects for testing purposes.
 func (d *Dispatcher) addPeer(
-	peerID core.PeerID, b *bitset.BitSet, messages Messages) (*peer, error) {
+	peerID core.PeerID, isPeerOrigin bool, b *bitset.BitSet, messages Messages) (*peer, error) {
 
 	pstats := &peerStats{}
 	if s, ok := d.peerStats.LoadOrStore(peerID, pstats); ok {
@@ -275,7 +275,7 @@ func (d *Dispatcher) addPeer(
 		pstats = ps
 	}
 
-	p := newPeer(peerID, b, messages, d.clk, pstats)
+	p := newPeer(peerID, isPeerOrigin, b, messages, d.clk, pstats)
 	if _, ok := d.peers.LoadOrStore(peerID, p); ok {
 		return nil, errors.New("peer already exists")
 	}
@@ -411,7 +411,7 @@ func (d *Dispatcher) maybeRequestMorePieces(p *peer) (bool, error) {
 }
 
 func (d *Dispatcher) maybeSendPieceRequests(p *peer, pieceCandidates *bitset.BitSet) (bool, error) {
-	pieces, err := d.pieceRequestManager.ReservePieces(p.id, pieceCandidates, d.numPeersByPiece, d.endgame())
+	pieces, err := d.pieceRequestManager.ReservePieces(p.id, p.isOrigin, pieceCandidates, d.numPeersByPiece, d.endgame())
 	if err != nil {
 		return false, err
 	}

--- a/lib/torrent/scheduler/dispatch/dispatcher_test.go
+++ b/lib/torrent/scheduler/dispatch/dispatcher_test.go
@@ -142,7 +142,7 @@ func TestDispatcherSendUniquePieceRequestsWithinLimit(t *testing.T) {
 	require := require.New(t)
 
 	config := Config{
-		PipelineLimit: 3,
+		AgentPipelineLimit: 3,
 	}
 	clk := clock.NewMock()
 
@@ -164,7 +164,7 @@ func TestDispatcherSendUniquePieceRequestsWithinLimit(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			p, err := d.addPeer(core.PeerIDFixture(), peerBitfield, newMockMessages())
+			p, err := d.addPeer(core.PeerIDFixture(), false, peerBitfield, newMockMessages())
 			require.NoError(err)
 			_, err = d.maybeRequestMorePieces(p)
 			require.NoError(err)
@@ -175,14 +175,14 @@ func TestDispatcherSendUniquePieceRequestsWithinLimit(t *testing.T) {
 				totalRequestsPerPiece[i] += n
 				require.True(totalRequestsPerPiece[i] <= 1)
 				totalRequestPerPeer[p.id] += n
-				require.True(totalRequestPerPeer[p.id] <= config.PipelineLimit)
+				require.True(totalRequestPerPeer[p.id] <= config.AgentPipelineLimit)
 				mu.Unlock()
 			}
 		}()
 	}
 	wg.Wait()
 
-	require.Equal(config.PipelineLimit*10, requestCount)
+	require.Equal(config.AgentPipelineLimit*10, requestCount)
 
 	buffer := make([]uint, peerBitfield.Len())
 	_, buffer = peerBitfield.NextSetMany(uint(0), buffer)
@@ -206,7 +206,7 @@ func TestDispatcherResendFailedPieceRequests(t *testing.T) {
 	d := testDispatcher(config, clk, torrent)
 
 	// p1 has both pieces and sends requests for both.
-	p1, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true, true), newMockMessages())
+	p1, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true, true), newMockMessages())
 	require.NoError(err)
 	_, err = d.maybeRequestMorePieces(p1)
 	require.NoError(err)
@@ -217,7 +217,7 @@ func TestDispatcherResendFailedPieceRequests(t *testing.T) {
 
 	// p2 has piece 0 and sends no piece requests.
 	p2, err := d.addPeer(
-		core.PeerIDFixture(), bitsetutil.FromBools(true, false), newMockMessages())
+		core.PeerIDFixture(), false, bitsetutil.FromBools(true, false), newMockMessages())
 	require.NoError(err)
 	_, err = d.maybeRequestMorePieces(p2)
 	require.NoError(err)
@@ -225,7 +225,7 @@ func TestDispatcherResendFailedPieceRequests(t *testing.T) {
 
 	// p3 has piece 1 and sends no piece requests.
 	p3, err := d.addPeer(
-		core.PeerIDFixture(), bitsetutil.FromBools(false, true), newMockMessages())
+		core.PeerIDFixture(), false, bitsetutil.FromBools(false, true), newMockMessages())
 	require.NoError(err)
 	_, err = d.maybeRequestMorePieces(p3)
 	require.NoError(err)
@@ -265,7 +265,7 @@ func TestDispatcherSendErrorsMarksPieceRequestsUnsent(t *testing.T) {
 
 	d := testDispatcher(config, clk, torrent)
 
-	p1, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true), newMockMessages())
+	p1, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true), newMockMessages())
 	require.NoError(err)
 
 	p1.messages.Close()
@@ -276,7 +276,7 @@ func TestDispatcherSendErrorsMarksPieceRequestsUnsent(t *testing.T) {
 
 	require.Equal(map[int]int{}, numRequestsPerPiece(p1.messages))
 
-	p2, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true), newMockMessages())
+	p2, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true), newMockMessages())
 	require.NoError(err)
 
 	// Send should succeed since pending requests were marked unsent.
@@ -315,8 +315,8 @@ func TestDispatcherEndgame(t *testing.T) {
 	require := require.New(t)
 
 	config := Config{
-		PipelineLimit:    1,
-		EndgameThreshold: 1,
+		AgentPipelineLimit: 1,
+		EndgameThreshold:   1,
 	}
 	clk := clock.NewMock()
 
@@ -325,14 +325,14 @@ func TestDispatcherEndgame(t *testing.T) {
 
 	d := testDispatcher(config, clk, torrent)
 
-	p1, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true), newMockMessages())
+	p1, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true), newMockMessages())
 	require.NoError(err)
 
 	_, err = d.maybeRequestMorePieces(p1)
 	require.NoError(err)
 	require.Equal(map[int]int{0: 1}, numRequestsPerPiece(p1.messages))
 
-	p2, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true), newMockMessages())
+	p2, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true), newMockMessages())
 	require.NoError(err)
 
 	// Should send duplicate request for piece 0 since we're in endgame.
@@ -351,10 +351,10 @@ func TestDispatcherHandlePiecePayloadAnnouncesPiece(t *testing.T) {
 
 	d := testDispatcher(Config{}, clock.NewMock(), torrent)
 
-	p1, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(false, false), newMockMessages())
+	p1, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(false, false), newMockMessages())
 	require.NoError(err)
 
-	p2, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(false, false), newMockMessages())
+	p2, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(false, false), newMockMessages())
 	require.NoError(err)
 
 	msg := conn.NewPiecePayloadMessage(0, piecereader.NewBuffer(blob.Content[0:1]))
@@ -378,10 +378,10 @@ func TestDispatcherHandlePiecePayloadSendsCompleteMessage(t *testing.T) {
 
 	d := testDispatcher(Config{}, clock.NewMock(), torrent)
 
-	p1, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(false), newMockMessages())
+	p1, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(false), newMockMessages())
 	require.NoError(err)
 
-	p2, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(false), newMockMessages())
+	p2, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(false), newMockMessages())
 	require.NoError(err)
 
 	msg := conn.NewPiecePayloadMessage(0, piecereader.NewBuffer(blob.Content[0:1]))
@@ -402,11 +402,11 @@ func TestDispatcherClosesCompletedPeersWhenComplete(t *testing.T) {
 
 	d := testDispatcher(Config{}, clock.NewMock(), torrent)
 
-	completedPeer, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true), newMockMessages())
+	completedPeer, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true), newMockMessages())
 	require.NoError(err)
 
 	incompletePeer, err := d.addPeer(
-		core.PeerIDFixture(), bitsetutil.FromBools(false), newMockMessages())
+		core.PeerIDFixture(), false, bitsetutil.FromBools(false), newMockMessages())
 	require.NoError(err)
 
 	msg := conn.NewPiecePayloadMessage(0, piecereader.NewBuffer(blob.Content[0:1]))
@@ -431,7 +431,7 @@ func TestDispatcherHandleCompleteRequestsPieces(t *testing.T) {
 
 	d := testDispatcher(Config{}, clock.NewMock(), torrent)
 
-	p, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(false), newMockMessages())
+	p, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(false), newMockMessages())
 	require.NoError(err)
 
 	require.Empty(numRequestsPerPiece(p.messages))
@@ -454,7 +454,7 @@ func TestDispatcherPeerPieceCounts(t *testing.T) {
 
 	var err error
 
-	p, err := d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(false, false, false), newMockMessages())
+	p, err := d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(false, false, false), newMockMessages())
 	require.NoError(err)
 
 	require.Equal(0, d.numPeersByPiece.Get(0))
@@ -470,21 +470,21 @@ func TestDispatcherPeerPieceCounts(t *testing.T) {
 
 	require.Equal(2, d.numPeersByPiece.Get(0))
 
-	_, err = d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true, true, true), newMockMessages())
+	_, err = d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true, true, true), newMockMessages())
 	require.NoError(err)
 
 	require.Equal(3, d.numPeersByPiece.Get(0))
 	require.Equal(1, d.numPeersByPiece.Get(1))
 	require.Equal(2, d.numPeersByPiece.Get(2))
 
-	_, err = d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(true, false, true), newMockMessages())
+	_, err = d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(true, false, true), newMockMessages())
 	require.NoError(err)
 
 	require.Equal(4, d.numPeersByPiece.Get(0))
 	require.Equal(1, d.numPeersByPiece.Get(1))
 	require.Equal(3, d.numPeersByPiece.Get(2))
 
-	_, err = d.addPeer(core.PeerIDFixture(), bitsetutil.FromBools(false, false, false), newMockMessages())
+	_, err = d.addPeer(core.PeerIDFixture(), false, bitsetutil.FromBools(false, false, false), newMockMessages())
 	require.NoError(err)
 
 	require.Equal(4, d.numPeersByPiece.Get(0))

--- a/lib/torrent/scheduler/dispatch/peer.go
+++ b/lib/torrent/scheduler/dispatch/peer.go
@@ -24,7 +24,8 @@ import (
 
 // peer consolidates bookeeping for a remote peer.
 type peer struct {
-	id core.PeerID
+	id       core.PeerID
+	isOrigin bool
 
 	// Tracks the pieces which the remote peer has.
 	bitfield *syncBitfield
@@ -43,6 +44,7 @@ type peer struct {
 
 func newPeer(
 	peerID core.PeerID,
+	isOrigin bool,
 	b *bitset.BitSet,
 	messages Messages,
 	clk clock.Clock,
@@ -50,6 +52,7 @@ func newPeer(
 
 	return &peer{
 		id:       peerID,
+		isOrigin: isOrigin,
 		bitfield: newSyncBitfield(b),
 		messages: messages,
 		clk:      clk,

--- a/lib/torrent/scheduler/dispatch/piecerequest/manager.go
+++ b/lib/torrent/scheduler/dispatch/piecerequest/manager.go
@@ -64,8 +64,9 @@ type Manager struct {
 	clock   clock.Clock
 	timeout time.Duration
 
-	policy        pieceSelectionPolicy
-	pipelineLimit int
+	policy              pieceSelectionPolicy
+	agentPipelineLimit  int
+	originPipelineLimit int
 }
 
 // NewManager creates a new Manager.
@@ -73,14 +74,16 @@ func NewManager(
 	clk clock.Clock,
 	timeout time.Duration,
 	policy string,
-	pipelineLimit int) (*Manager, error) {
+	agentPipelineLimit int,
+	originPipelineLimit int) (*Manager, error) {
 
 	m := &Manager{
-		requests:       make(map[int][]*Request),
-		requestsByPeer: make(map[core.PeerID]map[int]*Request),
-		clock:          clk,
-		timeout:        timeout,
-		pipelineLimit:  pipelineLimit,
+		requests:            make(map[int][]*Request),
+		requestsByPeer:      make(map[core.PeerID]map[int]*Request),
+		clock:               clk,
+		timeout:             timeout,
+		agentPipelineLimit:  agentPipelineLimit,
+		originPipelineLimit: originPipelineLimit,
 	}
 
 	switch policy {
@@ -100,6 +103,7 @@ func NewManager(
 // reserved under other peers.
 func (m *Manager) ReservePieces(
 	peerID core.PeerID,
+	isPeerOrigin bool,
 	pieceCandidates *bitset.BitSet,
 	numPeersByPiece syncutil.Counters,
 	allowDuplicates bool) ([]int, error) {
@@ -107,7 +111,7 @@ func (m *Manager) ReservePieces(
 	m.Lock()
 	defer m.Unlock()
 
-	quota := m.requestQuota(peerID)
+	quota := m.requestQuota(peerID, isPeerOrigin)
 	if quota <= 0 {
 		return nil, nil
 	}
@@ -235,8 +239,12 @@ func (m *Manager) validRequest(peerID core.PeerID, pieceIdx int, allowDuplicates
 	return true
 }
 
-func (m *Manager) requestQuota(peerID core.PeerID) int {
-	quota := m.pipelineLimit
+func (m *Manager) requestQuota(peerID core.PeerID, isPeerOrigin bool) int {
+	quota := m.agentPipelineLimit
+	if isPeerOrigin {
+		quota = m.originPipelineLimit
+	}
+
 	pm, ok := m.requestsByPeer[peerID]
 	if !ok {
 		return quota

--- a/lib/torrent/scheduler/dispatch/piecerequest/manager_test.go
+++ b/lib/torrent/scheduler/dispatch/piecerequest/manager_test.go
@@ -31,7 +31,7 @@ func newManager(
 	policy string,
 	pipelineLimit int) *Manager {
 
-	m, err := NewManager(clk, timeout, policy, pipelineLimit)
+	m, err := NewManager(clk, timeout, policy, pipelineLimit, pipelineLimit)
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +54,7 @@ func TestManagerPipelineLimit(t *testing.T) {
 
 	peerID := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(peerID, bitsetutil.FromBools(true, true, true, true),
+	pieces, err := m.ReservePieces(peerID, false, bitsetutil.FromBools(true, true, true, true),
 		countsFromInts(0, 0, 0, 0), false)
 	require.NoError(err)
 	require.Len(pieces, 3)
@@ -72,25 +72,25 @@ func TestManagerReserveExpiredRequest(t *testing.T) {
 
 	peerID := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err := m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
 
 	// Further reservations fail.
-	pieces, err = m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
-	pieces, err = m.ReservePieces(core.PeerIDFixture(), bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(core.PeerIDFixture(), false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
 	clk.Add(timeout + 1)
 
-	pieces, err = m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
@@ -103,25 +103,25 @@ func TestManagerReserveUnsentRequest(t *testing.T) {
 
 	peerID := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err := m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
 
 	// Further reservations fail.
-	pieces, err = m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
-	pieces, err = m.ReservePieces(core.PeerIDFixture(), bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(core.PeerIDFixture(), false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
 	m.MarkUnsent(peerID, 0)
 
-	pieces, err = m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
@@ -134,25 +134,25 @@ func TestManagerReserveInvalidRequest(t *testing.T) {
 
 	peerID := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err := m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
 
 	// Further reservations fail.
-	pieces, err = m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
-	pieces, err = m.ReservePieces(core.PeerIDFixture(), bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(core.PeerIDFixture(), false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
 	m.MarkInvalid(peerID, 0)
 
-	pieces, err = m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
@@ -170,17 +170,17 @@ func TestManagerGetFailedRequests(t *testing.T) {
 	p1 := core.PeerIDFixture()
 	p2 := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(p0, bitsetutil.FromBools(true, true, true),
+	pieces, err := m.ReservePieces(p0, false, bitsetutil.FromBools(true, true, true),
 		countsFromInts(0, 1, 2), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
 
-	pieces, err = m.ReservePieces(p1, bitsetutil.FromBools(false, true, false),
+	pieces, err = m.ReservePieces(p1, false, bitsetutil.FromBools(false, true, false),
 		countsFromInts(0, 1, 2), false)
 	require.NoError(err)
 	require.Equal([]int{1}, pieces)
 
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(false, false, true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(false, false, true),
 		countsFromInts(0, 1, 2), false)
 	require.NoError(err)
 	require.Equal([]int{2}, pieces)
@@ -190,7 +190,7 @@ func TestManagerGetFailedRequests(t *testing.T) {
 	clk.Add(timeout + 1) // Expires p2's request.
 
 	p3 := core.PeerIDFixture()
-	pieces, err = m.ReservePieces(p3, bitsetutil.FromBools(false, false, false, true),
+	pieces, err = m.ReservePieces(p3, false, bitsetutil.FromBools(false, false, false, true),
 		countsFromInts(0, 0, 0, 0), false)
 	require.NoError(err)
 	require.Equal([]int{3}, pieces)
@@ -210,7 +210,7 @@ func TestManagerClear(t *testing.T) {
 
 	peerID := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(peerID, bitsetutil.FromBools(true),
+	pieces, err := m.ReservePieces(peerID, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
@@ -230,17 +230,17 @@ func TestManagerClearPeer(t *testing.T) {
 	p1 := core.PeerIDFixture()
 	p2 := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(p1, bitsetutil.FromBools(true),
+	pieces, err := m.ReservePieces(p1, false, bitsetutil.FromBools(true),
 		countsFromInts(0), false)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
 
-	pieces, err = m.ReservePieces(p1, bitsetutil.FromBools(true, true),
+	pieces, err = m.ReservePieces(p1, false, bitsetutil.FromBools(true, true),
 		countsFromInts(0, 1), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true, true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true, true),
 		countsFromInts(0, 1), false)
 	require.NoError(err)
 	require.Equal([]int{1}, pieces)
@@ -259,19 +259,19 @@ func TestManagerReservePiecesAllowDuplicate(t *testing.T) {
 	p1 := core.PeerIDFixture()
 	p2 := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(p1, bitsetutil.FromBools(true),
+	pieces, err := m.ReservePieces(p1, false, bitsetutil.FromBools(true),
 		countsFromInts(0), true)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
 
 	// Shouldn't allow duplicates on the same peer.
-	pieces, err = m.ReservePieces(p1, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(p1, false, bitsetutil.FromBools(true),
 		countsFromInts(0), true)
 	require.NoError(err)
 	require.Empty(pieces)
 
 	// Should allow duplicates for different peers.
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true),
 		countsFromInts(0), true)
 	require.NoError(err)
 	require.Equal([]int{0}, pieces)
@@ -285,12 +285,12 @@ func TestManagerClearWhenAllowedDuplicates(t *testing.T) {
 	p1 := core.PeerIDFixture()
 	p2 := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(p1, bitsetutil.FromBools(true, true),
+	pieces, err := m.ReservePieces(p1, false, bitsetutil.FromBools(true, true),
 		countsFromInts(0, 0), true)
 	require.NoError(err)
 	require.Equal([]int{0, 1}, pieces)
 
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true, true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true, true),
 		countsFromInts(0, 0), true)
 	require.NoError(err)
 	require.Equal([]int{0, 1}, pieces)
@@ -309,12 +309,12 @@ func TestManagerClearPeerWhenAllowedDuplicates(t *testing.T) {
 	p1 := core.PeerIDFixture()
 	p2 := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(p1, bitsetutil.FromBools(true, true),
+	pieces, err := m.ReservePieces(p1, false, bitsetutil.FromBools(true, true),
 		countsFromInts(0, 0), true)
 	require.NoError(err)
 	require.Equal([]int{0, 1}, pieces)
 
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true, true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true, true),
 		countsFromInts(0, 0), true)
 	require.NoError(err)
 	require.Equal([]int{0, 1}, pieces)
@@ -347,12 +347,12 @@ func TestManagerMarkStatusWhenAllowedDuplicates(t *testing.T) {
 			p1 := core.PeerIDFixture()
 			p2 := core.PeerIDFixture()
 
-			pieces, err := m.ReservePieces(p1, bitsetutil.FromBools(true, true),
+			pieces, err := m.ReservePieces(p1, false, bitsetutil.FromBools(true, true),
 				countsFromInts(0, 0), true)
 			require.NoError(err)
 			require.Equal([]int{0, 1}, pieces)
 
-			pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true, true),
+			pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true, true),
 				countsFromInts(0, 0), true)
 			require.NoError(err)
 			require.Equal([]int{0, 1}, pieces)
@@ -374,34 +374,34 @@ func TestRarestFirstPolicy(t *testing.T) {
 	p2 := core.PeerIDFixture()
 	p3 := core.PeerIDFixture()
 
-	pieces, err := m.ReservePieces(p1, bitsetutil.FromBools(true, true, false, true),
+	pieces, err := m.ReservePieces(p1, false, bitsetutil.FromBools(true, true, false, true),
 		countsFromInts(2, 3, 1, 0), false)
 	require.NoError(err)
 	require.Equal([]int{3, 0}, pieces)
 
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true, true, false, true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true, true, false, true),
 		countsFromInts(2, 3, 1, 0), false)
 	require.NoError(err)
 	require.Equal([]int{1}, pieces)
 
-	pieces, err = m.ReservePieces(p3, bitsetutil.FromBools(true, true, false, true),
+	pieces, err = m.ReservePieces(p3, false, bitsetutil.FromBools(true, true, false, true),
 		countsFromInts(2, 3, 1, 0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
-	pieces, err = m.ReservePieces(p1, bitsetutil.FromBools(true, true, false, true),
+	pieces, err = m.ReservePieces(p1, false, bitsetutil.FromBools(true, true, false, true),
 		countsFromInts(2, 3, 1, 0), false)
 	require.NoError(err)
 	require.Empty(pieces)
 
 	m.MarkUnsent(p1, 3)
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true, true, false, true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true, true, false, true),
 		countsFromInts(2, 3, 1, 0), false)
 	require.NoError(err)
 	require.Equal([]int{3}, pieces)
 
 	m.MarkUnsent(p1, 0)
-	pieces, err = m.ReservePieces(p2, bitsetutil.FromBools(true, true, false, true),
+	pieces, err = m.ReservePieces(p2, false, bitsetutil.FromBools(true, true, false, true),
 		countsFromInts(2, 3, 1, 0), false)
 	require.NoError(err)
 	require.Empty(pieces)

--- a/lib/torrent/scheduler/scheduler.go
+++ b/lib/torrent/scheduler/scheduler.go
@@ -401,7 +401,7 @@ func (s *scheduler) initializeOutgoingHandshake(
 	p *core.PeerInfo, info *storage.TorrentInfo, rb conn.RemoteBitfields, namespace string) {
 
 	addr := fmt.Sprintf("%s:%d", p.IP, p.Port)
-	result, err := s.handshaker.Initialize(p.PeerID, addr, info, rb, namespace)
+	result, err := s.handshaker.Initialize(p.PeerID, p.Origin, addr, info, rb, namespace)
 	if err != nil {
 		s.log(
 			"peer", p.PeerID,

--- a/lib/torrent/scheduler/state.go
+++ b/lib/torrent/scheduler/state.go
@@ -129,7 +129,7 @@ func (s *state) addOutgoingConn(c *conn.Conn, b *bitset.BitSet, info *storage.To
 	if !ok {
 		return errors.New("torrent controls must be created before sending handshake")
 	}
-	if err := ctrl.dispatcher.AddPeer(c.PeerID(), b, c); err != nil {
+	if err := ctrl.dispatcher.AddPeer(c.PeerID(), c.IsPeerOrigin(), b, c); err != nil {
 		return fmt.Errorf("add conn to dispatcher: %s", err)
 	}
 	return nil
@@ -156,7 +156,7 @@ func (s *state) addIncomingConn(
 			return err
 		}
 	}
-	if err := ctrl.dispatcher.AddPeer(c.PeerID(), b, c); err != nil {
+	if err := ctrl.dispatcher.AddPeer(c.PeerID(), c.IsPeerOrigin(), b, c); err != nil {
 		return fmt.Errorf("add conn to dispatcher: %s", err)
 	}
 	return nil


### PR DESCRIPTION
Currently, the P2P algo parallelizes a torrent download from up to 10 peers, downloading up to N torrent pieces from a peer concurrently (also called multiplexing). This level of multiplexing is currently configurable, but must be the same for agents and origins (both of which are considered peers). This PR makes it so we can tune each separately, in case we want to put more/less load on the origin cluster compared to the P2P network.

The concrete reason we want to do that is since we will be reducing the replication factor at Uber from 3 to 2 to reduce load on the origins (disk IO and space being used due to replication). If we only reduce the RF, the agent will now leech blobs from the origin cluster at 2/3 of the previous bandwidth. To prevent this regression, we will bump the multiplexing level from origin by 1.5x.

 - After announcing to tracker, propagate whether a peer is an origin or an agent to the piecerequest manager, where the decision is made how many torrent pieces to request from a peer
 - Add config on how many pieces we should be requesting in parallel from a peer if they are an origin or an agent