### PR TITLE
feat(proxy): emit upload counter for blob upload qps

### DIFF
--- a/lib/dockerregistry/transfer/rw_transferer.go
+++ b/lib/dockerregistry/transfer/rw_transferer.go
@@ -176,6 +176,7 @@ func (t *ReadWriteTransferer) downloadFromOrigin(ctx context.Context, namespace 
 func (t *ReadWriteTransferer) Upload(
 	namespace string, d core.Digest, blob store.FileReader,
 ) error {
+	t.stats.Counter("upload_requests").Inc(1)
 	ctx, span := t.tracer.Start(context.Background(), "registry.upload_blob",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(


### PR DESCRIPTION
This PR adds an upload counter to the read-write transferer to measure proxy blob upload QPS.