### PR TITLE
feat(agent): tune bucket ranges for download performance histograms

### DIFF
--- a/lib/torrent/observability/download_performance.go
+++ b/lib/torrent/observability/download_performance.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	_xsmall, _small, _medium, _large, _xlarge, _xxlarge = "0B-100MiB", "100MiB-1GB", "1GiB-2GiB", "2GiB-5GiB", "5GiB-10GiB", "10GiB+"
+	_xsmall, _small, _medium, _large, _xlarge, _xxlarge = "0B-5MiB", "5MiB-100MiB", "100MiB-1GB", "1GiB-5GiB", "5GiB-10GiB", "10GiB+"
 )
 
 var (
-	_sizeBoundaries = []uint64{0, 100 * memsize.MB, memsize.GB, 2 * memsize.GB, 5 * memsize.GB, 10 * memsize.GB}
+	_sizeBoundaries = []uint64{0, 5 * memsize.MB, 100 * memsize.MB, memsize.GB, 5 * memsize.GB, 10 * memsize.GB}
 	_sizeTags       = []string{_xsmall, _small, _medium, _large, _xlarge, _xxlarge}
 
 	_downloadLatencyBuckets tally.DurationBuckets

--- a/lib/torrent/observability/download_performance_test.go
+++ b/lib/torrent/observability/download_performance_test.go
@@ -31,7 +31,7 @@ func TestGetSizeTag(t *testing.T) {
 		"below min":       {memsize.MB, _xsmall},
 		"above max":       {30 * memsize.GB, _xxlarge},
 		"between buckets": {3 * memsize.GB, _large},
-		"exact bucket":    {1 * memsize.GB, _medium},
+		"exact bucket":    {1 * memsize.GB, _large},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/lib/torrent/observability/download_performance_test.go
+++ b/lib/torrent/observability/download_performance_test.go
@@ -60,10 +60,10 @@ func TestEmitDownloadPerformance(t *testing.T) {
 
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
-		downloadTimeXsmallKey := "download_time+size=0B-100MiB,version=4"
-		downloadTimeXsmall, ok := histograms[downloadTimeXsmallKey]
+		downloadTimeXXsmallKey := "download_time+size=0B-5MiB,version=4"
+		downloadTimeXXsmall, ok := histograms[downloadTimeXXsmallKey]
 		require.True(ok)
-		require.Equal(int64(1), downloadTimeXsmall.Durations()[500*time.Millisecond])
+		require.Equal(int64(1), downloadTimeXXsmall.Durations()[500*time.Millisecond])
 
 		downloadTimeXXlargeKey := "download_time+size=10GiB+,version=4"
 		downloadTimeXXlarge, ok := histograms[downloadTimeXXlargeKey]
@@ -81,10 +81,10 @@ func TestEmitDownloadPerformance(t *testing.T) {
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
 
-		downloadThroughputXsmallKey := "download_throughput+size=0B-100MiB"
-		downloadThroughputXsmall, ok := histograms[downloadThroughputXsmallKey]
+		downloadThroughputXXsmallKey := "download_throughput+size=0B-5MiB"
+		downloadThroughputXXsmall, ok := histograms[downloadThroughputXXsmallKey]
 		require.True(ok)
-		require.Equal(int64(1), downloadThroughputXsmall.Values()[2])
+		require.Equal(int64(1), downloadThroughputXXsmall.Values()[2])
 
 		downloadThroughputXXlargeKey := "download_throughput+size=10GiB+"
 		downloadThroughputXXlarge, ok := histograms[downloadThroughputXXlargeKey]
@@ -102,7 +102,7 @@ func TestEmitDownloadPerformance(t *testing.T) {
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
 
-		downloadThroughputXsmallKey := "metainfo_download_throughput+torrent_size=0B-100MiB"
+		downloadThroughputXsmallKey := "metainfo_download_throughput+torrent_size=0B-5MiB"
 		downloadThroughputXsmall, ok := histograms[downloadThroughputXsmallKey]
 		require.True(ok)
 		require.Equal(int64(1), downloadThroughputXsmall.Values()[math.MaxFloat64])


### PR DESCRIPTION
When emiting latency and throughput metrics for its torrent downloads, the agent tags them by the size category of the blob. This allows us to then query latency/throughput performance for a specific blob size category if we'd like. This PR changes the boundaries of these buckets to gain more actionable data from the metrics.

Before this PR, the smallest category was `xsmall` - 0B-100MiB. I am adding a `0B-5MiB` category and merging the `1GiB-2GiB` and `2GiB-5GiB` categories together. The reason is that there are a lot of blobs <5MiB (mostly image manifests) and I'd like to get metrics specifically isolated for them, as the overhead of starting a P2P download is more significant on a <1MiB blob compared to a 1GiB blob.

After looking at the other buckets, I decided there's no real reason to keep metrics on 1-2GB blobs separate from 2-5GB blobs, so I decided to merge those buckets for simplicity and to reduce metric ingestion/cardinality rates.