### PR TITLE
perf(lib/buffer_readwriter): avoid write lock while writing to buffer to reduce mutex contentions

### DIFF
--- a/lib/store/base/buffer_readwriter.go
+++ b/lib/store/base/buffer_readwriter.go
@@ -17,54 +17,96 @@ package base
 import (
 	"fmt"
 	"io"
-
-	"github.com/aws/aws-sdk-go/aws"
+	"sync"
+	"sync/atomic"
 )
 
 var _ FileReadWriter = &BufferReadWriter{}
 
-// BufferReadWriter implements FileReadWriter interface for in-memory buffering.
+// BufferReadWriter implements FileReadWriter for in-memory buffering.
+//
+// When created with size > 0, WriteAt takes a fast path using RLock, allowing
+// concurrent goroutines writing to non-overlapping byte ranges to proceed in
+// parallel with no serialization. The maximum written extent is tracked via an
+// atomic so that Bytes(), Size(), Read, and ReadAt return only the data that
+// was actually written.
+//
+// When created with size == 0, every WriteAt that extends the buffer acquires a
+// full write lock to grow the backing slice.
+//
+// Write, Read, ReadAt, and Seek must not be called concurrently with each other
+// or with WriteAt.
 type BufferReadWriter struct {
-	buf    *aws.WriteAtBuffer
-	offset int64
+	mu      sync.RWMutex
+	buf     []byte
+	written atomic.Int64
+	offset  int64
 }
 
-// NewBufferReadWriter creates a new BufferReadWriter with an initial capacity of size bytes.
+// NewBufferReadWriter creates a new BufferReadWriter pre-allocated to size bytes.
+// Pass the exact blob size when known to enable lock-free
+// concurrent WriteAt calls for non-overlapping shard ranges.
 func NewBufferReadWriter(size uint64) *BufferReadWriter {
-	bytesSlice := make([]byte, 0, size)
-	buf := aws.NewWriteAtBuffer(bytesSlice)
-	// Although this is default, this is explicitly set to notify that we are reserving
-	// only as much capacity as needed
-	buf.GrowthCoeff = 1
-
-	return &BufferReadWriter{
-		buf:    buf,
-		offset: 0,
-	}
+	return &BufferReadWriter{buf: make([]byte, size)}
 }
 
-// Write implements io.Writer by using WriteAt with current write offset.
+// Write implements io.Writer using the current sequential write offset.
 func (b *BufferReadWriter) Write(p []byte) (n int, err error) {
-	n, err = b.buf.WriteAt(p, b.offset)
+	n, err = b.WriteAt(p, b.offset)
 	b.offset += int64(n)
 	return n, err
 }
 
-// WriteAt implements io.WriterAt for parallel writes.
-func (b *BufferReadWriter) WriteAt(p []byte, off int64) (n int, err error) {
+// WriteAt implements io.WriterAt.
+//
+// Fast path (off+len(p) within pre-allocated buffer): multiple goroutines may
+// call WriteAt concurrently, provided their byte ranges do not overlap.
+// Slow path (write extends beyond current buffer): acquires an exclusive lock
+// to grow the buffer, then writes.
+func (b *BufferReadWriter) WriteAt(p []byte, off int64) (int, error) {
 	if off < 0 {
 		return 0, fmt.Errorf("negative offset")
 	}
-	return b.buf.WriteAt(p, off)
+	end := off + int64(len(p))
+	if end < off {
+		return 0, fmt.Errorf("write at offset %d length %d overflows int64", off, len(p))
+	}
+
+	b.mu.RLock()
+	if end <= int64(len(b.buf)) {
+		n := copy(b.buf[off:], p)
+		for {
+			cur := b.written.Load()
+			if end <= cur || b.written.CompareAndSwap(cur, end) {
+				break
+			}
+		}
+		b.mu.RUnlock()
+		return n, nil
+	}
+	b.mu.RUnlock()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if end > int64(len(b.buf)) {
+		grown := make([]byte, end)
+		copy(grown, b.buf)
+		b.buf = grown
+	}
+	n := copy(b.buf[off:], p)
+	if end > b.written.Load() {
+		b.written.Store(end)
+	}
+	return n, nil
 }
 
 // Read implements io.Reader for sequential reads.
 func (b *BufferReadWriter) Read(p []byte) (n int, err error) {
-	bufBytes := b.buf.Bytes()
-	if b.offset >= int64(len(bufBytes)) {
+	written := b.written.Load()
+	if b.offset >= written {
 		return 0, io.EOF
 	}
-	n = copy(p, bufBytes[b.offset:])
+	n = copy(p, b.buf[b.offset:written])
 	b.offset += int64(n)
 	if n < len(p) {
 		err = io.EOF
@@ -77,11 +119,14 @@ func (b *BufferReadWriter) ReadAt(p []byte, off int64) (n int, err error) {
 	if off < 0 {
 		return 0, fmt.Errorf("negative offset")
 	}
-	bufBytes := b.buf.Bytes()
-	if off >= int64(len(bufBytes)) {
+	b.mu.RLock()
+	buf := b.buf
+	written := b.written.Load()
+	b.mu.RUnlock()
+	if off >= written {
 		return 0, io.EOF
 	}
-	n = copy(p, bufBytes[off:])
+	n = copy(p, buf[off:written])
 	if n < len(p) {
 		err = io.EOF
 	}
@@ -91,23 +136,19 @@ func (b *BufferReadWriter) ReadAt(p []byte, off int64) (n int, err error) {
 // Seek implements io.Seeker.
 func (b *BufferReadWriter) Seek(offset int64, whence int) (int64, error) {
 	var newOffset int64
-	bufSize := int64(len(b.buf.Bytes()))
-
 	switch whence {
 	case io.SeekStart:
 		newOffset = offset
 	case io.SeekCurrent:
 		newOffset = b.offset + offset
 	case io.SeekEnd:
-		newOffset = bufSize + offset
+		newOffset = b.written.Load() + offset
 	default:
 		return 0, fmt.Errorf("invalid whence: %d", whence)
 	}
-
 	if newOffset < 0 {
 		return 0, fmt.Errorf("negative position: %d", newOffset)
 	}
-
 	b.offset = newOffset
 	return newOffset, nil
 }
@@ -117,10 +158,8 @@ func (b *BufferReadWriter) Close() error {
 	return nil
 }
 
-// Size returns the size of the buffer
-func (b *BufferReadWriter) Size() int64 {
-	return int64(len(b.buf.Bytes()))
-}
+// Size returns the largest end offset written so far.
+func (b *BufferReadWriter) Size() int64 { return b.written.Load() }
 
 // Cancel is no-op
 func (b *BufferReadWriter) Cancel() error {
@@ -132,7 +171,7 @@ func (b *BufferReadWriter) Commit() error {
 	return nil
 }
 
-// Bytes returns the full buffer
+// Bytes returns the bytes that have been written so far.
 func (b *BufferReadWriter) Bytes() []byte {
-	return b.buf.Bytes()
+	return b.buf[:b.written.Load()]
 }

--- a/lib/store/base/buffer_readwriter.go
+++ b/lib/store/base/buffer_readwriter.go
@@ -56,8 +56,10 @@ func (b *BufferReadWriter) Write(p []byte) (n int, err error) {
 //
 // Fast path (off+len(p) within pre-allocated buffer): multiple goroutines may
 // call WriteAt concurrently, provided their byte ranges do not overlap.
+//
 // Slow path (write extends beyond current buffer): acquires an exclusive lock
-// to grow the buffer, then writes.
+// only to grow the buffer, then copies under a shared read lock so other
+// writers can proceed in parallel.
 func (b *BufferReadWriter) WriteAt(p []byte, off int64) (int, error) {
 	if off < 0 {
 		return 0, fmt.Errorf("negative offset")
@@ -75,19 +77,23 @@ func (b *BufferReadWriter) WriteAt(p []byte, off int64) (int, error) {
 		return n, nil
 	}
 
-	// slow path
+	// slow path: grow, then call updateBuffer again
+	b.growBuffer(end)
+	n, _ := b.updateBuffer(p, off, end)
+	return n, nil
+}
+
+// growBuffer expands b.buf to at least size bytes. It is a no-op when the
+// buffer is already large enough.
+func (b *BufferReadWriter) growBuffer(size int64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if end > int64(len(b.buf)) {
-		grown := make([]byte, end)
-		copy(grown, b.buf)
-		b.buf = grown
+	if size <= int64(len(b.buf)) {
+		return
 	}
-	n := copy(b.buf[off:], p)
-	if end > b.written.Load() {
-		b.written.Store(end)
-	}
-	return n, nil
+	grown := make([]byte, size)
+	copy(grown, b.buf)
+	b.buf = grown
 }
 
 // updateBuffer copies p into [off, end).

--- a/lib/store/base/buffer_readwriter.go
+++ b/lib/store/base/buffer_readwriter.go
@@ -91,7 +91,7 @@ func (b *BufferReadWriter) WriteAt(p []byte, off int64) (int, error) {
 }
 
 // updateBuffer copies p into [off, end).
-// Returns -1, false if end exceeds the buffer, which cause WriteAt to take the slow path
+// Returns (-1, true) if end exceeds the buffer, causing WriteAt to take the slow path.
 func (b *BufferReadWriter) updateBuffer(p []byte, off, end int64) (int, bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()

--- a/lib/store/base/buffer_readwriter.go
+++ b/lib/store/base/buffer_readwriter.go
@@ -25,17 +25,12 @@ var _ FileReadWriter = &BufferReadWriter{}
 
 // BufferReadWriter implements FileReadWriter for in-memory buffering.
 //
-// When created with size > 0, WriteAt takes a fast path using RLock, allowing
-// concurrent goroutines writing to non-overlapping byte ranges to proceed in
-// parallel with no serialization. The maximum written extent is tracked via an
-// atomic so that Bytes(), Size(), Read, and ReadAt return only the data that
-// was actually written.
+// Pre-sizing (size > 0) allows concurrent WriteAt calls to non-overlapping
+// ranges to run in parallel. Without pre-sizing, each write that grows the
+// buffer is serialized.
 //
-// When created with size == 0, every WriteAt that extends the buffer acquires a
-// full write lock to grow the backing slice.
-//
-// Write, Read, ReadAt, and Seek must not be called concurrently with each other
-// or with WriteAt.
+// Bytes, Size, Write, Read, ReadAt, and Seek must not be called concurrently
+// with each other or with WriteAt.
 type BufferReadWriter struct {
 	mu      sync.RWMutex
 	buf     []byte
@@ -44,8 +39,8 @@ type BufferReadWriter struct {
 }
 
 // NewBufferReadWriter creates a new BufferReadWriter pre-allocated to size bytes.
-// Pass the exact blob size when known to enable lock-free
-// concurrent WriteAt calls for non-overlapping shard ranges.
+// Pass the exact blob size when known so concurrent WriteAt calls for
+// non-overlapping shard ranges can run in parallel without writer serialization.
 func NewBufferReadWriter(size uint64) *BufferReadWriter {
 	return &BufferReadWriter{buf: make([]byte, size)}
 }
@@ -67,25 +62,20 @@ func (b *BufferReadWriter) WriteAt(p []byte, off int64) (int, error) {
 	if off < 0 {
 		return 0, fmt.Errorf("negative offset")
 	}
+	if len(p) == 0 {
+		return 0, nil
+	}
 	end := off + int64(len(p))
 	if end < off {
 		return 0, fmt.Errorf("write at offset %d length %d overflows int64", off, len(p))
 	}
 
-	b.mu.RLock()
-	if end <= int64(len(b.buf)) {
-		n := copy(b.buf[off:], p)
-		for {
-			cur := b.written.Load()
-			if end <= cur || b.written.CompareAndSwap(cur, end) {
-				break
-			}
-		}
-		b.mu.RUnlock()
+	// fast path
+	if n, shouldGrowBuffer := b.updateBuffer(p, off, end); !shouldGrowBuffer {
 		return n, nil
 	}
-	b.mu.RUnlock()
 
+	// slow path
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if end > int64(len(b.buf)) {
@@ -98,6 +88,24 @@ func (b *BufferReadWriter) WriteAt(p []byte, off int64) (int, error) {
 		b.written.Store(end)
 	}
 	return n, nil
+}
+
+// updateBuffer copies p into [off, end).
+// Returns -1, false if end exceeds the buffer, which cause WriteAt to take the slow path
+func (b *BufferReadWriter) updateBuffer(p []byte, off, end int64) (int, bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if end <= int64(len(b.buf)) {
+		n := copy(b.buf[off:], p)
+		for {
+			cur := b.written.Load()
+			if end <= cur || b.written.CompareAndSwap(cur, end) {
+				break
+			}
+		}
+		return n, false
+	}
+	return -1, true
 }
 
 // Read implements io.Reader for sequential reads.
@@ -171,7 +179,8 @@ func (b *BufferReadWriter) Commit() error {
 	return nil
 }
 
-// Bytes returns the bytes that have been written so far.
+// Bytes returns the buffer up to the highest offset written so far.
+// Any gaps between writes are zero-filled.
 func (b *BufferReadWriter) Bytes() []byte {
 	return b.buf[:b.written.Load()]
 }

--- a/lib/store/base/buffer_readwriter_test.go
+++ b/lib/store/base/buffer_readwriter_test.go
@@ -53,6 +53,7 @@ func TestBufferReadWriter_Write(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedSize, buf.Size())
+			assert.Equal(t, tt.expectedResult, buf.Bytes())
 		})
 	}
 }
@@ -115,6 +116,9 @@ func TestBufferReadWriter_WriteAt(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedSize, buf.Size())
+			if tt.expectedResult != nil {
+				assert.Equal(t, tt.expectedResult, buf.Bytes())
+			}
 		})
 	}
 }

--- a/lib/store/base/buffer_readwriter_test.go
+++ b/lib/store/base/buffer_readwriter_test.go
@@ -317,30 +317,43 @@ func TestBufferReadWriter_TestReader(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestBufferReadWriter_ConcurrentWriteAt validates that concurrent writes to
-// non-overlapping byte ranges on a pre-sized buffer produce correct results.
 func TestBufferReadWriter_ConcurrentWriteAt(t *testing.T) {
 	const numShards, shardSize = 10, 1024
-	data := make([]byte, numShards*shardSize)
-	for i := range data {
-		data[i] = byte(i % 256)
+	totalSize := uint64(numShards * shardSize)
+
+	tests := []struct {
+		name     string
+		initSize uint64
+	}{
+		{"presized", totalSize},
+		{"half_presized", totalSize / 2},
+		{"dynamic", 0},
 	}
 
-	buf := NewBufferReadWriter(numShards * shardSize)
-	errs := make([]error, numShards)
-	var wg sync.WaitGroup
-	for i := 0; i < numShards; i++ {
-		wg.Add(1)
-		go func(shard int) {
-			defer wg.Done()
-			off := shard * shardSize
-			_, errs[shard] = buf.WriteAt(data[off:off+shardSize], int64(off))
-		}(i)
-	}
-	wg.Wait()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, totalSize)
+			for i := range data {
+				data[i] = byte(i % 256)
+			}
 
-	require.NoError(t, errors.Join(errs...))
-	assert.Equal(t, data, buf.Bytes())
+			buf := NewBufferReadWriter(tt.initSize)
+			errs := make([]error, numShards)
+			var wg sync.WaitGroup
+			for i := 0; i < numShards; i++ {
+				wg.Add(1)
+				go func(shard int) {
+					defer wg.Done()
+					off := shard * shardSize
+					_, errs[shard] = buf.WriteAt(data[off:off+shardSize], int64(off))
+				}(i)
+			}
+			wg.Wait()
+
+			require.NoError(t, errors.Join(errs...))
+			assert.Equal(t, data, buf.Bytes())
+		})
+	}
 }
 
 func TestBufferReadWriter_WriteAtEmpty(t *testing.T) {

--- a/lib/store/base/buffer_readwriter_test.go
+++ b/lib/store/base/buffer_readwriter_test.go
@@ -15,6 +15,7 @@
 package base
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"runtime"
@@ -314,7 +315,6 @@ func TestBufferReadWriter_TestReader(t *testing.T) {
 
 // TestBufferReadWriter_ConcurrentWriteAt validates that concurrent writes to
 // non-overlapping byte ranges on a pre-sized buffer produce correct results.
-// Run with -race to confirm no data races.
 func TestBufferReadWriter_ConcurrentWriteAt(t *testing.T) {
 	const numShards, shardSize = 10, 1024
 	data := make([]byte, numShards*shardSize)
@@ -323,35 +323,40 @@ func TestBufferReadWriter_ConcurrentWriteAt(t *testing.T) {
 	}
 
 	buf := NewBufferReadWriter(numShards * shardSize)
+	errs := make([]error, numShards)
 	var wg sync.WaitGroup
 	for i := 0; i < numShards; i++ {
 		wg.Add(1)
 		go func(shard int) {
 			defer wg.Done()
-			off := int64(shard * shardSize)
-			_, err := buf.WriteAt(data[off:off+shardSize], off)
-			require.NoError(t, err)
+			off := shard * shardSize
+			_, errs[shard] = buf.WriteAt(data[off:off+shardSize], int64(off))
 		}(i)
 	}
 	wg.Wait()
+
+	require.NoError(t, errors.Join(errs...))
 	assert.Equal(t, data, buf.Bytes())
 }
 
-// totalMutexContentions returns the total number of mutex contention events
-// recorded in the runtime mutex profile since profiling was enabled.
 func totalMutexContentions() int64 {
-	records := make([]runtime.BlockProfileRecord, 10000)
-	n, _ := runtime.MutexProfile(records)
-	var total int64
-	for i := 0; i < n; i++ {
-		total += records[i].Count
+	size := 1024
+	for {
+		records := make([]runtime.BlockProfileRecord, size)
+		n, ok := runtime.MutexProfile(records)
+		if ok {
+			var total int64
+			for i := 0; i < n; i++ {
+				total += records[i].Count
+			}
+			return total
+		}
+		size = n + 64
 	}
-	return total
 }
 
 // benchmarkWriteAt is the shared helper for all WriteAt benchmarks.
 // numShards goroutines each write a non-overlapping 4 MiB shard concurrently,
-// matching the transfermanager production workload.
 // initSize controls the buffer's initial allocation:
 //   - initSize == totalSize: pre-sized fast path (production case)
 //   - initSize == 0:         dynamic growth (sequential / wrong-size case)
@@ -369,13 +374,15 @@ func benchmarkWriteAt(b *testing.B, numShards int, initSize uint64) {
 		}
 	}
 
-	runtime.SetMutexProfileFraction(1)
+	prev := runtime.SetMutexProfileFraction(1)
+	defer runtime.SetMutexProfileFraction(prev)
 	b.ResetTimer()
 	b.SetBytes(int64(totalSize))
 	b.ReportAllocs()
 
 	startContentions := totalMutexContentions()
 
+	errs := make([]error, numShards)
 	for i := 0; i < b.N; i++ {
 		buf := NewBufferReadWriter(initSize)
 		var wg sync.WaitGroup
@@ -383,11 +390,13 @@ func benchmarkWriteAt(b *testing.B, numShards int, initSize uint64) {
 			wg.Add(1)
 			go func(s int) {
 				defer wg.Done()
-				_, err := buf.WriteAt(shards[s], int64(s)*shardSize)
-				require.NoError(b, err)
+				_, errs[s] = buf.WriteAt(shards[s], int64(s)*shardSize)
 			}(shard)
 		}
 		wg.Wait()
+		if err := errors.Join(errs...); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	b.StopTimer()
@@ -396,13 +405,8 @@ func benchmarkWriteAt(b *testing.B, numShards int, initSize uint64) {
 	}
 }
 
-// BenchmarkBufferReadWriter_WriteAt exercises three buffer initialisation
-// strategies × three shard counts, giving a full picture of throughput and
-// mutex contention under varying concurrency and pre-allocation.
-//
-// Run before and after the implementation change, then compare with:
-//
-//	benchstat bench-results/before.txt bench-results/after.txt
+// BenchmarkBufferReadWriter_WriteAt exercises three buffer initialization
+// strategies × three shard counts.
 func BenchmarkBufferReadWriter_WriteAt(b *testing.B) {
 	const shardSize = 4 * 1024 * 1024
 	cases := []struct {

--- a/lib/store/base/buffer_readwriter_test.go
+++ b/lib/store/base/buffer_readwriter_test.go
@@ -343,6 +343,15 @@ func TestBufferReadWriter_ConcurrentWriteAt(t *testing.T) {
 	assert.Equal(t, data, buf.Bytes())
 }
 
+func TestBufferReadWriter_WriteAtEmpty(t *testing.T) {
+	buf := NewBufferReadWriter(0)
+	n, err := buf.WriteAt(nil, 1<<30)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, int64(0), buf.Size())
+	assert.Empty(t, buf.Bytes())
+}
+
 func totalMutexContentions() int64 {
 	size := 1024
 	for {
@@ -380,14 +389,13 @@ func benchmarkWriteAt(b *testing.B, numShards int, initSize uint64) {
 
 	prev := runtime.SetMutexProfileFraction(1)
 	defer runtime.SetMutexProfileFraction(prev)
-	b.ResetTimer()
+	startContentions := totalMutexContentions()
 	b.SetBytes(int64(totalSize))
 	b.ReportAllocs()
-
-	startContentions := totalMutexContentions()
+	b.ResetTimer()
 
 	errs := make([]error, numShards)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		buf := NewBufferReadWriter(initSize)
 		var wg sync.WaitGroup
 		for shard := 0; shard < numShards; shard++ {

--- a/lib/store/base/buffer_readwriter_test.go
+++ b/lib/store/base/buffer_readwriter_test.go
@@ -15,7 +15,10 @@
 package base
 
 import (
+	"fmt"
 	"io"
+	"runtime"
+	"sync"
 	"testing"
 	"testing/iotest"
 
@@ -307,4 +310,118 @@ func TestBufferReadWriter_TestReader(t *testing.T) {
 
 	err = iotest.TestReader(buf, content)
 	require.NoError(t, err)
+}
+
+// TestBufferReadWriter_ConcurrentWriteAt validates that concurrent writes to
+// non-overlapping byte ranges on a pre-sized buffer produce correct results.
+// Run with -race to confirm no data races.
+func TestBufferReadWriter_ConcurrentWriteAt(t *testing.T) {
+	const numShards, shardSize = 10, 1024
+	data := make([]byte, numShards*shardSize)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	buf := NewBufferReadWriter(numShards * shardSize)
+	var wg sync.WaitGroup
+	for i := 0; i < numShards; i++ {
+		wg.Add(1)
+		go func(shard int) {
+			defer wg.Done()
+			off := int64(shard * shardSize)
+			_, err := buf.WriteAt(data[off:off+shardSize], off)
+			require.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, data, buf.Bytes())
+}
+
+// totalMutexContentions returns the total number of mutex contention events
+// recorded in the runtime mutex profile since profiling was enabled.
+func totalMutexContentions() int64 {
+	records := make([]runtime.BlockProfileRecord, 10000)
+	n, _ := runtime.MutexProfile(records)
+	var total int64
+	for i := 0; i < n; i++ {
+		total += records[i].Count
+	}
+	return total
+}
+
+// benchmarkWriteAt is the shared helper for all WriteAt benchmarks.
+// numShards goroutines each write a non-overlapping 4 MiB shard concurrently,
+// matching the transfermanager production workload.
+// initSize controls the buffer's initial allocation:
+//   - initSize == totalSize: pre-sized fast path (production case)
+//   - initSize == 0:         dynamic growth (sequential / wrong-size case)
+//   - initSize == totalSize/2: partial pre-allocation, triggers growth mid-download
+func benchmarkWriteAt(b *testing.B, numShards int, initSize uint64) {
+	b.Helper()
+	const shardSize = 4 * 1024 * 1024
+	totalSize := uint64(numShards) * shardSize
+
+	shards := make([][]byte, numShards)
+	for i := range shards {
+		shards[i] = make([]byte, shardSize)
+		for j := range shards[i] {
+			shards[i][j] = byte(i)
+		}
+	}
+
+	runtime.SetMutexProfileFraction(1)
+	b.ResetTimer()
+	b.SetBytes(int64(totalSize))
+	b.ReportAllocs()
+
+	startContentions := totalMutexContentions()
+
+	for i := 0; i < b.N; i++ {
+		buf := NewBufferReadWriter(initSize)
+		var wg sync.WaitGroup
+		for shard := 0; shard < numShards; shard++ {
+			wg.Add(1)
+			go func(s int) {
+				defer wg.Done()
+				_, err := buf.WriteAt(shards[s], int64(s)*shardSize)
+				require.NoError(b, err)
+			}(shard)
+		}
+		wg.Wait()
+	}
+
+	b.StopTimer()
+	if b.N > 0 {
+		b.ReportMetric(float64(totalMutexContentions()-startContentions)/float64(b.N), "mutex-contentions/op")
+	}
+}
+
+// BenchmarkBufferReadWriter_WriteAt exercises three buffer initialisation
+// strategies × three shard counts, giving a full picture of throughput and
+// mutex contention under varying concurrency and pre-allocation.
+//
+// Run before and after the implementation change, then compare with:
+//
+//	benchstat bench-results/before.txt bench-results/after.txt
+func BenchmarkBufferReadWriter_WriteAt(b *testing.B) {
+	const shardSize = 4 * 1024 * 1024
+	cases := []struct {
+		label    string
+		initFunc func(total uint64) uint64
+	}{
+		{"presized", func(total uint64) uint64 { return total }},          // production fast path
+		{"half_presized", func(total uint64) uint64 { return total / 2 }}, // partial pre-alloc, growth needed
+		{"dynamic", func(total uint64) uint64 { return 0 }},               // no pre-alloc, always grows
+	}
+	shardCounts := []int{1, 4, 10}
+
+	for _, tc := range cases {
+		for _, numShards := range shardCounts {
+			totalSize := uint64(numShards) * shardSize
+			initSize := tc.initFunc(totalSize)
+			b.Run(fmt.Sprintf("%s_%d_shards", tc.label, numShards), func(b *testing.B) {
+				benchmarkWriteAt(b, numShards, initSize)
+			})
+		}
+	}
 }


### PR DESCRIPTION
# What?
Mutexes on the buffer are the third-highest mutex contention for kraken-origin. 
The `aws.WriteAtBuffer` [acquires a lock at every lock in the whole buffer](https://github.com/cognusion/go-utils/blob/c18d467d15730a757ba025f28967f714bf35ffda/writeatbuffer/writeatbuffer.go#L31-L49) even when there's no overlap
```
--- mutex:
cycles/second=2445350745
sampling period=1
65383536215716 29312064 @ 0x5154cb3 0x5154b6a 0x708ee8a 0x708f322 0x7188429 0x49db190 0x718fdbd 0x718fd7d 0x49db09d 0x71a1508 0x71a14da 0x719fff5 0x71a1137 0x499fb81
#	0x5154cb2	sync.(*Mutex).Unlock+0x12								GOROOT/src/sync/mutex.go:65
#	0x5154b69	golang.org/x/net/http2.transportResponseBody.Read+0x409					external/org_golang_x_net/http2/transport.go:2598
#	0x708ee89	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*wrappedBody).Read+0x29	external/io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp/transport.go:229
#	0x708f321	go:(*struct { io.ReadCloser }).Read+0x21						<autogenerated>:1
#	0x7188428	cloud.google.com/go/storage.(*httpReader).Read+0xa8					external/com_google_cloud_go_storage/http_client.go:1341
#	0x49db18f	io.copyBuffer+0x18f									GOROOT/src/io/io.go:429
#	0x718fdbc	io.Copy+0x5c										GOROOT/src/io/io.go:388
#	0x718fd7c	cloud.google.com/go/storage.(*Reader).WriteTo+0x1c					external/com_google_cloud_go_storage/reader.go:302
#	0x49db09c	io.copyBuffer+0x9c									GOROOT/src/io/io.go:411
#	0x71a1507	io.Copy+0x367										GOROOT/src/io/io.go:388
#	0x71a14d9	cloud.google.com/go/storage/transfermanager.(*DownloadObjectInput).downloadShard+0x339	external/com_google_cloud_go_storage/transfermanager/downloader.go:660
#	0x719fff4	cloud.google.com/go/storage/transfermanager.(*Downloader).downloadWorker+0x74		external/com_google_cloud_go_storage/transfermanager/downloader.go:363
#	0x71a1136	cloud.google.com/go/storage/transfermanager.NewDownloader.gowrap2+0x16			external/com_google_cloud_go_storage/transfermanager/downloader.go:555

2942885073034 1384198 @ 0x5154cb3 0x5154b6a 0x708ee8a 0x708f322 0x7188429 0x718fd0c 0x49db423 0x49db190 0x49dae4c 0x49dae2b 0x71a1bc8 0x71a00cf 0x719ffd5 0x71a1137 0x499fb81
#	0x5154cb2	sync.(*Mutex).Unlock+0x12									GOROOT/src/sync/mutex.go:65
#	0x5154b69	golang.org/x/net/http2.transportResponseBody.Read+0x409						external/org_golang_x_net/http2/transport.go:2598
#	0x708ee89	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*wrappedBody).Read+0x29		external/io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp/transport.go:229
#	0x708f321	go:(*struct { io.ReadCloser }).Read+0x21							<autogenerated>:1
#	0x7188428	cloud.google.com/go/storage.(*httpReader).Read+0xa8						external/com_google_cloud_go_storage/http_client.go:1341
#	0x718fd0b	cloud.google.com/go/storage.(*Reader).Read+0x2b							external/com_google_cloud_go_storage/reader.go:290
#	0x49db422	io.(*LimitedReader).Read+0x42									GOROOT/src/io/io.go:479
#	0x49db18f	io.copyBuffer+0x18f										GOROOT/src/io/io.go:429
#	0x49dae4b	io.Copy+0x8b											GOROOT/src/io/io.go:388
#	0x49dae2a	io.CopyN+0x6a											GOROOT/src/io/io.go:364
#	0x71a1bc7	cloud.google.com/go/storage/transfermanager.(*DownloadObjectInput).downloadFirstShard+0x2a7	external/com_google_cloud_go_storage/transfermanager/downloader.go:706
#	0x71a00ce	cloud.google.com/go/storage/transfermanager.(*Downloader).startDownload+0x6e			external/com_google_cloud_go_storage/transfermanager/downloader.go:382
#	0x719ffd4	cloud.google.com/go/storage/transfermanager.(*Downloader).downloadWorker+0x54			external/com_google_cloud_go_storage/transfermanager/downloader.go:361
#	0x71a1136	cloud.google.com/go/storage/transfermanager.NewDownloader.gowrap2+0x16				external/com_google_cloud_go_storage/transfermanager/downloader.go:555

652185813531 2034435 @ 0x6fe1333 0x6fe1287 0x6fe3617 0x49db70c 0x49dc8c2 0x49db1d4 0x718fdbd 0x718fd7d 0x49db09d 0x71a1508 0x71a14da 0x719fff5 0x71a1137 0x499fb81
#	0x6fe1332	sync.(*Mutex).Unlock+0x12								GOROOT/src/sync/mutex.go:65
#	0x6fe1286	github.com/aws/aws-sdk-go/aws.(*WriteAtBuffer).WriteAt+0x206				external/com_github_aws_aws_sdk_go/aws/types.go:200
#	0x6fe3616	github.com/uber/kraken/lib/store/base.(*BufferReadWriter).WriteAt+0x76			external/com_github_uber_kraken/lib/store/base/buffer_readwriter.go:58
#	0x49db70b	io.(*OffsetWriter).Write+0x2b								GOROOT/src/io/io.go:583
#	0x49dc8c1	io.(*multiWriter).Write+0x61								GOROOT/src/io/multi.go:85
#	0x49db1d3	io.copyBuffer+0x1d3									GOROOT/src/io/io.go:431
#	0x718fdbc	io.Copy+0x5c										GOROOT/src/io/io.go:388
#	0x718fd7c	cloud.google.com/go/storage.(*Reader).WriteTo+0x1c					external/com_google_cloud_go_storage/reader.go:302
#	0x49db09c	io.copyBuffer+0x9c									GOROOT/src/io/io.go:411
#	0x71a1507	io.Copy+0x367										GOROOT/src/io/io.go:388
#	0x71a14d9	cloud.google.com/go/storage/transfermanager.(*DownloadObjectInput).downloadShard+0x339	external/com_google_cloud_go_storage/transfermanager/downloader.go:660
#	0x719fff4	cloud.google.com/go/storage/transfermanager.(*Downloader).downloadWorker+0x74		external/com_google_cloud_go_storage/transfermanager/downloader.go:363
#	0x71a1136	cloud.google.com/go/storage/transfermanager.NewDownloader.gowrap2+0x16			external/com_google_cloud_go_storage/transfermanager/downloader.go:555
```
Some observations:
1. Mismatch between the actual blob download size and the `Stat` call is rare; growth of the buffer and the need to acquire a lock at that time are rare but required.
2. The blobs that are supposed to be downloaded are chunked, and ideally, there shouldn't be any overlap b/w chunks. If it is there, the caller should handle it rather than the buffer getting blocked.

This change removes `aws.WriteAtBuffer` and adds a normal byte array that can be edited by simultaneous writers. Also, to handle the rare scenario where the buffer is smaller than expected, a lock is acquired, and a new buffer is allocated with the new size.

# Testing

Benchmarks 
```
goos: linux
goarch: amd64
pkg: github.com/uber/kraken/lib/store/base
cpu: AMD EPYC 7B13
                                                    │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/before.txt │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/after.txt │
                                                    │                                 sec/op                                 │                    sec/op                     vs base                 │
BufferReadWriter_WriteAt/presized_1_shards-96                                                                   1173.1µ ± 3%                                    988.4µ ± 2%  -15.74% (n=100)
BufferReadWriter_WriteAt/presized_4_shards-96                                                                    3.833m ± 2%                                    2.664m ± 2%  -30.48% (n=100)
BufferReadWriter_WriteAt/presized_10_shards-96                                                                   9.736m ± 2%                                    6.944m ± 2%  -28.68% (n=100)
BufferReadWriter_WriteAt/half_presized_1_shards-96                                                               2.359m ± 2%                                    2.335m ± 2%   -1.02% (p=0.008 n=100)
BufferReadWriter_WriteAt/half_presized_4_shards-96                                                               5.738m ± 3%                                    6.939m ± 3%  +20.92% (p=0.000 n=100)
BufferReadWriter_WriteAt/half_presized_10_shards-96                                                              11.91m ± 3%                                    12.29m ± 3%   +3.11% (p=0.006 n=100)
BufferReadWriter_WriteAt/dynamic_1_shards-96                                                                     1.303m ± 2%                                    1.230m ± 3%   -5.61% (p=0.002 n=100)
BufferReadWriter_WriteAt/dynamic_4_shards-96                                                                     3.971m ± 3%                                    2.756m ± 3%  -30.58% (n=100)
BufferReadWriter_WriteAt/dynamic_10_shards-96                                                                    10.87m ± 2%                                    11.49m ± 3%   +5.72% (p=0.000 n=100)
geomean                                                                                                          4.189m                                         3.736m       -10.81%

                                                    │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/before.txt │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/after.txt │
                                                    │                                  B/s                                   │                     B/s                       vs base                 │
BufferReadWriter_WriteAt/presized_1_shards-96                                                                   3.330Gi ± 3%                                   3.952Gi ± 2%  +18.68% (p=0.000 n=100)
BufferReadWriter_WriteAt/presized_4_shards-96                                                                   4.077Gi ± 3%                                   5.865Gi ± 2%  +43.85% (p=0.000 n=100)
BufferReadWriter_WriteAt/presized_10_shards-96                                                                  4.012Gi ± 2%                                   5.626Gi ± 2%  +40.21% (p=0.000 n=100)
BufferReadWriter_WriteAt/half_presized_1_shards-96                                                              1.656Gi ± 2%                                   1.673Gi ± 2%   +1.03% (p=0.008 n=100)
BufferReadWriter_WriteAt/half_presized_4_shards-96                                                              2.723Gi ± 4%                                   2.252Gi ± 3%  -17.30% (p=0.000 n=100)
BufferReadWriter_WriteAt/half_presized_10_shards-96                                                             3.278Gi ± 3%                                   3.180Gi ± 3%   -3.02% (p=0.006 n=100)
BufferReadWriter_WriteAt/dynamic_1_shards-96                                                                    2.997Gi ± 3%                                   3.175Gi ± 3%   +5.94% (p=0.002 n=100)
BufferReadWriter_WriteAt/dynamic_4_shards-96                                                                    3.935Gi ± 3%                                   5.669Gi ± 3%  +44.05% (p=0.000 n=100)
BufferReadWriter_WriteAt/dynamic_10_shards-96                                                                   3.593Gi ± 2%                                   3.398Gi ± 2%   -5.41% (p=0.000 n=100)
geomean                                                                                                         3.189Gi                                        3.576Gi       +12.12%

                                                    │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/before.txt │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/after.txt │
                                                    │                          mutex-contentions/op                          │             mutex-contentions/op              vs base                 │
BufferReadWriter_WriteAt/presized_1_shards-96                                                                     6.309 ± 3%                                     4.607 ± 4%  -26.98% (n=100)
BufferReadWriter_WriteAt/presized_4_shards-96                                                                    10.575 ± 2%                                     7.136 ± 5%  -32.52% (n=100)
BufferReadWriter_WriteAt/presized_10_shards-96                                                                    20.09 ± 4%                                     10.92 ± 6%  -45.64% (n=100)
BufferReadWriter_WriteAt/half_presized_1_shards-96                                                                6.840 ± 4%                                     6.333 ± 3%   -7.41% (p=0.000 n=100)
BufferReadWriter_WriteAt/half_presized_4_shards-96                                                               15.455 ± 3%                                     9.612 ± 7%  -37.81% (n=100)
BufferReadWriter_WriteAt/half_presized_10_shards-96                                                               36.44 ± 3%                                     30.92 ± 6%  -15.15% (n=100)
BufferReadWriter_WriteAt/dynamic_1_shards-96                                                                      9.361 ± 2%                                     6.575 ± 7%  -29.76% (n=100)
BufferReadWriter_WriteAt/dynamic_4_shards-96                                                                      13.06 ± 2%                                     11.02 ± 4%  -15.58% (n=100)
BufferReadWriter_WriteAt/dynamic_10_shards-96                                                                     24.23 ± 2%                                     24.13 ± 2%        ~ (p=0.635 n=100)
geomean                                                                                                           13.54                                          10.19       -24.76%

                                                    │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/before.txt │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/after.txt │
                                                    │                                  B/op                                  │                     B/op                      vs base                 │
BufferReadWriter_WriteAt/presized_1_shards-96                                                                   4.000Mi ± 0%                                   4.000Mi ± 0%   -0.00% (p=0.000 n=100)
BufferReadWriter_WriteAt/presized_4_shards-96                                                                   16.00Mi ± 0%                                   16.00Mi ± 0%   -0.00% (n=100)
BufferReadWriter_WriteAt/presized_10_shards-96                                                                  40.00Mi ± 0%                                   40.00Mi ± 0%   -0.00% (n=100)
BufferReadWriter_WriteAt/half_presized_1_shards-96                                                              6.000Mi ± 0%                                   6.000Mi ± 0%   -0.00% (p=0.002 n=100)
BufferReadWriter_WriteAt/half_presized_4_shards-96                                                              24.00Mi ± 0%                                   24.12Mi ± 0%   +0.50% (p=0.008 n=100)
BufferReadWriter_WriteAt/half_presized_10_shards-96                                                             60.00Mi ± 0%                                   60.00Mi ± 0%   -0.00% (p=0.000 n=100)
BufferReadWriter_WriteAt/dynamic_1_shards-96                                                                    4.000Mi ± 0%                                   4.000Mi ± 0%   -0.00% (p=0.000 n=100)
BufferReadWriter_WriteAt/dynamic_4_shards-96                                                                    16.01Mi ± 0%                                   16.05Mi ± 0%   +0.21% (p=0.000 n=100)
BufferReadWriter_WriteAt/dynamic_10_shards-96                                                                   40.19Mi ± 0%                                   45.42Mi ± 1%  +13.01% (p=0.000 n=100)
geomean                                                                                                         15.67Mi                                        15.90Mi        +1.45%

                                                    │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/before.txt │ /home/user/kraken/bench-results/run-a2-20260522-095049-n100/after.txt │
                                                    │                               allocs/op                                │                      allocs/op                        vs base         │
BufferReadWriter_WriteAt/presized_1_shards-96                                                                     6.000 ± 0%                                             5.000 ± 0%  -16.67% (n=100)
BufferReadWriter_WriteAt/presized_4_shards-96                                                                     14.00 ± 0%                                             11.00 ± 0%  -21.43% (n=100)
BufferReadWriter_WriteAt/presized_10_shards-96                                                                    30.00 ± 3%                                             24.00 ± 0%  -20.00% (n=100)
BufferReadWriter_WriteAt/half_presized_1_shards-96                                                                7.000 ± 0%                                             6.000 ± 0%  -14.29% (n=100)
BufferReadWriter_WriteAt/half_presized_4_shards-96                                                                15.00 ± 0%                                             13.00 ± 0%  -13.33% (n=100)
BufferReadWriter_WriteAt/half_presized_10_shards-96                                                               34.00 ± 0%                                             29.00 ± 3%  -14.71% (n=100)
BufferReadWriter_WriteAt/dynamic_1_shards-96                                                                      6.000 ± 0%                                             5.000 ± 0%  -16.67% (n=100)
BufferReadWriter_WriteAt/dynamic_4_shards-96                                                                      13.00 ± 0%                                             11.00 ± 0%  -15.38% (n=100)
BufferReadWriter_WriteAt/dynamic_10_shards-96                                                                     27.00 ± 4%                                             25.00 ± 4%   -7.41% (n=100)
geomean                                                                                                           13.87                                                  11.70       -15.63%

```