### PR TITLE
perf(castore): generate metadata from bytes in in-mem cache

### DIFF
--- a/core/metainfo.go
+++ b/core/metainfo.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"io"
 
 	"github.com/jackpal/bencode-go"
@@ -58,21 +57,7 @@ func NewMetaInfo(d Digest, blob io.Reader, pieceLength int64) (*MetaInfo, error)
 	if err != nil {
 		return nil, err
 	}
-	info := info{
-		PieceLength: pieceLength,
-		PieceSums:   pieceSums,
-		Name:        d.Hex(),
-		Length:      length,
-	}
-	h, err := info.Hash()
-	if err != nil {
-		return nil, fmt.Errorf("compute info hash: %s", err)
-	}
-	return &MetaInfo{
-		info:     info,
-		infoHash: h,
-		digest:   d,
-	}, nil
+	return assembleMetaInfo(d, length, pieceSums, pieceLength)
 }
 
 // InfoHash returns the torrent InfoHash.
@@ -188,6 +173,11 @@ func NewMetaInfoFromBytes(d Digest, data []byte, pieceLength int64) (*MetaInfo, 
 	if err != nil {
 		return nil, err
 	}
+	return assembleMetaInfo(d, length, pieceSums, pieceLength)
+}
+
+// assembleMetaInfo constructs a MetaInfo from pre-computed piece sums.
+func assembleMetaInfo(d Digest, length int64, pieceSums []uint32, pieceLength int64) (*MetaInfo, error) {
 	info := info{
 		PieceLength: pieceLength,
 		PieceSums:   pieceSums,
@@ -198,11 +188,7 @@ func NewMetaInfoFromBytes(d Digest, data []byte, pieceLength int64) (*MetaInfo, 
 	if err != nil {
 		return nil, fmt.Errorf("compute info hash: %s", err)
 	}
-	return &MetaInfo{
-		info:     info,
-		infoHash: h,
-		digest:   d,
-	}, nil
+	return &MetaInfo{info: info, infoHash: h, digest: d}, nil
 }
 
 // calcPieceSumsFromBytes hashes data in pieceLength chunks. Mirrors
@@ -216,14 +202,14 @@ func calcPieceSumsFromBytes(data []byte, pieceLength int64) (int64, []uint32, er
 	if n == 0 {
 		return 0, nil, nil
 	}
-	numPieces := (n + pieceLength - 1) / pieceLength
+	numPieces := (n-1)/pieceLength + 1
 	pieceSums := make([]uint32, 0, numPieces)
 	for offset := int64(0); offset < n; offset += pieceLength {
 		end := offset + pieceLength
 		if end > n {
 			end = n
 		}
-		pieceSums = append(pieceSums, crc32.ChecksumIEEE(data[offset:end]))
+		pieceSums = append(pieceSums, PieceSum(data[offset:end]))
 	}
 	return n, pieceSums, nil
 }

--- a/core/metainfo.go
+++ b/core/metainfo.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 
 	"github.com/jackpal/bencode-go"
@@ -172,4 +173,57 @@ func calcPieceSums(blob io.Reader, pieceLength int64) (length int64, pieceSums [
 		}
 	}
 	return length, pieceSums, nil
+}
+
+// NewMetaInfoFromBytes is the byte-slice variant of NewMetaInfo. It avoids
+// the io.Reader indirection and the 32 KB scratch buffer per piece that
+// io.Copy allocates when reading from a bytes.Reader wrapped in
+// io.LimitReader, by hashing each piece directly off the underlying slice.
+//
+// Result is bit-identical to NewMetaInfo(d, bytes.NewReader(data),
+// pieceLength). Caller is expected to have already verified that d is the
+// correct digest for data.
+func NewMetaInfoFromBytes(d Digest, data []byte, pieceLength int64) (*MetaInfo, error) {
+	length, pieceSums, err := calcPieceSumsFromBytes(data, pieceLength)
+	if err != nil {
+		return nil, err
+	}
+	info := info{
+		PieceLength: pieceLength,
+		PieceSums:   pieceSums,
+		Name:        d.Hex(),
+		Length:      length,
+	}
+	h, err := info.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("compute info hash: %s", err)
+	}
+	return &MetaInfo{
+		info:     info,
+		infoHash: h,
+		digest:   d,
+	}, nil
+}
+
+// calcPieceSumsFromBytes hashes data in pieceLength chunks. Mirrors
+// calcPieceSums but avoids per-piece hash.Hash32 allocation by using
+// crc32.ChecksumIEEE, and pre-sizes pieceSums to its exact final length.
+func calcPieceSumsFromBytes(data []byte, pieceLength int64) (int64, []uint32, error) {
+	if pieceLength <= 0 {
+		return 0, nil, errors.New("piece length must be positive")
+	}
+	n := int64(len(data))
+	if n == 0 {
+		return 0, nil, nil
+	}
+	numPieces := (n + pieceLength - 1) / pieceLength
+	pieceSums := make([]uint32, 0, numPieces)
+	for offset := int64(0); offset < n; offset += pieceLength {
+		end := offset + pieceLength
+		if end > n {
+			end = n
+		}
+		pieceSums = append(pieceSums, crc32.ChecksumIEEE(data[offset:end]))
+	}
+	return n, pieceSums, nil
 }

--- a/core/metainfo_test.go
+++ b/core/metainfo_test.go
@@ -133,6 +133,9 @@ func TestNewMetaInfoFromBytes_MatchesReader(t *testing.T) {
 		{"two_pieces", 512, 256},
 		{"non_aligned", 700, 256},
 		{"many_pieces", 1 << 20, 256},
+		{"piece_length_one", 100, 1},
+		{"piece_larger_than_blob", 100, 1024},
+		{"invalid_piece_length", 100, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -170,7 +173,7 @@ func TestNewMetaInfoFromBytes_MatchesReader(t *testing.T) {
 	}
 }
 
-func BenchmarkNewMetaInfo(b *testing.B) {
+func BenchmarkNewMetaInfoFromBytes(b *testing.B) {
 	cases := []struct {
 		name        string
 		blobSize    uint64

--- a/core/metainfo_test.go
+++ b/core/metainfo_test.go
@@ -194,10 +194,8 @@ func BenchmarkNewMetaInfo(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			b.SetBytes(int64(tc.blobSize))
-			for i := 0; i < b.N; i++ {
-				// BENCH_A1_TOGGLE_START
-				mi, err := NewMetaInfo(d, bytes.NewReader(data), pl)
-				// BENCH_A1_TOGGLE_END
+			for b.Loop() {
+				mi, err := NewMetaInfoFromBytes(d, data, pl)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/core/metainfo_test.go
+++ b/core/metainfo_test.go
@@ -14,12 +14,14 @@
 package core
 
 import (
+	"bytes"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/kraken/utils/memsize"
+	"github.com/uber/kraken/utils/randutil"
 )
 
 func TestMetaInfoGetPieceLength(t *testing.T) {
@@ -115,6 +117,94 @@ func TestMetaInfoSerializationLimit(t *testing.T) {
 			size := uint64(len(b))
 			require.True(size < redisValueLimit,
 				"%d piece serialization %d bytes too large", numPieces, size-redisValueLimit)
+		})
+	}
+}
+
+func TestNewMetaInfoFromBytes_MatchesReader(t *testing.T) {
+	cases := []struct {
+		name        string
+		size        uint64
+		pieceLength uint64
+	}{
+		{"empty", 0, 256},
+		{"smaller_than_piece", 100, 256},
+		{"exact_one_piece", 256, 256},
+		{"two_pieces", 512, 256},
+		{"non_aligned", 700, 256},
+		{"many_pieces", 1 << 20, 256},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			data := randutil.Text(tc.size)
+			d, err := NewDigester().FromBytes(data)
+			require.NoError(err)
+
+			miReader, errReader := NewMetaInfo(d, bytes.NewReader(data), int64(tc.pieceLength))
+			miBytes, errBytes := NewMetaInfoFromBytes(d, data, int64(tc.pieceLength))
+
+			require.Equal(errReader != nil, errBytes != nil)
+			if errReader != nil {
+				return
+			}
+
+			require.Equal(miReader.InfoHash(), miBytes.InfoHash())
+			require.Equal(miReader.Length(), miBytes.Length())
+			require.Equal(miReader.NumPieces(), miBytes.NumPieces())
+			require.Equal(miReader.PieceLength(), miBytes.PieceLength())
+			for i := 0; i < miReader.NumPieces(); i++ {
+				require.Equal(miReader.GetPieceSum(i), miBytes.GetPieceSum(i),
+					"piece %d sum mismatch", i)
+			}
+			bReader, err := miReader.Serialize()
+			if err != nil {
+				t.Fatal(err)
+			}
+			bBytes, err := miBytes.Serialize()
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.Equal(bReader, bBytes)
+		})
+	}
+}
+
+func BenchmarkNewMetaInfo(b *testing.B) {
+	cases := []struct {
+		name        string
+		blobSize    uint64
+		pieceLength uint64
+	}{
+		{"1MB_4pc", 1 << 20, 256 << 10},
+		{"16MB_64pc", 16 << 20, 256 << 10},
+		{"64MB_256pc", 64 << 20, 256 << 10},
+		{"256MB_1024pc", 256 << 20, 256 << 10},
+		{"16MB_4pc_4MBpc", 16 << 20, 4 << 20},
+		{"16MB_16pc_1MBpc", 16 << 20, 1 << 20},
+		{"16MB_1024pc_16KBpc", 16 << 20, 16 << 10},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			data := randutil.Text(tc.blobSize)
+			d, err := NewDigester().FromBytes(data)
+			require.NoError(b, err)
+			pl := int64(tc.pieceLength)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			b.SetBytes(int64(tc.blobSize))
+			for i := 0; i < b.N; i++ {
+				// BENCH_A1_TOGGLE_START
+				mi, err := NewMetaInfo(d, bytes.NewReader(data), pl)
+				// BENCH_A1_TOGGLE_END
+				if err != nil {
+					b.Fatal(err)
+				}
+				if mi == nil {
+					b.Fatal("nil MetaInfo")
+				}
+			}
 		})
 	}
 }

--- a/core/metainfo_test.go
+++ b/core/metainfo_test.go
@@ -146,12 +146,13 @@ func TestNewMetaInfoFromBytes_MatchesReader(t *testing.T) {
 
 			miReader, errReader := NewMetaInfo(d, bytes.NewReader(data), int64(tc.pieceLength))
 			miBytes, errBytes := NewMetaInfoFromBytes(d, data, int64(tc.pieceLength))
-
 			require.Equal(errReader != nil, errBytes != nil)
 			if errReader != nil {
+				require.EqualError(errBytes, errReader.Error())
 				return
 			}
-
+			require.NoError(errReader)
+			require.NoError(errBytes)
 			require.Equal(miReader.InfoHash(), miBytes.InfoHash())
 			require.Equal(miReader.Length(), miBytes.Length())
 			require.Equal(miReader.NumPieces(), miBytes.NumPieces())
@@ -160,15 +161,6 @@ func TestNewMetaInfoFromBytes_MatchesReader(t *testing.T) {
 				require.Equal(miReader.GetPieceSum(i), miBytes.GetPieceSum(i),
 					"piece %d sum mismatch", i)
 			}
-			bReader, err := miReader.Serialize()
-			if err != nil {
-				t.Fatal(err)
-			}
-			bBytes, err := miBytes.Serialize()
-			if err != nil {
-				t.Fatal(err)
-			}
-			require.Equal(bReader, bBytes)
 		})
 	}
 }

--- a/core/piece_hash.go
+++ b/core/piece_hash.go
@@ -22,3 +22,10 @@ import (
 func PieceHash() hash.Hash32 {
 	return crc32.NewIEEE()
 }
+
+// PieceSum returns the checksum of b using the same algorithm as PieceHash.
+// It is equivalent to creating a PieceHash, writing b, and calling Sum32,
+// but avoids allocating a hash.Hash32 object.
+func PieceSum(b []byte) uint32 {
+	return crc32.ChecksumIEEE(b)
+}

--- a/core/piece_hash_test.go
+++ b/core/piece_hash_test.go
@@ -28,7 +28,8 @@ func TestPieceSumMatchesPieceHash(t *testing.T) {
 	}
 	for _, data := range cases {
 		h := PieceHash()
-		h.Write(data)
+		_, err := h.Write(data)
+		require.NoError(t, err)
 		require.Equal(t, h.Sum32(), PieceSum(data))
 	}
 }

--- a/core/piece_hash_test.go
+++ b/core/piece_hash_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPieceSumMatchesPieceHash(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		{},
+		[]byte("hello"),
+		make([]byte, 32*1024),
+	}
+	for _, data := range cases {
+		h := PieceHash()
+		h.Write(data)
+		require.Equal(t, h.Sum32(), PieceSum(data))
+	}
+}

--- a/lib/store/ca_store.go
+++ b/lib/store/ca_store.go
@@ -14,7 +14,6 @@
 package store
 
 import (
-	"bytes"
 	"container/list"
 	"errors"
 	"fmt"
@@ -299,7 +298,7 @@ func (s *CAStore) generateMetadataFromBytes(name string, data []byte, pieceLengt
 	if err != nil {
 		return nil, fmt.Errorf("new digest from hex: %s", err)
 	}
-	metaInfo, err := core.NewMetaInfo(digest, bytes.NewReader(data), pieceLength)
+	metaInfo, err := core.NewMetaInfoFromBytes(digest, data, pieceLength)
 	if err != nil {
 		return nil, fmt.Errorf("generate metainfo: %w", err)
 	}


### PR DESCRIPTION
 # What?
While downloading the blobs in the in-memory cache, we use the same method as for disk cache to generate metadata for the blob downloaded. 
`core.NewMetaInfo` creates a 32KB scratch buffer for each piece of the blob, resulting in unnecessary allocs even though the blob is already in memory. This is shown in the `io.CopyN`, which internally copies the buffer.
Although this is just 0.5% of the total allocation, it provides a quick win, with further improvements already planned.
<img width="997" height="396" alt="Screenshot 2026-05-04 at 13 41 05" src="https://github.com/user-attachments/assets/74c564ff-aad0-4b5e-9630-ef4834010404" />

This change adds `core.NewMetaInfoFromBytes`, a byte-slice variant of `core.NewMetaInfo` that avoids the per-piece 32KB allocation.`castore.generateMetadataFromBytes` is updated to use it

# Testing
Added a new benchmark `BenchmarkNewMetaInfo`, which was first executed on `core.NewMetaInfo` and then on `core.NewMetaInfoFromBytes`.
```
goos: linux
goarch: amd64
pkg: github.com/uber/kraken/core
cpu: AMD EPYC 7B13
                                  │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/before.txt │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/after.txt │
                                  │                                sec/op                                 │                    sec/op                     vs base                │
NewMetaInfo/1MB_4pc-96                                                                       159.95µ ± 2%                                    91.44µ ± 2%  -42.83% (p=0.000 n=50)
NewMetaInfo/16MB_64pc-96                                                                      2.343m ± 1%                                    1.424m ± 1%  -39.22% (p=0.000 n=50)
NewMetaInfo/64MB_256pc-96                                                                    10.920m ± 1%                                    6.080m ± 1%  -44.32% (p=0.000 n=50)
NewMetaInfo/256MB_1024pc-96                                                                   40.96m ± 1%                                    24.20m ± 1%  -40.93% (p=0.000 n=50)
NewMetaInfo/16MB_4pc_4MBpc-96                                                                 2.035m ± 1%                                    1.428m ± 1%  -29.84% (p=0.000 n=50)
NewMetaInfo/16MB_16pc_1MBpc-96                                                                2.121m ± 1%                                    1.397m ± 1%  -34.11% (p=0.000 n=50)
NewMetaInfo/16MB_1024pc_16KBpc-96                                                             5.688m ± 2%                                    1.526m ± 1%  -73.17% (p=0.000 n=50)
geomean                                                                                       3.284m                                         1.788m       -45.56%

                                  │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/before.txt │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/after.txt │
                                  │                                  B/s                                  │                     B/s                      vs base                 │
NewMetaInfo/1MB_4pc-96                                                                       6.105Gi ± 2%                                 10.680Gi ± 2%   +74.93% (p=0.000 n=50)
NewMetaInfo/16MB_64pc-96                                                                     6.668Gi ± 1%                                 10.971Gi ± 1%   +64.53% (p=0.000 n=50)
NewMetaInfo/64MB_256pc-96                                                                    5.723Gi ± 2%                                 10.279Gi ± 1%   +79.59% (p=0.000 n=50)
NewMetaInfo/256MB_1024pc-96                                                                  6.103Gi ± 1%                                 10.332Gi ± 2%   +69.30% (p=0.000 n=50)
NewMetaInfo/16MB_4pc_4MBpc-96                                                                7.679Gi ± 1%                                 10.945Gi ± 1%   +42.53% (p=0.000 n=50)
NewMetaInfo/16MB_16pc_1MBpc-96                                                               7.367Gi ± 1%                                 11.182Gi ± 2%   +51.78% (p=0.000 n=50)
NewMetaInfo/16MB_1024pc_16KBpc-96                                                            2.747Gi ± 1%                                 10.238Gi ± 0%  +272.70% (p=0.000 n=50)
geomean                                                                                      5.801Gi                                       10.65Gi        +83.68%

                                  │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/before.txt │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/after.txt │
                                  │                                 B/op                                  │                         B/op                          vs base        │
NewMetaInfo/1MB_4pc-96                                                                     162.213Ki ± 0%                                           1.053Ki ± 0%  -99.35% (n=50)
NewMetaInfo/16MB_64pc-96                                                                  2087.698Ki ± 0%                                           3.250Ki ± 0%  -99.84% (n=50)
NewMetaInfo/64MB_256pc-96                                                                  8248.18Ki ± 0%                                           11.50Ki ± 0%  -99.86% (n=50)
NewMetaInfo/256MB_1024pc-96                                                               32894.65Ki ± 0%                                           44.50Ki ± 0%  -99.86% (n=50)
NewMetaInfo/16MB_4pc_4MBpc-96                                                              161.412Ki ± 0%                                           1.047Ki ± 0%  -99.35% (n=50)
NewMetaInfo/16MB_16pc_1MBpc-96                                                             546.874Ki ± 0%                                           1.688Ki ± 0%  -99.69% (n=50)
NewMetaInfo/16MB_1024pc_16KBpc-96                                                         16505.61Ki ± 0%                                           44.53Ki ± 0%  -99.73% (n=50)
geomean                                                                                      1.966Mi                                                5.422Ki       -99.73%

                                  │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/before.txt │ /home/user/kraken/bench-results/run-a1-20260504-104049-n50/after.txt │
                                  │                               allocs/op                               │                      allocs/op                        vs base        │
NewMetaInfo/1MB_4pc-96                                                                         38.00 ± 0%                                             21.00 ± 0%  -44.74% (n=50)
NewMetaInfo/16MB_64pc-96                                                                      284.00 ± 0%                                             83.00 ± 0%  -70.77% (n=50)
NewMetaInfo/64MB_256pc-96                                                                     1056.0 ± 0%                                             277.0 ± 0%  -73.77% (n=50)
NewMetaInfo/256MB_1024pc-96                                                                   4.133k ± 0%                                            1.047k ± 0%  -74.67% (n=50)
NewMetaInfo/16MB_4pc_4MBpc-96                                                                  38.00 ± 0%                                             21.00 ± 0%  -44.74% (n=50)
NewMetaInfo/16MB_16pc_1MBpc-96                                                                 89.00 ± 0%                                             34.00 ± 0%  -61.80% (n=50)
NewMetaInfo/16MB_1024pc_16KBpc-96                                                             4.137k ± 0%                                            1.047k ± 0%  -74.69% (n=50)
geomean                                                                                        351.2                                                  120.9       -65.57%
```

