### PR TITLE
feat(agent): emit metainfo download time and throughput

### DIFF
--- a/lib/torrent/observability/download_performance.go
+++ b/lib/torrent/observability/download_performance.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package scheduler
+package observability
 
 import (
 	"time"
@@ -67,18 +67,49 @@ func getSizeTag(sizeBytes uint64) string {
 	return _sizeTags[0]
 }
 
-// emitBlobDownloadPerformance emits metrics on the speed of a blob's download from the moment
-// the blob was requested through Kraken's API to the moment it is fully downloaded.
-func emitBlobDownloadPerformance(stats tally.Scope, sizeBytes int64, t time.Duration) {
-	sizeTag := getSizeTag(uint64(sizeBytes))
+type DownloadType string
 
+const (
+	TORRENT_DOWNLOAD  DownloadType = "TORRENT_DOWNLOAD"
+	METAINFO_DOWNLOAD DownloadType = "METAINFO_DOWNLOAD"
+)
+
+// EmitDownloadPerformance emits metrics on the download performance for either a torrent (blob) download
+// or a metainfo download. Both latency and throughput are measured for the end-to-end download.
+// the blob was requested through Kraken's API to the moment it is fully downloaded.
+func EmitDownloadPerformance(stats tally.Scope, downloadType DownloadType, sizeBytes int64, t time.Duration) {
+	sizeTag := getSizeTag(uint64(sizeBytes))
+	mbPerSecond := (float64(sizeBytes) / (float64(memsize.MB))) / t.Seconds()
+
+	switch downloadType {
+	case TORRENT_DOWNLOAD:
+		emitBlobDownloadPerformance(stats, mbPerSecond, sizeTag, t)
+	case METAINFO_DOWNLOAD:
+		emitMetainfoDownloadPerformance(stats, mbPerSecond, sizeTag, t)
+	}
+}
+
+func emitBlobDownloadPerformance(stats tally.Scope, mbPerSecond float64, sizeTag string, t time.Duration) {
 	stats.Tagged(map[string]string{
 		"size":    sizeTag,
 		"version": "4",
 	}).Histogram("download_time", _downloadLatencyBuckets).RecordDuration(t)
 
-	mbPerSecond := (float64(sizeBytes) / (float64(memsize.MB))) / t.Seconds()
 	stats.Tagged(map[string]string{
 		"size": sizeTag,
 	}).Histogram("download_throughput", _downloadThroughputBuckets).RecordValue(mbPerSecond)
+}
+
+func emitMetainfoDownloadPerformance(stats tally.Scope, mbPerSecond float64, sizeTag string, t time.Duration) {
+	// Metrics are tagged by torrent_size, as origin needs to download the blob from storage (e.g. GCS) to
+	// calculate its metainfo, before returning it to tracker, which in turn, returns it to agent. Thus, even if
+	// metainfo itself is <1 KiB, its download may take 10s of minutes on huge blobs.
+
+	stats.Tagged(map[string]string{
+		"torrent_size": sizeTag,
+	}).Histogram("metainfo_download_time", _downloadLatencyBuckets).RecordDuration(t)
+
+	stats.Tagged(map[string]string{
+		"torrent_size": sizeTag,
+	}).Histogram("metainfo_download_throughput", _downloadThroughputBuckets).RecordValue(mbPerSecond)
 }

--- a/lib/torrent/observability/download_performance.go
+++ b/lib/torrent/observability/download_performance.go
@@ -76,7 +76,6 @@ const (
 
 // EmitDownloadPerformance emits metrics on the download performance for either a torrent (blob) download
 // or a metainfo download. Both latency and throughput are measured for the end-to-end download.
-// the blob was requested through Kraken's API to the moment it is fully downloaded.
 func EmitDownloadPerformance(stats tally.Scope, downloadType DownloadType, sizeBytes int64, t time.Duration) {
 	sizeTag := getSizeTag(uint64(sizeBytes))
 	mbPerSecond := (float64(sizeBytes) / (float64(memsize.MB))) / t.Seconds()

--- a/lib/torrent/observability/download_performance_test.go
+++ b/lib/torrent/observability/download_performance_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package scheduler
+package observability
 
 import (
 	"math"
@@ -50,13 +50,13 @@ func TestBucketsConfiguredCorrectly(t *testing.T) {
 	}
 }
 
-func TestEmitBlobDownloadPerformance(t *testing.T) {
+func TestEmitDownloadPerformance(t *testing.T) {
 	t.Run("latency", func(t *testing.T) {
 		require := require.New(t)
 		stats := tally.NewTestScope("", nil)
 
-		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 220*time.Millisecond)
-		emitBlobDownloadPerformance(stats, 10*int64(memsize.GB), 20*time.Minute)
+		EmitDownloadPerformance(stats, TORRENT_DOWNLOAD, 3*int64(memsize.MB), 220*time.Millisecond)
+		EmitDownloadPerformance(stats, TORRENT_DOWNLOAD, 10*int64(memsize.GB), 20*time.Minute)
 
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
@@ -75,8 +75,8 @@ func TestEmitBlobDownloadPerformance(t *testing.T) {
 		require := require.New(t)
 		stats := tally.NewTestScope("", nil)
 
-		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 2*time.Second)   // 1.5 MiB/s
-		emitBlobDownloadPerformance(stats, 10*int64(memsize.GB), 20*time.Minute) // 8.53 MiB/s
+		EmitDownloadPerformance(stats, TORRENT_DOWNLOAD, 3*int64(memsize.MB), 2*time.Second)   // 1.5 MiB/s
+		EmitDownloadPerformance(stats, TORRENT_DOWNLOAD, 10*int64(memsize.GB), 20*time.Minute) // 8.53 MiB/s
 
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
@@ -96,13 +96,13 @@ func TestEmitBlobDownloadPerformance(t *testing.T) {
 		require := require.New(t)
 		stats := tally.NewTestScope("", nil)
 
-		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 2*time.Millisecond) // 1500 MiB/s
-		emitBlobDownloadPerformance(stats, 3*int64(memsize.MB), 1*time.Hour)        // 0.000833333333 MiB/s
+		EmitDownloadPerformance(stats, METAINFO_DOWNLOAD, 3*int64(memsize.MB), 2*time.Millisecond) // 1500 MiB/s
+		EmitDownloadPerformance(stats, METAINFO_DOWNLOAD, 3*int64(memsize.MB), 1*time.Hour)        // 0.000833333333 MiB/s
 
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
 
-		downloadThroughputXsmallKey := "download_throughput+size=0B-100MiB"
+		downloadThroughputXsmallKey := "metainfo_download_throughput+torrent_size=0B-100MiB"
 		downloadThroughputXsmall, ok := histograms[downloadThroughputXsmallKey]
 		require.True(ok)
 		require.Equal(int64(1), downloadThroughputXsmall.Values()[math.MaxFloat64])

--- a/lib/torrent/scheduler/scheduler.go
+++ b/lib/torrent/scheduler/scheduler.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/torrent/networkevent"
+	"github.com/uber/kraken/lib/torrent/observability"
 	"github.com/uber/kraken/lib/torrent/scheduler/announcequeue"
 	"github.com/uber/kraken/lib/torrent/scheduler/announcer"
 	"github.com/uber/kraken/lib/torrent/scheduler/conn"
@@ -275,7 +276,7 @@ func (s *scheduler) Download(namespace string, d core.Digest) error {
 		s.torrentlog.DownloadFailure(namespace, d, size, err)
 	} else {
 		downloadTime := time.Since(start)
-		emitBlobDownloadPerformance(s.stats, size, downloadTime)
+		observability.EmitDownloadPerformance(s.stats, observability.TORRENT_DOWNLOAD, size, downloadTime)
 		s.torrentlog.DownloadSuccess(namespace, d, size, downloadTime)
 	}
 	return err

--- a/lib/torrent/storage/agentstorage/torrent_archive.go
+++ b/lib/torrent/storage/agentstorage/torrent_archive.go
@@ -16,6 +16,7 @@ package agentstorage
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/uber-go/tally"
 	"github.com/willf/bitset"
@@ -23,6 +24,7 @@ import (
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/store"
 	"github.com/uber/kraken/lib/store/metadata"
+	"github.com/uber/kraken/lib/torrent/observability"
 	"github.com/uber/kraken/lib/torrent/storage"
 	"github.com/uber/kraken/tracker/metainfoclient"
 )
@@ -74,7 +76,7 @@ func (a *TorrentArchive) Stat(namespace string, d core.Digest) (*storage.Torrent
 func (a *TorrentArchive) CreateTorrent(namespace string, d core.Digest) (storage.Torrent, error) {
 	var tm metadata.TorrentMeta
 	if err := a.cads.Any().GetMetadata(d.Hex(), &tm); os.IsNotExist(err) {
-		downloadTimer := a.stats.Timer("metainfo_download").Start()
+		startTime := time.Now()
 		mi, err := a.metaInfoClient.Download(namespace, d)
 		if err != nil {
 			if err == metainfoclient.ErrNotFound {
@@ -82,7 +84,8 @@ func (a *TorrentArchive) CreateTorrent(namespace string, d core.Digest) (storage
 			}
 			return nil, fmt.Errorf("download metainfo: %s", err)
 		}
-		downloadTimer.Stop()
+		metainfoDownloadLatency := time.Since(startTime)
+		observability.EmitDownloadPerformance(a.stats, observability.METAINFO_DOWNLOAD, mi.Length(), metainfoDownloadLatency)
 
 		// There's a race condition here, but it's "okay"... Basically, we could
 		// initialize a download file with metainfo that is rejected by file store,


### PR DESCRIPTION
Before every P2P download in an agent, the agent must first acquire the metainfo of that torrent. That process has shown to sometimes be a massive bottleneck in P2P downloads, as origin must download the whole blob from remote storage (e.g. GCS) in order to calculate its metainfo.

This PR adds client-side metrics (i.e. in agent) to record the latency and throughput of the metainfo request. Metrics are tagged by blob size, just like e2e torrent downloads in agent are.

Before this PR, the metainfo latency was already emitted, but 
1. that latency was not tagged by `torrent_size` (which is relevant to put the latency into context)
2. the throughput of the download was not measured
3. a timer was used, instead of a histogram, with timers emitting much more unneeded metrics compared to a histogram. Across a huge fleet of agents, this makes a big difference, so I am now using a histogram for efficiency.

Note: we also emit metainfo download latency server-side in tracker, but we cannot rely on that metric, as the tracker has an nginx cache in front of the application code, therefore emitting metrics only on cache misses, which provides a skewed distribution.