### PR TITLE
fix(blobrefresh): deduplicate download requests for blobs under different namespaces

### DIFF
--- a/lib/blobrefresh/refresher.go
+++ b/lib/blobrefresh/refresher.go
@@ -104,7 +104,7 @@ func (r *Refresher) Refresh(namespace string, d core.Digest, hooks ...PostHook) 
 		return fmt.Errorf("%s blob exceeds size limit of %s", size, r.config.SizeLimit)
 	}
 
-	id := namespace + ":" + d.Hex()
+	id := d.Hex()
 	err = r.requests.Start(id, func() error {
 		start := time.Now()
 		pieceLength := r.metaInfoGenerator.GetPieceLength(int64(size))

--- a/lib/blobrefresh/refresher_test.go
+++ b/lib/blobrefresh/refresher_test.go
@@ -212,3 +212,47 @@ func TestRefreshWithMemoryCache(t *testing.T) {
 	require.NoError(err)
 	require.Equal(blob.Content, diskData)
 }
+
+func TestDedupSameBlobWithDifferentNamespaces(t *testing.T) {
+	require := require.New(t)
+
+	mocks, cleanup := newRefresherMocks(t)
+	defer cleanup()
+
+	refresher := mocks.new()
+
+	namespace1 := core.TagFixture()
+	namespace2 := core.TagFixture()
+	client1 := mocks.newClient(namespace1)
+	client2 := mocks.newClient(namespace2)
+
+	blob := core.SizedBlobFixture(100, uint64(_testPieceLength))
+
+	client1.EXPECT().Stat(namespace1, blob.Digest.Hex()).Return(core.NewBlobInfo(int64(len(blob.Content))), nil)
+	client2.EXPECT().Stat(namespace2, blob.Digest.Hex()).Return(core.NewBlobInfo(int64(len(blob.Content))), nil)
+
+	downloadStarted := make(chan struct{})
+	finishDownload := make(chan struct{})
+
+	client1.EXPECT().Download(namespace1, blob.Digest.Hex(), gomock.Any()).DoAndReturn(
+		func(_ string, _ string, w io.Writer) error {
+			close(downloadStarted)
+			<-finishDownload
+			_, err := w.Write(blob.Content)
+			return err
+		},
+	)
+
+	require.NoError(refresher.Refresh(namespace1, blob.Digest))
+	<-downloadStarted
+
+	err := refresher.Refresh(namespace2, blob.Digest)
+	require.Equal(ErrPending, err)
+
+	close(finishDownload)
+
+	require.NoError(testutil.PollUntilTrue(5*time.Second, func() bool {
+		_, err := mocks.cas.GetCacheFileStat(blob.Digest.Hex())
+		return !os.IsNotExist(err)
+	}))
+}


### PR DESCRIPTION
When origin downloads blobs from GCS, it deduplicates simultaneous downloads for the same blob to avoid extra load. It deduplicates based on an `id` defined to be the blob's namespace + digest. However, this is wrong - if the same blob is being requested under 2 different namespaces, it will have 2 different IDs and deduplication will fail. This PR fixes that by changing the `id` of a download blob request to be the blob's digest, instead of namespace+digest. I also add a unit test that would have caught the bug.

This issue has been happening for 8+ years, but we just caught it because of [this log message](https://github.com/uber/kraken/blob/396c1a1eae0908aba28c2468d10f92fa4c6a1f7c/utils/cache/blob_memory_cache.go#L76).