### PR TITLE
feat(proxy): add metrics for data served and download failures

### DIFF
--- a/lib/dockerregistry/transfer/rw_transferer.go
+++ b/lib/dockerregistry/transfer/rw_transferer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/uber/kraken/origin/blobclient"
 	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/log"
+	"github.com/uber/kraken/utils/memsize"
 
 	"github.com/docker/distribution/uuid"
 	"github.com/uber-go/tally"
@@ -115,12 +116,21 @@ func (t *ReadWriteTransferer) Download(namespace string, d core.Digest) (store.F
 	if err == nil {
 		span.SetAttributes(attribute.String("cache.status", "hit"))
 		span.SetStatus(codes.Ok, "cache hit")
+		mbServed := int64(uint64(blob.Size()) / memsize.MB)
+		t.stats.Counter("mb_served").Inc(mbServed)
 		return blob, nil
 	}
 	if os.IsNotExist(err) {
 		span.SetAttributes(attribute.String("cache.status", "miss"))
-		return t.downloadFromOrigin(ctx, namespace, d)
+		blob, err = t.downloadFromOrigin(ctx, namespace, d)
+		if err != nil {
+			t.stats.Counter("download_failures").Inc(1)
+		}
+		mbServed := int64(uint64(blob.Size()) / memsize.MB)
+		t.stats.Counter("mb_served").Inc(mbServed)
+		return blob, err
 	}
+	t.stats.Counter("download_failures").Inc(1)
 	span.RecordError(err)
 	span.SetStatus(codes.Error, "cache read error")
 	return nil, fmt.Errorf("get cache file: %s", err)

--- a/lib/dockerregistry/transfer/rw_transferer.go
+++ b/lib/dockerregistry/transfer/rw_transferer.go
@@ -125,9 +125,10 @@ func (t *ReadWriteTransferer) Download(namespace string, d core.Digest) (store.F
 		blob, err = t.downloadFromOrigin(ctx, namespace, d)
 		if err != nil {
 			t.stats.Counter("download_failures").Inc(1)
+		} else {
+			mbServed := int64(uint64(blob.Size()) / memsize.MB)
+			t.stats.Counter("mb_served").Inc(mbServed)
 		}
-		mbServed := int64(uint64(blob.Size()) / memsize.MB)
-		t.stats.Counter("mb_served").Inc(mbServed)
 		return blob, err
 	}
 	t.stats.Counter("download_failures").Inc(1)


### PR DESCRIPTION
 - Add `mb_served` metric in proxy. The metric has the same format as the agent's metric added in https://github.com/uber/kraken/pull/597, in order to stay consistent.
 - Add `download_failures` metric, so the failure rate for proxy's `Download` API can be calculated, as we currently only emit `download_requests`.