### PR TITLE
fix(nginx): update deprecated ssl directive to listen parameter

### DIFF
--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -25,7 +25,7 @@ upstream agent-server {
 }
 
 server {
-  listen {{.port}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
 
   {{range .allowed_cidrs}}
     allow {{.}};

--- a/nginx/config/base.go
+++ b/nginx/config/base.go
@@ -62,7 +62,6 @@ http {
   ##
 
   {{if .ssl_enabled}}
-    ssl on;
     ssl_certificate {{.ssl_certificate}};
     ssl_certificate_key {{.ssl_certificate_key}};
     {{if .ssl_password_file}}

--- a/nginx/config/build-index.go
+++ b/nginx/config/build-index.go
@@ -24,7 +24,7 @@ upstream build-index {
 }
 
 server {
-  listen {{.port}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
 
   {{.client_verification}}
 

--- a/nginx/config/origin.go
+++ b/nginx/config/origin.go
@@ -16,7 +16,7 @@ package config
 // OriginTemplate is the default origin nginx tmpl.
 const OriginTemplate = `
 server {
-  listen {{.port}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
 
   {{.client_verification}}
 

--- a/nginx/config/proxy.go
+++ b/nginx/config/proxy.go
@@ -29,7 +29,7 @@ upstream proxy-server {
 
 {{range .ports}}
 server {
-  listen {{.}};
+  listen {{.}}{{if $.ssl_enabled}} ssl{{end}};
 
   {{$.client_verification}}
 

--- a/nginx/config/tracker.go
+++ b/nginx/config/tracker.go
@@ -22,7 +22,7 @@ upstream tracker {
 }
 
 server {
-  listen {{.port}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
 
   {{.client_verification}}
 

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -131,6 +131,9 @@ func (c *Config) Build(params map[string]interface{}) ([]byte, error) {
 	if _, ok := params["proxy_read_timeout"]; !ok {
 		params["proxy_read_timeout"] = c.ProxyTimeout
 	}
+	if _, ok := params["ssl_enabled"]; !ok {
+		params["ssl_enabled"] = !c.tls.Server.Disabled
+	}
 	site, err := populateTemplate(tmpl, params)
 	if err != nil {
 		return nil, fmt.Errorf("populate template: %s", err)


### PR DESCRIPTION
This PR fixes a deployment failure in the control plane services caused by the `ssl on;` directive, which has been removed in newer versions of Nginx. This fix moves SSL configuration to the `listen` directive instead.