### PR TITLE
feat(nginx/config): allow overwrite of proxy_read_timeout through yaml

### DIFF
--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -37,6 +37,8 @@ server {
   access_log {{.access_log_path}};
   error_log {{.error_log_path}};
 
+  proxy_read_timeout {{if .proxy_read_timeout}}{{.proxy_read_timeout}}{{else}}10m{{end}};
+
   gzip on;
   gzip_types text/plain test/csv application/json;
 

--- a/nginx/config/build-index.go
+++ b/nginx/config/build-index.go
@@ -50,7 +50,7 @@ server {
     proxy_cache_valid   any 1s;
     proxy_cache_lock    on;
 
-    proxy_read_timeout {{.proxy_read_timeout}};
+    proxy_read_timeout {{if .proxy_read_timeout}}{{.proxy_read_timeout}}{{else}}3m{{end}};
   }
 
   location ~* ^/repositories/.*/tags$ {
@@ -71,7 +71,7 @@ server {
     proxy_cache_valid   any 1s;
     proxy_cache_lock    on;
 
-    proxy_read_timeout {{.proxy_read_timeout}};
+    proxy_read_timeout {{if .proxy_read_timeout}}{{.proxy_read_timeout}}{{else}}3m{{end}};
   }
 }
 `

--- a/nginx/config/origin.go
+++ b/nginx/config/origin.go
@@ -29,7 +29,7 @@ server {
   gzip_types text/plain test/csv application/json;
 
   # Committing large blobs might take a while.
-  proxy_read_timeout {{.proxy_read_timeout}};
+  proxy_read_timeout {{if .proxy_read_timeout}}{{.proxy_read_timeout}}{{else}}3m{{end}};
 
   proxy_set_header traceparent $http_traceparent;
   proxy_set_header tracestate $http_tracestate;

--- a/nginx/config/proxy.go
+++ b/nginx/config/proxy.go
@@ -42,7 +42,7 @@ server {
   gzip_types text/plain test/csv application/json;
 
   # Committing large blobs might take a while.
-  proxy_read_timeout 3m;
+  proxy_read_timeout {{if $.proxy_read_timeout}}{{$.proxy_read_timeout}}{{else}}3m{{end}};
 
 {{healthEndpoint "proxy-server"}}
 

--- a/nginx/config/tracker.go
+++ b/nginx/config/tracker.go
@@ -29,6 +29,8 @@ server {
   access_log {{.access_log_path}};
   error_log {{.error_log_path}};
 
+  proxy_read_timeout {{if .proxy_read_timeout}}{{.proxy_read_timeout}}{{else}}60s{{end}};
+
 {{healthEndpoint "tracker"}}
 
   location / {

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -85,7 +85,7 @@ func (c *Config) applyDefaults() error {
 		c.ErrorLogPath = filepath.Join(c.LogDir, "nginx-error.log")
 	}
 	if c.ProxyTimeout == "" {
-		c.ProxyTimeout = "3m"
+		return errors.New("proxy_timeout must be set")
 	}
 	return nil
 }

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -84,9 +84,6 @@ func (c *Config) applyDefaults() error {
 		}
 		c.ErrorLogPath = filepath.Join(c.LogDir, "nginx-error.log")
 	}
-	if c.ProxyTimeout == "" {
-		return errors.New("proxy_timeout must be set")
-	}
 	return nil
 }
 


### PR DESCRIPTION
Set explicit defaults for the `proxy_read_timeout` setting for all kraken services' nginx configs and allow overriding them through the yaml config.

`proxy_read_timeout` configures a timeout for the service's APIs that is triggered after the API has not responded with any data for the respective duration. NOTE that if the API returns some data, but not all data, the timeout does not trigger.

A problematic part of this setting is that while it is intended to trigger when the server is completely inresponsive (e.g. a blob download not starting after X minutes), it does NOT work like that with agent's download blob API. This happens as the agent does not start streaming data to its consumer until it has fully downloaded and cached it on disk. Therefore, `proxy_read_timeout` ends up functioning as a end-to-end API timeout.

Another problem is that the setting's default is 60s if not set explicitly - the current situation in agent. To avoid unnecessary server-side timeouts in agent (upon which the agent does not abort the download btw), I'm bumping the default to 10m. Keep in mind the agent already has an internal `timeout` built in when a torrent download doesn't make progress for 5m.

To avoid such an issue in the future, I am explicitly defining service-specific defaults in each service's nginx config file.

Timeouts before vs after this PR:
 - agent: 1m -> 10m
 - origin: 3m -> 3m
 - build-index: 3m -> 3m
 - proxy: 3m -> 3m
 - tracker: 1m -> 1m