### PR TITLE
feat(agent): emit total data served

### DIFF
--- a/agent/agentserver/server.go
+++ b/agent/agentserver/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/handler"
 	"github.com/uber/kraken/utils/httputil"
+	"github.com/uber/kraken/utils/memsize"
 
 	"github.com/go-chi/chi"
 	"github.com/uber-go/tally"
@@ -160,6 +161,9 @@ func (s *Server) downloadBlobHandler(w http.ResponseWriter, r *http.Request) err
 		}
 	}
 	defer closers.Close(f)
+	mbServed := int64(uint64(f.Size()) / memsize.MB)
+	s.stats.Counter("mb_served").Inc(mbServed)
+
 	if _, err := io.Copy(w, f); err != nil {
 		return fmt.Errorf("copy file: %s", err)
 	}

--- a/lib/dockerregistry/transfer/ro_transferer.go
+++ b/lib/dockerregistry/transfer/ro_transferer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/store"
 	"github.com/uber/kraken/lib/torrent/scheduler"
+	"github.com/uber/kraken/utils/memsize"
 )
 
 var _ ImageTransferer = (*ReadOnlyTransferer)(nil)
@@ -82,6 +83,8 @@ func (t *ReadOnlyTransferer) Download(namespace string, d core.Digest) (store.Fi
 	} else if err != nil {
 		return nil, fmt.Errorf("cache: %s", err)
 	}
+	mbServed := int64(uint64(f.Size()) / memsize.MB)
+	t.stats.Counter("mb_served").Inc(mbServed)
 	return f, nil
 }
 


### PR DESCRIPTION
Currently, we do not have a metric for the total data that Kraken serves. This PR adds it, as it is quite important to gauge the load of a blob distribution system.

As the agent exposes 2 APIs to serve data (docker registry API and HTTP API), there are 2 places where we emit the same metric. As each place has a different `module` tag, we can also compare how much data we serve as a Docker registry vs as a CDN.

I considered emitting the data in bytes, but ultimately decided on MiB to avoid any potential overflows. The reasons are that:
1. Prometheus counters are compounding and ever-increasing (i.e. they only get bigger with each metric emission)
2. The agent can run for weeks/months, meaning the counter will get quite large with time
3. Queries will sum the result for MANY agents (possibly 100K+) - is that sum going to overflow?
4. Emitting data in MiB as opposed to bytes will lose negligible percision, as image blobs are usually in the magnitude of 10s/100s of MiBs.

Subsequent PRs will be created for the proxy's APIs that serve data.