### PR TITLE
feat(proxy): Add blob download performance metrics

### DIFF
--- a/lib/dockerregistry/transfer/rw_transferer.go
+++ b/lib/dockerregistry/transfer/rw_transferer.go
@@ -17,9 +17,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/uber/kraken/build-index/tagclient"
 	"github.com/uber/kraken/core"
+	"github.com/uber/kraken/lib/observability"
 	"github.com/uber/kraken/lib/store"
 	"github.com/uber/kraken/origin/blobclient"
 	"github.com/uber/kraken/utils/closers"
@@ -100,6 +102,7 @@ func (t *ReadWriteTransferer) originStat(namespace string, d core.Digest) (*core
 // Download downloads the blob of name into the file store and returns a reader
 // to the newly downloaded file.
 func (t *ReadWriteTransferer) Download(namespace string, d core.Digest) (store.FileReader, error) {
+	start := time.Now()
 	t.stats.Counter("download_requests").Inc(1)
 	ctx, span := t.tracer.Start(context.Background(), "registry.download_blob",
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -118,6 +121,7 @@ func (t *ReadWriteTransferer) Download(namespace string, d core.Digest) (store.F
 		span.SetStatus(codes.Ok, "cache hit")
 		mbServed := int64(uint64(blob.Size()) / memsize.MB)
 		t.stats.Counter("mb_served").Inc(mbServed)
+		observability.EmitDownloadPerformance(t.stats, observability.PROXY_BLOB_DOWNLOAD, blob.Size(), time.Since(start))
 		return blob, nil
 	}
 	if os.IsNotExist(err) {
@@ -128,6 +132,7 @@ func (t *ReadWriteTransferer) Download(namespace string, d core.Digest) (store.F
 		} else {
 			mbServed := int64(uint64(blob.Size()) / memsize.MB)
 			t.stats.Counter("mb_served").Inc(mbServed)
+			observability.EmitDownloadPerformance(t.stats, observability.PROXY_BLOB_DOWNLOAD, blob.Size(), time.Since(start))
 		}
 		return blob, err
 	}

--- a/lib/observability/download_performance.go
+++ b/lib/observability/download_performance.go
@@ -81,6 +81,8 @@ const (
 	METAINFO_DOWNLOAD DownloadType = "METAINFO_DOWNLOAD"
 	// Measures the e2e blob download from remote storage (e.g. GCS) in origin/build-index.
 	REMOTE_DOWNLOAD DownloadType = "REMOTE_DOWNLOAD"
+	// Measures the e2e blob download performance of a blob from proxy.
+	PROXY_BLOB_DOWNLOAD = "PROXY_BLOB_DOWNLOAD"
 )
 
 // EmitDownloadPerformance emits metrics (usually latency and throughput) on the download performance of a blob.
@@ -104,6 +106,8 @@ func EmitDownloadPerformance(stats tally.Scope, downloadType DownloadType, sizeB
 		emitTorrentLeechPerformance(stats, mbPerSecond, sizeTag)
 	case REMOTE_DOWNLOAD:
 		emitRemoteBlobDownloadPerformance(stats, mbPerSecond, sizeTag, t)
+	case PROXY_BLOB_DOWNLOAD:
+		emitBlobDownloadPerformanceInProxy(stats, mbPerSecond, sizeTag, t)
 	}
 }
 
@@ -148,4 +152,14 @@ func emitRemoteBlobDownloadPerformance(stats tally.Scope, mbPerSecond float64, s
 	stats.Tagged(map[string]string{
 		"size": sizeTag,
 	}).Histogram("remote_blob_download_throughput", _downloadThroughputBuckets).RecordValue(mbPerSecond)
+}
+
+func emitBlobDownloadPerformanceInProxy(stats tally.Scope, mbPerSecond float64, sizeTag string, t time.Duration) {
+	stats.Tagged(map[string]string{
+		"size": sizeTag,
+	}).Histogram("blob_download_time", _downloadLatencyBuckets).RecordDuration(t)
+
+	stats.Tagged(map[string]string{
+		"size": sizeTag,
+	}).Histogram("blob_download_throughput", _downloadThroughputBuckets).RecordValue(mbPerSecond)
 }

--- a/lib/observability/download_performance_test.go
+++ b/lib/observability/download_performance_test.go
@@ -149,6 +149,29 @@ func TestEmitDownloadPerformance(t *testing.T) {
 		require.Equal(int64(1), downloadTimeXsmall.Durations()[1*time.Hour])
 	})
 
+	t.Run("blob download from proxy", func(t *testing.T) {
+		require := require.New(t)
+		stats := tally.NewTestScope("", nil)
+
+		EmitDownloadPerformance(stats, PROXY_BLOB_DOWNLOAD, 3*int64(memsize.MB), 2*time.Millisecond) // 1500 MiB/s
+		EmitDownloadPerformance(stats, PROXY_BLOB_DOWNLOAD, 3*int64(memsize.MB), 1*time.Hour)        // 0.000833333333 MiB/s
+
+		snapshot := stats.Snapshot()
+		histograms := snapshot.Histograms()
+
+		downloadThroughputXsmallKey := "blob_download_throughput+size=0B-5MiB"
+		downloadThroughputXsmall, ok := histograms[downloadThroughputXsmallKey]
+		require.True(ok)
+		require.Equal(int64(1), downloadThroughputXsmall.Values()[math.MaxFloat64])
+		require.Equal(int64(1), downloadThroughputXsmall.Values()[0.1])
+
+		downloadTimeXsmallKey := "blob_download_time+size=0B-5MiB"
+		downloadTimeXsmall, ok := histograms[downloadTimeXsmallKey]
+		require.True(ok)
+		require.Equal(int64(1), downloadTimeXsmall.Durations()[500*time.Millisecond])
+		require.Equal(int64(1), downloadTimeXsmall.Durations()[1*time.Hour])
+	})
+
 	t.Run("safeguard against 0 latency", func(t *testing.T) {
 		require := require.New(t)
 		stats := tally.NewTestScope("", nil)

--- a/lib/persistedretry/writeback/executor.go
+++ b/lib/persistedretry/writeback/executor.go
@@ -30,6 +30,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var _writebackLatencyBuckets = tally.MustMakeExponentialDurationBuckets(1*time.Second, 1.4, 30)
+
 // FileStore defines store operations required for write-back.
 type FileStore interface {
 	DeleteCacheFileMetadata(name string, md metadata.Metadata) error
@@ -195,9 +197,11 @@ func (e *Executor) upload(ctx context.Context, t *Task) error {
 		"name", t.Name,
 	).Info("Uploaded cache file to remote backend")
 
-	// We don't want to time noops nor errors.
-	e.stats.Timer("upload").Record(time.Since(start))
-	e.stats.Timer("lifetime").Record(time.Since(t.CreatedAt))
+	s := e.stats.Tagged(map[string]string{
+		"version": "2",
+	})
+	s.Histogram("upload", _writebackLatencyBuckets).RecordDuration(time.Since(start))
+	s.Histogram("lifetime", _writebackLatencyBuckets).RecordDuration(time.Since(t.CreatedAt))
 
 	return nil
 }


### PR DESCRIPTION
 - Add blob download latency and throughput metrics for downloads from proxy
 - Replace the timer metrics with histograms in the `writebackexecutor` module, in order to 1) reduce cardinality and 2) allow us to aggregate p50/p95, etc. over the whole fleet of hosts (timers pre-aggregate on a per-host basis)