### PR TITLE
fix(agent): emit blob download RPS metric even on failure

### DIFF
--- a/lib/dockerregistry/transfer/ro_transferer.go
+++ b/lib/dockerregistry/transfer/ro_transferer.go
@@ -70,7 +70,6 @@ func (t *ReadOnlyTransferer) Stat(namespace string, d core.Digest) (*core.BlobIn
 
 // Download downloads blobs as torrent.
 func (t *ReadOnlyTransferer) Download(namespace string, d core.Digest) (store.FileReader, error) {
-	t.stats.Counter("downloads").Inc(1)
 	f, err := t.cads.Cache().GetFileReader(d.Hex())
 	if os.IsNotExist(err) || t.cads.InDownloadError(err) {
 		if err := t.sched.Download(namespace, d); err != nil {

--- a/lib/torrent/scheduler/scheduler.go
+++ b/lib/torrent/scheduler/scheduler.go
@@ -254,6 +254,7 @@ func (s *scheduler) doDownload(namespace string, d core.Digest) (size int64, err
 // Download downloads the torrent given metainfo. Once the torrent is downloaded,
 // it will begin seeding asynchronously.
 func (s *scheduler) Download(namespace string, d core.Digest) error {
+	s.stats.Counter("download_requests")
 	start := time.Now()
 	size, err := s.doDownload(namespace, d)
 	if err != nil {

--- a/lib/torrent/scheduler/scheduler.go
+++ b/lib/torrent/scheduler/scheduler.go
@@ -254,7 +254,7 @@ func (s *scheduler) doDownload(namespace string, d core.Digest) (size int64, err
 // Download downloads the torrent given metainfo. Once the torrent is downloaded,
 // it will begin seeding asynchronously.
 func (s *scheduler) Download(namespace string, d core.Digest) error {
-	s.stats.Counter("download_requests")
+	s.stats.Counter("download_requests").Inc(1)
 	start := time.Now()
 	size, err := s.doDownload(namespace, d)
 	if err != nil {


### PR DESCRIPTION
The current QPS metric for agent downloads is in the ro_transferer's `Download` method, which does not always get called on blob downloads. This PR moves it into the P2P scheduler's `Download` method, which is always called when a blob is downloaded, unless there's a cache hit.

## Reasoning
Container runtimes (e.g. containerd) usually call the HEAD API on an image layer, before calling GET, for various reasons. However, agent has implemented its API, such that even the HEAD API triggers a P2P image download. This means that the HEAD API is blocked by agent downloading the full blob (might be 10+GB). If that blob download errors out or times out, containerd doesn't reach the GET API step, meaning that the QPS metric in the ro_transferer's Download method is never called, while kraken-agent started a blob download.

Emitting QPS in the scheduler instead of the transferer has 1 downside, which is that cache hits against the agent's disk cache do not emit the metric. I am making this trade-off consciously, as
1. I expect there to be fewer cache hits than downloads that timeout/fail, and thus never reach the transferer's Download API. My reasoning is that images get cached in containerd's cache after being served by agent, so subsequent image downloads on the host will hit that cache, before hitting agent's

I explored other approaches, where we emit the data in Stat, but containerd and dockerd are inconsistent with when they call HEAD and when they skip it, so such a metric would be unreliable and very bug-prone, so I opted for the simpler, error-free approach.