### PR TITLE
feat(agent): emit e2e torrent download throughput metric

### DIFF
--- a/lib/torrent/scheduler/buckets.go
+++ b/lib/torrent/scheduler/buckets.go
@@ -25,55 +25,38 @@ const (
 )
 
 var (
-	_sizeBoundaries         = []uint64{0, 100 * memsize.MB, memsize.GB, 2 * memsize.GB, 5 * memsize.GB, 10 * memsize.GB}
-	_sizeTags               = []string{_xsmall, _small, _medium, _large, _xlarge, _xxlarge}
-	_downloadLatencyBuckets = append(
-		[]time.Duration{
-			0,
-			500 * time.Millisecond,
-			1 * time.Second,
-			2 * time.Second,
-			4 * time.Second,
-			7 * time.Second,
-			12 * time.Second,
-			15 * time.Second,
-		},
-		append(
-			tally.MustMakeLinearDurationBuckets(20*time.Second, 5*time.Second, 9),
-			append(
-				tally.MustMakeLinearDurationBuckets(70*time.Second, 10*time.Second, 6),
-				append(
-					tally.MustMakeLinearDurationBuckets(140*time.Second, 20*time.Second, 6),
-					append(
-						tally.MustMakeLinearDurationBuckets(270*time.Second, 30*time.Second, 8),
-						append(
-							tally.MustMakeLinearDurationBuckets(540*time.Second, 60*time.Second, 7),
-							append(
-								tally.MustMakeLinearDurationBuckets(1020*time.Second, 120*time.Second, 5),
-								append(
-									tally.MustMakeLinearDurationBuckets(1800*time.Second, 300*time.Second, 3),
-									tally.MustMakeLinearDurationBuckets(2700*time.Second, 300*time.Second, 4)...,
-								)...,
-							)...,
-						)...,
-					)...,
-				)...,
-			)...,
-		)...,
-	)
+	_sizeBoundaries = []uint64{0, 100 * memsize.MB, memsize.GB, 2 * memsize.GB, 5 * memsize.GB, 10 * memsize.GB}
+	_sizeTags       = []string{_xsmall, _small, _medium, _large, _xlarge, _xxlarge}
 
+	_downloadLatencyBuckets tally.DurationBuckets
 	// In MiB/s.
-	_downloadThroughputBuckets = append(
-		tally.MustMakeLinearValueBuckets(0, 1, 10), // [0, 10)
-		append(
-			tally.MustMakeLinearValueBuckets(10, 2, 5), // [10, 20)
-			append(
-				tally.MustMakeLinearValueBuckets(20, 5, 6), // [20, 50)
-				append(
-					tally.MustMakeLinearValueBuckets(50, 10, 15),                // [50, 200)
-					tally.MustMakeLinearValueBuckets(200, 50, 4)...)...)...)..., // [200, 400)
-	)
+	_downloadThroughputBuckets tally.ValueBuckets
 )
+
+func init() {
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, 0,
+		500*time.Millisecond,
+		1*time.Second,
+		2*time.Second,
+		4*time.Second,
+		7*time.Second,
+		12*time.Second,
+		15*time.Second)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(20*time.Second, 5*time.Second, 9)...)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(70*time.Second, 10*time.Second, 6)...)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(140*time.Second, 20*time.Second, 6)...)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(270*time.Second, 30*time.Second, 8)...)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(540*time.Second, 60*time.Second, 7)...)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(1020*time.Second, 120*time.Second, 5)...)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(1800*time.Second, 300*time.Second, 3)...)
+	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(2700*time.Second, 300*time.Second, 4)...)
+
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(0, 1, 10)...)   // [0, 10)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(10, 2, 5)...)   // [10, 20)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(20, 5, 6)...)   // [20, 50)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(50, 10, 15)...) // [50, 200)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(200, 50, 4)...) // [200, 400)
+}
 
 func getSizeTag(sizeBytes uint64) string {
 	for i := len(_sizeBoundaries) - 1; i >= 0; i-- {
@@ -92,7 +75,7 @@ func emitBlobDownloadPerformance(stats tally.Scope, sizeBytes int64, t time.Dura
 	stats.Tagged(map[string]string{
 		"size":    sizeTag,
 		"version": "4",
-	}).Histogram("download_time", tally.DurationBuckets(_downloadLatencyBuckets)).RecordDuration(t)
+	}).Histogram("download_time", _downloadLatencyBuckets).RecordDuration(t)
 
 	mbPerSecond := (float64(sizeBytes) / (float64(memsize.MB))) / t.Seconds()
 	stats.Tagged(map[string]string{

--- a/lib/torrent/scheduler/buckets.go
+++ b/lib/torrent/scheduler/buckets.go
@@ -25,45 +25,55 @@ const (
 )
 
 var (
-	_sizeBoundaries = []uint64{0, 100 * memsize.MB, memsize.GB, 2 * memsize.GB, 5 * memsize.GB, 10 * memsize.GB}
-	_sizeTags       = []string{_xsmall, _small, _medium, _large, _xlarge, _xxlarge}
-	_buckets        = tally.DurationBuckets{}
+	_sizeBoundaries         = []uint64{0, 100 * memsize.MB, memsize.GB, 2 * memsize.GB, 5 * memsize.GB, 10 * memsize.GB}
+	_sizeTags               = []string{_xsmall, _small, _medium, _large, _xlarge, _xxlarge}
+	_downloadLatencyBuckets = append(
+		[]time.Duration{
+			0,
+			500 * time.Millisecond,
+			1 * time.Second,
+			2 * time.Second,
+			4 * time.Second,
+			7 * time.Second,
+			12 * time.Second,
+			15 * time.Second,
+		},
+		append(
+			tally.MustMakeLinearDurationBuckets(20*time.Second, 5*time.Second, 9),
+			append(
+				tally.MustMakeLinearDurationBuckets(70*time.Second, 10*time.Second, 6),
+				append(
+					tally.MustMakeLinearDurationBuckets(140*time.Second, 20*time.Second, 6),
+					append(
+						tally.MustMakeLinearDurationBuckets(270*time.Second, 30*time.Second, 8),
+						append(
+							tally.MustMakeLinearDurationBuckets(540*time.Second, 60*time.Second, 7),
+							append(
+								tally.MustMakeLinearDurationBuckets(1020*time.Second, 120*time.Second, 5),
+								append(
+									tally.MustMakeLinearDurationBuckets(1800*time.Second, 300*time.Second, 3),
+									tally.MustMakeLinearDurationBuckets(2700*time.Second, 300*time.Second, 4)...,
+								)...,
+							)...,
+						)...,
+					)...,
+				)...,
+			)...,
+		)...,
+	)
+
+	// In MiB/s.
+	_downloadThroughputBuckets = append(
+		tally.MustMakeLinearValueBuckets(0, 1, 10), // [0, 10)
+		append(
+			tally.MustMakeLinearValueBuckets(10, 2, 5), // [10, 20)
+			append(
+				tally.MustMakeLinearValueBuckets(20, 5, 6), // [20, 50)
+				append(
+					tally.MustMakeLinearValueBuckets(50, 10, 15),                // [50, 200)
+					tally.MustMakeLinearValueBuckets(200, 50, 4)...)...)...)..., // [200, 400)
+	)
 )
-
-func createBucketBounderies(start, stop, width time.Duration) []time.Duration {
-	var buckets []time.Duration
-	for cur := start; cur <= stop; cur += width {
-		buckets = append(buckets, cur)
-	}
-	return buckets
-}
-
-func init() {
-	_buckets = []time.Duration{
-		500 * time.Millisecond,
-		1 * time.Second,
-		2 * time.Second,
-		4 * time.Second,
-		7 * time.Second,
-		12 * time.Second,
-		15 * time.Second,
-	}
-	_buckets = append(_buckets, createBucketBounderies(20*time.Second, time.Minute, 5*time.Second)...)
-	_buckets = append(_buckets, createBucketBounderies(time.Minute+10*time.Second, 2*time.Minute, 10*time.Second)...)
-	_buckets = append(_buckets, createBucketBounderies(2*time.Minute+20*time.Second, 4*time.Minute, 20*time.Second)...)
-	_buckets = append(_buckets, createBucketBounderies(4*time.Minute+30*time.Second, 8*time.Minute, 30*time.Second)...)
-	_buckets = append(_buckets, createBucketBounderies(9*time.Minute, 15*time.Minute, time.Minute)...)
-	_buckets = append(_buckets, createBucketBounderies(17*time.Minute, 25*time.Minute, 2*time.Minute)...)
-	_buckets = append(_buckets, createBucketBounderies(30*time.Minute, 40*time.Minute, 5*time.Minute)...)
-	_buckets = append(_buckets, createBucketBounderies(45*time.Minute, 60*time.Minute, 5*time.Minute)...)
-
-	// Sanity check to ensure buckets are sorted.
-	for i := 0; i < len(_buckets)-1; i++ {
-		if _buckets[i] >= _buckets[i+1] {
-			panic("buckets are not sorted properly")
-		}
-	}
-}
 
 func getSizeTag(sizeBytes uint64) string {
 	for i := len(_sizeBoundaries) - 1; i >= 0; i-- {
@@ -74,11 +84,18 @@ func getSizeTag(sizeBytes uint64) string {
 	return _sizeTags[0]
 }
 
-func emitDownloadTime(stats tally.Scope, sizeBytes int64, t time.Duration) {
+// emitBlobDownloadPerformance emits metrics on the speed of a blob's download from the moment
+// the blob was requested through Kraken's API to the moment it is fully downloaded.
+func emitBlobDownloadPerformance(stats tally.Scope, sizeBytes int64, t time.Duration) {
 	sizeTag := getSizeTag(uint64(sizeBytes))
 
 	stats.Tagged(map[string]string{
 		"size":    sizeTag,
 		"version": "4",
-	}).Histogram("download_time", _buckets).RecordDuration(t)
+	}).Histogram("download_time", tally.DurationBuckets(_downloadLatencyBuckets)).RecordDuration(t)
+
+	mbPerSecond := (float64(sizeBytes) / (float64(memsize.MB))) / t.Seconds()
+	stats.Tagged(map[string]string{
+		"size": sizeTag,
+	}).Histogram("download_throughput", _downloadThroughputBuckets).RecordValue(mbPerSecond)
 }

--- a/lib/torrent/scheduler/buckets_test.go
+++ b/lib/torrent/scheduler/buckets_test.go
@@ -14,6 +14,7 @@
 package scheduler
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -74,7 +75,7 @@ func TestEmitBlobDownloadPerformance(t *testing.T) {
 		require := require.New(t)
 		stats := tally.NewTestScope("", nil)
 
-		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 2*time.Second)   //1.5 MiB/s
+		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 2*time.Second)   // 1.5 MiB/s
 		emitBlobDownloadPerformance(stats, 10*int64(memsize.GB), 20*time.Minute) // 8.53 MiB/s
 
 		snapshot := stats.Snapshot()
@@ -89,5 +90,22 @@ func TestEmitBlobDownloadPerformance(t *testing.T) {
 		downloadThroughputXXlarge, ok := histograms[downloadThroughputXXlargeKey]
 		require.True(ok)
 		require.Equal(int64(1), downloadThroughputXXlarge.Values()[9])
+	})
+
+	t.Run("extremely small or large throughput", func(t *testing.T) {
+		require := require.New(t)
+		stats := tally.NewTestScope("", nil)
+
+		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 2*time.Millisecond) // 1500 MiB/s
+		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 1*time.Hour)        // 0.000833333333 MiB/s
+
+		snapshot := stats.Snapshot()
+		histograms := snapshot.Histograms()
+
+		downloadThroughputXsmallKey := "download_throughput+size=0B-100MiB"
+		downloadThroughputXsmall, ok := histograms[downloadThroughputXsmallKey]
+		require.True(ok)
+		require.Equal(int64(1), downloadThroughputXsmall.Values()[math.MaxFloat64])
+		require.Equal(int64(1), downloadThroughputXsmall.Values()[1])
 	})
 }

--- a/lib/torrent/scheduler/buckets_test.go
+++ b/lib/torrent/scheduler/buckets_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"github.com/uber/kraken/utils/memsize"
 )
 
@@ -38,19 +39,55 @@ func TestGetSizeTag(t *testing.T) {
 	}
 }
 
-func TestCreateBucketBounderies(t *testing.T) {
-	tests := map[string]struct {
-		start, stop, width time.Duration
-		expected           []time.Duration
-	}{
-		"normal": {1, 4, 1, []time.Duration{1, 2, 3, 4}},
-		"single": {1, 4, 5, []time.Duration{1}},
-		"none":   {4, 1, 1, nil},
+func TestBucketsConfiguredCorrectly(t *testing.T) {
+	for i := 0; i < len(_downloadLatencyBuckets)-1; i++ {
+		require.True(t, _downloadLatencyBuckets[i] < _downloadLatencyBuckets[i+1])
 	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			res := createBucketBounderies(tt.start, tt.stop, tt.width)
-			require.Equal(t, tt.expected, res)
-		})
+
+	for i := 0; i < len(_downloadThroughputBuckets)-1; i++ {
+		require.True(t, _downloadThroughputBuckets[i] < _downloadThroughputBuckets[i+1])
 	}
+}
+
+func TestEmitBlobDownloadPerformance(t *testing.T) {
+	t.Run("latency", func(t *testing.T) {
+		require := require.New(t)
+		stats := tally.NewTestScope("", nil)
+
+		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 220*time.Millisecond)
+		emitBlobDownloadPerformance(stats, 10*int64(memsize.GB), 20*time.Minute)
+
+		snapshot := stats.Snapshot()
+		histograms := snapshot.Histograms()
+		downloadTimeXsmallKey := "download_time+size=0B-100MiB,version=4"
+		downloadTimeXsmall, ok := histograms[downloadTimeXsmallKey]
+		require.True(ok)
+		require.Equal(int64(1), downloadTimeXsmall.Durations()[500*time.Millisecond])
+
+		downloadTimeXXlargeKey := "download_time+size=10GiB+,version=4"
+		downloadTimeXXlarge, ok := histograms[downloadTimeXXlargeKey]
+		require.True(ok)
+		require.Equal(int64(1), downloadTimeXXlarge.Durations()[1260*time.Second])
+	})
+
+	t.Run("throughput", func(t *testing.T) {
+		require := require.New(t)
+		stats := tally.NewTestScope("", nil)
+
+		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 2*time.Second)   //1.5 MiB/s
+		emitBlobDownloadPerformance(stats, 10*int64(memsize.GB), 20*time.Minute) // 8.53 MiB/s
+
+		snapshot := stats.Snapshot()
+		histograms := snapshot.Histograms()
+
+		downloadThroughputXsmallKey := "download_throughput+size=0B-100MiB"
+		downloadThroughputXsmall, ok := histograms[downloadThroughputXsmallKey]
+		require.True(ok)
+		require.Equal(int64(1), downloadThroughputXsmall.Values()[2])
+
+		downloadThroughputXXlargeKey := "download_throughput+size=10GiB+"
+		downloadThroughputXXlarge, ok := histograms[downloadThroughputXXlargeKey]
+		require.True(ok)
+		require.Equal(int64(1), downloadThroughputXXlarge.Values()[9])
+	})
 }

--- a/lib/torrent/scheduler/scheduler.go
+++ b/lib/torrent/scheduler/scheduler.go
@@ -275,7 +275,7 @@ func (s *scheduler) Download(namespace string, d core.Digest) error {
 		s.torrentlog.DownloadFailure(namespace, d, size, err)
 	} else {
 		downloadTime := time.Since(start)
-		emitDownloadTime(s.stats, size, downloadTime)
+		emitBlobDownloadPerformance(s.stats, size, downloadTime)
 		s.torrentlog.DownloadSuccess(namespace, d, size, downloadTime)
 	}
 	return err


### PR DESCRIPTION
Currently, we emit the following metrics for kraken-agent blob download performance:
1. leeching throughput from the p2p network (excludes the time to get metainfo from origin from the throughput calculation)
2. e2e torrent download time, including metainfo download.

This PR adds a 3rd metric - e2e throughput for downloading a torrent/blob in kraken-agent, INCLUDING receiving metainfo from origin. Since the Kraken customer cares only about the throughput of their blob download and not about the internals of Kraken, we should have a version of this metric that includes metainfo download, especially since it is a significant bottleneck (origin needs to download the full blob from GCS to calculate the metainfo).

 - emit histogram metric for e2e torrent download throughput (only for successful downloads)
 - fix buckets for e2e torrent download metric (the 0ms-500ms bucket was missing)
 - add tests for both the new and the old metrics
 - simplify the file for emitting download metrics
   - no longer uses `init` (bad practice)
   - no longer has a function for creating linear duration buckets, but instead now we reuse the `tally.MustMakeLinearBuckets` functions