### PR TITLE
feat(agent): emit download counter for blob download qps

### DIFF
--- a/lib/dockerregistry/transfer/ro_transferer.go
+++ b/lib/dockerregistry/transfer/ro_transferer.go
@@ -69,6 +69,7 @@ func (t *ReadOnlyTransferer) Stat(namespace string, d core.Digest) (*core.BlobIn
 
 // Download downloads blobs as torrent.
 func (t *ReadOnlyTransferer) Download(namespace string, d core.Digest) (store.FileReader, error) {
+	t.stats.Counter("downloads").Inc(1)
 	f, err := t.cads.Cache().GetFileReader(d.Hex())
 	if os.IsNotExist(err) || t.cads.InDownloadError(err) {
 		if err := t.sched.Download(namespace, d); err != nil {


### PR DESCRIPTION
This PR adds a download counter to the read-only transferer to improve agent observability by being able to track its download QPS.