### PR TITLE
fix(agent): tune download throughput histogram buckets

### DIFF
--- a/lib/torrent/observability/download_performance.go
+++ b/lib/torrent/observability/download_performance.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	_xsmall, _small, _medium, _large, _xlarge, _xxlarge = "0B-5MiB", "5MiB-100MiB", "100MiB-1GB", "1GiB-5GiB", "5GiB-10GiB", "10GiB+"
+	_xsmall, _small, _medium, _large, _xlarge, _xxlarge = "0B-5MiB", "5MiB-100MiB", "100MiB-1GiB", "1GiB-5GiB", "5GiB-10GiB", "10GiBplus"
 )
 
 var (
@@ -51,11 +51,13 @@ func init() {
 	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(1800*time.Second, 300*time.Second, 3)...)
 	_downloadLatencyBuckets = append(_downloadLatencyBuckets, tally.MustMakeLinearDurationBuckets(2700*time.Second, 300*time.Second, 4)...)
 
-	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(0, 1, 10)...)   // [0, 10)
-	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(10, 2, 5)...)   // [10, 20)
-	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(20, 5, 6)...)   // [20, 50)
-	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(50, 10, 15)...) // [50, 200)
-	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(200, 50, 4)...) // [200, 400)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(0, 0.1, 10)...) // [0, 1)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(1, 0.5, 4)...)  // [1, 3)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(3, 1, 7)...)    // [3, 10)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(10, 2, 10)...)  // [10, 30)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(30, 5, 4)...)   // [30, 50)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(50, 10, 5)...)  // [50, 100)
+	_downloadThroughputBuckets = append(_downloadThroughputBuckets, tally.MustMakeLinearValueBuckets(100, 50, 6)...) // [100, 400)
 }
 
 func getSizeTag(sizeBytes uint64) string {
@@ -95,7 +97,8 @@ func emitBlobDownloadPerformance(stats tally.Scope, mbPerSecond float64, sizeTag
 	}).Histogram("download_time", _downloadLatencyBuckets).RecordDuration(t)
 
 	stats.Tagged(map[string]string{
-		"size": sizeTag,
+		"size":    sizeTag,
+		"version": "2",
 	}).Histogram("download_throughput", _downloadThroughputBuckets).RecordValue(mbPerSecond)
 }
 
@@ -110,5 +113,6 @@ func emitMetainfoDownloadPerformance(stats tally.Scope, mbPerSecond float64, siz
 
 	stats.Tagged(map[string]string{
 		"torrent_size": sizeTag,
+		"version":      "2",
 	}).Histogram("metainfo_download_throughput", _downloadThroughputBuckets).RecordValue(mbPerSecond)
 }

--- a/lib/torrent/observability/download_performance_test.go
+++ b/lib/torrent/observability/download_performance_test.go
@@ -65,7 +65,7 @@ func TestEmitDownloadPerformance(t *testing.T) {
 		require.True(ok)
 		require.Equal(int64(1), downloadTimeXXsmall.Durations()[500*time.Millisecond])
 
-		downloadTimeXXlargeKey := "download_time+size=10GiB+,version=4"
+		downloadTimeXXlargeKey := "download_time+size=10GiBplus,version=4"
 		downloadTimeXXlarge, ok := histograms[downloadTimeXXlargeKey]
 		require.True(ok)
 		require.Equal(int64(1), downloadTimeXXlarge.Durations()[1260*time.Second])
@@ -81,12 +81,12 @@ func TestEmitDownloadPerformance(t *testing.T) {
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
 
-		downloadThroughputXXsmallKey := "download_throughput+size=0B-5MiB"
+		downloadThroughputXXsmallKey := "download_throughput+size=0B-5MiB,version=2"
 		downloadThroughputXXsmall, ok := histograms[downloadThroughputXXsmallKey]
 		require.True(ok)
-		require.Equal(int64(1), downloadThroughputXXsmall.Values()[2])
+		require.Equal(int64(1), downloadThroughputXXsmall.Values()[1.5])
 
-		downloadThroughputXXlargeKey := "download_throughput+size=10GiB+"
+		downloadThroughputXXlargeKey := "download_throughput+size=10GiBplus,version=2"
 		downloadThroughputXXlarge, ok := histograms[downloadThroughputXXlargeKey]
 		require.True(ok)
 		require.Equal(int64(1), downloadThroughputXXlarge.Values()[9])
@@ -102,10 +102,10 @@ func TestEmitDownloadPerformance(t *testing.T) {
 		snapshot := stats.Snapshot()
 		histograms := snapshot.Histograms()
 
-		downloadThroughputXsmallKey := "metainfo_download_throughput+torrent_size=0B-5MiB"
+		downloadThroughputXsmallKey := "metainfo_download_throughput+torrent_size=0B-5MiB,version=2"
 		downloadThroughputXsmall, ok := histograms[downloadThroughputXsmallKey]
 		require.True(ok)
 		require.Equal(int64(1), downloadThroughputXsmall.Values()[math.MaxFloat64])
-		require.Equal(int64(1), downloadThroughputXsmall.Values()[1])
+		require.Equal(int64(1), downloadThroughputXsmall.Values()[0.1])
 	})
 }


### PR DESCRIPTION
kraken-agent's throughput histogram does not have enough granularity in the <1MB/s range. This means that for blobs in the <5MB size range the throughput metric is always the same, as it's hitting the bottom bucket (0-1MB/s). This PR fixes that by changing the distribution of granularity in the histogram's buckets.

 - Change bucket config for throughput metrics in agent (blob download throughput and metainfo download throughput)
 - Bump the `version` tag of those metrics
 - Change the `10GiB+` size tag value to `10GiBplus`, as some metrics libraries/databases/ingestion pipelines cannot handle the `+` character.
 - Fix a typo in the `100MiB-1GB` range by changing it to `1GiB` from `1GB`.