### PR TITLE
feat: add ability to enable mutex profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,27 @@ All new features and bug fixes must include tests.
 - Logs are your friend - check component logs
 - Visualization tool available: `tools/bin/visualization`
 
+#### Mutex contention profiling
+
+All services support `--mutex-profile-fraction=N` (default 0, disabled). When
+enabled, ~1/N mutex contention events are recorded and exposed at
+`/debug/pprof/mutex`.
+
+```bash
+# Start any service with profiling enabled (1 = record every event)
+kraken-origin --mutex-profile-fraction=1 [other flags]
+
+# View the profile as text
+curl "http://localhost:<port>/debug/pprof/mutex?debug=1"
+
+# Analyze interactively
+go tool pprof http://localhost:<port>/debug/pprof/mutex
+```
+
+The devcluster already passes `--mutex-profile-fraction=1` to all services.
+Devcluster ports: proxy=15000, origin=15002, tracker=15003, build-index=15004,
+agent-1=16002, agent-2=17002.
+
 ### Modifying storage backends
 - Look at existing implementations in `lib/backend`
 - Maintain interface compatibility

--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
@@ -42,14 +43,15 @@ import (
 
 // Flags defines agent CLI flags.
 type Flags struct {
-	PeerIP            string
-	PeerPort          int
-	AgentServerPort   int
-	AgentRegistryPort int
-	ConfigFile        string
-	Zone              string
-	KrakenCluster     string
-	SecretsFile       string
+	PeerIP               string
+	PeerPort             int
+	AgentServerPort      int
+	AgentRegistryPort    int
+	ConfigFile           string
+	Zone                 string
+	KrakenCluster        string
+	SecretsFile          string
+	MutexProfileFraction int
 }
 
 // ParseFlags parses agent CLI flags.
@@ -71,6 +73,9 @@ func ParseFlags() *Flags {
 		&flags.KrakenCluster, "cluster", "", "cluster name (e.g. prod01-zone1)")
 	flag.StringVar(
 		&flags.SecretsFile, "secrets", "", "path to a secrets YAML file to load into configuration")
+	flag.IntVar(
+		&flags.MutexProfileFraction, "mutex-profile-fraction", 0,
+		"rate for runtime.SetMutexProfileFraction; 0 disables, 1 records all events")
 	flag.Parse()
 	return &flags
 }
@@ -113,6 +118,10 @@ func Run(flags *Flags, opts ...Option) {
 	var overrides options
 	for _, o := range opts {
 		o(&overrides)
+	}
+
+	if flags.MutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(flags.MutexProfileFraction)
 	}
 
 	var config Config

--- a/agent/cmd/cmd_test.go
+++ b/agent/cmd/cmd_test.go
@@ -52,6 +52,7 @@ func TestParseFlags(t *testing.T) {
 	assert.Equal(t, "test-zone", flags.Zone)
 	assert.Equal(t, "test-cluster", flags.KrakenCluster)
 	assert.Equal(t, "secrets.yaml", flags.SecretsFile)
+	assert.Equal(t, 0, flags.MutexProfileFraction)
 }
 
 func TestWithConfigOption(t *testing.T) {

--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"flag"
+	"runtime"
 
 	"github.com/uber/kraken/build-index/tagclient"
 	"github.com/uber/kraken/build-index/tagserver"
@@ -43,10 +44,11 @@ import (
 
 // Flags defines build-index CLI flags.
 type Flags struct {
-	Port          int
-	ConfigFile    string
-	KrakenCluster string
-	SecretsFile   string
+	Port                 int
+	ConfigFile           string
+	KrakenCluster        string
+	SecretsFile          string
+	MutexProfileFraction int
 }
 
 // ParseFlags parses build-index CLI flags.
@@ -60,6 +62,9 @@ func ParseFlags() *Flags {
 		&flags.KrakenCluster, "cluster", "", "cluster name (e.g. prod01-zone1)")
 	flag.StringVar(
 		&flags.SecretsFile, "secrets", "", "path to a secrets YAML file to load into configuration")
+	flag.IntVar(
+		&flags.MutexProfileFraction, "mutex-profile-fraction", 0,
+		"rate for runtime.SetMutexProfileFraction; 0 disables, 1 records all events")
 	flag.Parse()
 	return &flags
 }
@@ -98,6 +103,10 @@ func Run(flags *Flags, opts ...Option) {
 	var overrides options
 	for _, o := range opts {
 		o(&overrides)
+	}
+
+	if flags.MutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(flags.MutexProfileFraction)
 	}
 
 	var config Config

--- a/examples/devcluster/agent_one_start_container.sh
+++ b/examples/devcluster/agent_one_start_container.sh
@@ -12,4 +12,4 @@ docker run -d \
     -v $(pwd)/examples/devcluster/config/agent/development.yaml:/etc/kraken/config/agent/development.yaml \
     --name ${AGENT_CONTAINER_NAME} \
     kraken-agent:dev \
-    /usr/bin/kraken-agent --config=/etc/kraken/config/agent/development.yaml --peer-ip=${HOSTNAME} --peer-port=${AGENT_PEER_PORT} --agent-server-port=${AGENT_SERVER_PORT} --agent-registry-port=${AGENT_REGISTRY_PORT}
+    /usr/bin/kraken-agent --config=/etc/kraken/config/agent/development.yaml --peer-ip=${HOSTNAME} --peer-port=${AGENT_PEER_PORT} --agent-server-port=${AGENT_SERVER_PORT} --agent-registry-port=${AGENT_REGISTRY_PORT} --mutex-profile-fraction=1

--- a/examples/devcluster/agent_two_start_container.sh
+++ b/examples/devcluster/agent_two_start_container.sh
@@ -12,4 +12,4 @@ docker run -d \
     -v $(pwd)/examples/devcluster/config/agent/development.yaml:/etc/kraken/config/agent/development.yaml \
     --name ${AGENT_CONTAINER_NAME} \
     kraken-agent:dev \
-    /usr/bin/kraken-agent --config=/etc/kraken/config/agent/development.yaml --peer-ip=${HOSTNAME} --peer-port=${AGENT_PEER_PORT} --agent-server-port=${AGENT_SERVER_PORT} --agent-registry-port=${AGENT_REGISTRY_PORT}
+    /usr/bin/kraken-agent --config=/etc/kraken/config/agent/development.yaml --peer-ip=${HOSTNAME} --peer-port=${AGENT_PEER_PORT} --agent-server-port=${AGENT_SERVER_PORT} --agent-registry-port=${AGENT_REGISTRY_PORT} --mutex-profile-fraction=1

--- a/examples/devcluster/herd_start_processes.sh
+++ b/examples/devcluster/herd_start_processes.sh
@@ -16,21 +16,25 @@ sleep 3
     --blobserver-port=${ORIGIN_SERVER_PORT} \
     --peer-ip=${HOSTNAME} \
     --peer-port=${ORIGIN_PEER_PORT} \
+    --mutex-profile-fraction=1 \
     &>/var/log/kraken/kraken-origin/stdout.log &
 
 /usr/bin/kraken-tracker \
     --config=/etc/kraken/config/tracker/development.yaml \
     --port=${TRACKER_PORT} \
+    --mutex-profile-fraction=1 \
     &>/var/log/kraken/kraken-tracker/stdout.log &
 
 /usr/bin/kraken-build-index \
     --config=/etc/kraken/config/build-index/development.yaml \
     --port=${BUILD_INDEX_PORT} \
+    --mutex-profile-fraction=1 \
     &>/var/log/kraken/kraken-build-index/stdout.log &
 
 /usr/bin/kraken-proxy \
     --config=/etc/kraken/config/proxy/development.yaml \
     --port=${PROXY_PORT} \
+    --mutex-profile-fraction=1 \
     &>/var/log/kraken/kraken-proxy/stdout.log &
 
 sleep 3

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/backend"
@@ -52,14 +53,15 @@ import (
 
 // Flags defines origin CLI flags.
 type Flags struct {
-	PeerIP             string
-	PeerPort           int
-	BlobServerHostName string
-	BlobServerPort     int
-	ConfigFile         string
-	Zone               string
-	KrakenCluster      string
-	SecretsFile        string
+	PeerIP               string
+	PeerPort             int
+	BlobServerHostName   string
+	BlobServerPort       int
+	ConfigFile           string
+	Zone                 string
+	KrakenCluster        string
+	SecretsFile          string
+	MutexProfileFraction int
 }
 
 // ParseFlags parses origin CLI flags.
@@ -81,6 +83,9 @@ func ParseFlags() *Flags {
 		&flags.KrakenCluster, "cluster", "", "cluster name (e.g. prod01-zone1)")
 	flag.StringVar(
 		&flags.SecretsFile, "secrets", "", "path to a secrets YAML file to load into configuration")
+	flag.IntVar(
+		&flags.MutexProfileFraction, "mutex-profile-fraction", 0,
+		"rate for runtime.SetMutexProfileFraction; 0 disables, 1 records all events")
 	flag.Parse()
 	return &flags
 }
@@ -122,6 +127,10 @@ func Run(flags *Flags, opts ...Option) {
 	var overrides options
 	for _, o := range opts {
 		o(&overrides)
+	}
+
+	if flags.MutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(flags.MutexProfileFraction)
 	}
 
 	var config Config

--- a/proxy/cmd/cmd.go
+++ b/proxy/cmd/cmd.go
@@ -16,6 +16,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"runtime"
 
 	"github.com/uber-go/tally"
 	"github.com/uber/kraken/build-index/tagclient"
@@ -37,10 +38,11 @@ import (
 
 // Flags defines proxy CLI flags.
 type Flags struct {
-	Ports         flagutil.Ints
-	ConfigFile    string
-	KrakenCluster string
-	SecretsFile   string
+	Ports                flagutil.Ints
+	ConfigFile           string
+	KrakenCluster        string
+	SecretsFile          string
+	MutexProfileFraction int
 }
 
 // ParseFlags parses proxy CLI flags.
@@ -54,6 +56,9 @@ func ParseFlags() *Flags {
 		&flags.KrakenCluster, "cluster", "", "cluster name (e.g. prod01-zone1)")
 	flag.StringVar(
 		&flags.SecretsFile, "secrets", "", "path to a secrets YAML file to load into configuration")
+	flag.IntVar(
+		&flags.MutexProfileFraction, "mutex-profile-fraction", 0,
+		"rate for runtime.SetMutexProfileFraction; 0 disables, 1 records all events")
 	flag.Parse()
 	return &flags
 }
@@ -98,6 +103,10 @@ func Run(flags *Flags, opts ...Option) {
 	var overrides options
 	for _, o := range opts {
 		o(&overrides)
+	}
+
+	if flags.MutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(flags.MutexProfileFraction)
 	}
 
 	var config Config

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -16,6 +16,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"runtime"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/uber-go/tally"
@@ -36,10 +37,11 @@ import (
 
 // Flags define tracker CLI flags.
 type Flags struct {
-	Port          int
-	ConfigFile    string
-	KrakenCluster string
-	SecretsFile   string
+	Port                 int
+	ConfigFile           string
+	KrakenCluster        string
+	SecretsFile          string
+	MutexProfileFraction int
 }
 
 // ParseFlags parses tracker CLI flags.
@@ -53,6 +55,9 @@ func ParseFlags() *Flags {
 		&flags.KrakenCluster, "cluster", "", "cluster name (e.g. prod01-zone1)")
 	flag.StringVar(
 		&flags.SecretsFile, "secrets", "", "path to a secrets YAML file to load into configuration")
+	flag.IntVar(
+		&flags.MutexProfileFraction, "mutex-profile-fraction", 0,
+		"rate for runtime.SetMutexProfileFraction; 0 disables, 1 records all events")
 	flag.Parse()
 	return &flags
 }
@@ -87,6 +92,10 @@ func Run(flags *Flags, opts ...Option) {
 	var overrides options
 	for _, o := range opts {
 		o(&overrides)
+	}
+
+	if flags.MutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(flags.MutexProfileFraction)
 	}
 
 	var config Config


### PR DESCRIPTION
# What?
Add the ability to enable mutex profile fraction in all services of Kraken

# Why?
As of now, there's no way to enable mutex profile contention. As we are exploring different types of hosts for kraken we need to verify the performance changes by profiling. For debugging, a mutex profile is needed rather than taking a trace every time; it is much cleaner and provides clear code paths for the contending mutexes.

## Why not enable it by default without using a flag?
mutex profile has an overhead since every mutex action needs to be sampled (decided by the rate provided) ref: https://cs.opensource.google/go/go/+/go1.24.0:src/runtime/mprof.go;l=892. We will use this flag to selectively enable mutex profile

# Testing
Enabled by default in devcluster
Output:
```
> curl http://localhost:16002/debug/pprof/mutex\?debug\=1
--- mutex:
cycles/second=2449999982
sampling period=1
2770415 29 @ 0x9d1fa1
#       0x9d1fa0        runtime._LostContendedRuntimeLock+0x0   /usr/local/go/src/runtime/proc.go:5444

> curl http://localhost:15003/debug/pprof/mutex\?debug\=1
--- mutex:
cycles/second=2450000025
sampling period=1
162315 6 @ 0x4504a1
#       0x4504a0        runtime._LostContendedRuntimeLock+0x0   /usr/local/go/src/runtime/proc.go:5444
```