### PR TITLE
fix(build-index): fix blob dependency resolver for multi-arch manifests

### DIFF
--- a/build-index/tagtype/docker_resolver.go
+++ b/build-index/tagtype/docker_resolver.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/origin/blobclient"
@@ -33,15 +34,16 @@ type dockerResolver struct {
 	backoffConfig httputil.ExponentialBackOffConfig
 }
 
-// Resolve returns all layers + manifest of given tag as its dependencies.
+// Resolve returns all blob digests the manifest at d depends on, including d itself.
+// For manifest lists, each sub-manifest is resolved recursively.
 func (r *dockerResolver) Resolve(tag string, d core.Digest) (core.DigestList, error) {
 	m, err := r.downloadManifest(tag, d)
 	if err != nil {
 		return nil, fmt.Errorf("download manifest: %w", err)
 	}
-	deps, err := dockerutil.GetManifestReferences(m)
+	deps, err := r.resolveDeps(tag, m)
 	if err != nil {
-		return nil, fmt.Errorf("get manifest references: %w", err)
+		return nil, err
 	}
 	return append(deps, d), nil
 }
@@ -80,4 +82,35 @@ func (r *dockerResolver) downloadManifest(tag string, d core.Digest) (distributi
 		return nil, fmt.Errorf("parse manifest: %w", err)
 	}
 	return manifest, nil
+}
+
+func (r *dockerResolver) resolveDeps(tag string, m distribution.Manifest) (core.DigestList, error) {
+	ml, ok := m.(*manifestlist.DeserializedManifestList)
+	if !ok {
+		refs, err := dockerutil.GetManifestReferences(m)
+		if err != nil {
+			return nil, fmt.Errorf("get manifest references: %w", err)
+		}
+		return refs, nil
+	}
+
+	subDigests, err := dockerutil.GetManifestReferences(ml)
+	if err != nil {
+		return nil, fmt.Errorf("get manifest list references: %w", err)
+	}
+
+	var deps core.DigestList
+	for _, subDigest := range subDigests {
+		subManifest, err := r.downloadManifest(tag, subDigest)
+		if err != nil {
+			return nil, fmt.Errorf("download sub-manifest: %w", err)
+		}
+		subRefs, err := dockerutil.GetManifestReferences(subManifest)
+		if err != nil {
+			return nil, fmt.Errorf("get sub-manifest references: %w", err)
+		}
+		deps = append(deps, subDigest)
+		deps = append(deps, subRefs...)
+	}
+	return deps, nil
 }

--- a/build-index/tagtype/docker_resolver_test.go
+++ b/build-index/tagtype/docker_resolver_test.go
@@ -241,3 +241,55 @@ func TestDockerResolver_Resolve_WithRetries(t *testing.T) {
 	require.NotNil(deps)
 	require.Equal(core.DigestList(append(layers, manifest)), deps)
 }
+
+func TestDockerResolver_Resolve_ManifestList(t *testing.T) {
+	require, _, resolver, mockOrigin := setupDockerResolverTest(t)
+
+	tag := "repo/image:v1.0"
+
+	m1Layers := core.DigestListFixture(3)
+	m2Layers := core.DigestListFixture(3)
+	m1Digest, m1Bytes := dockerutil.ManifestFixture(m1Layers[0], m1Layers[1], m1Layers[2])
+	m2Digest, m2Bytes := dockerutil.ManifestFixture(m2Layers[0], m2Layers[1], m2Layers[2])
+	mlDigest, mlBytes := dockerutil.ManifestListFixture(m1Digest, m2Digest)
+
+	gomock.InOrder(
+		mockOrigin.EXPECT().DownloadBlob(gomock.Any(), tag, mlDigest, mockutil.MatchWriter(mlBytes)).Return(nil),
+		mockOrigin.EXPECT().DownloadBlob(gomock.Any(), tag, m1Digest, mockutil.MatchWriter(m1Bytes)).Return(nil),
+		mockOrigin.EXPECT().DownloadBlob(gomock.Any(), tag, m2Digest, mockutil.MatchWriter(m2Bytes)).Return(nil),
+	)
+
+	deps, err := resolver.Resolve(tag, mlDigest)
+	require.NoError(err)
+
+	var wantDeps core.DigestList
+	wantDeps = append(wantDeps, m1Digest)
+	wantDeps = append(wantDeps, m1Layers...)
+	wantDeps = append(wantDeps, m2Digest)
+	wantDeps = append(wantDeps, m2Layers...)
+	wantDeps = append(wantDeps, mlDigest)
+	require.Equal(wantDeps, deps)
+}
+
+func TestDockerResolver_Resolve_ManifestList_SubManifestDownloadError(t *testing.T) {
+	require, _, resolver, mockOrigin := setupDockerResolverTest(t)
+
+	tag := "repo/image:v1.0"
+
+	m1Digest, _ := dockerutil.ManifestFixture(core.DigestFixture(), core.DigestFixture(), core.DigestFixture())
+	mlDigest, mlBytes := dockerutil.ManifestListFixture(m1Digest, core.DigestFixture())
+
+	gomock.InOrder(
+		mockOrigin.EXPECT().
+			DownloadBlob(gomock.Any(), tag, mlDigest, mockutil.MatchWriter(mlBytes)).
+			Return(nil),
+		// sub-manifest download exhausts all retries (MaxRetries=3, so 4 total calls)
+		mockOrigin.EXPECT().
+			DownloadBlob(gomock.Any(), tag, m1Digest, gomock.Any()).
+			Return(blobclient.ErrBlobNotFound).
+			Times(4),
+	)
+
+	_, err := resolver.Resolve(tag, mlDigest)
+	require.ErrorContains(err, "download sub-manifest")
+}

--- a/utils/dockerutil/fixtures.go
+++ b/utils/dockerutil/fixtures.go
@@ -50,3 +50,37 @@ func ManifestFixture(config core.Digest, layer1 core.Digest, layer2 core.Digest)
 
 	return d, raw
 }
+
+// ManifestListFixture creates a manifest list blob for testing purposes.
+func ManifestListFixture(manifest1 core.Digest, manifest2 core.Digest) (core.Digest, []byte) {
+	raw := []byte(fmt.Sprintf(`{
+		"schemaVersion": 2,
+		"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+		"manifests": [
+			{
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"size": 1024,
+				"digest": "%s",
+				"platform": {
+					"architecture": "amd64",
+					"os": "linux"
+				}
+			},
+			{
+				"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+				"size": 1024,
+				"digest": "%s",
+				"platform": {
+					"architecture": "arm64",
+					"os": "linux"
+				}
+			}
+		]
+	}`, manifest1, manifest2))
+
+	d, err := core.NewDigester().FromBytes(raw)
+	if err != nil {
+		panic(err)
+	}
+	return d, raw
+}


### PR DESCRIPTION
The dependency resolver of the build-index assumes that the image is single-arch, meaning that for multi-arch images, its nested dependencies are not considered.

This PR fixes https://github.com/uber/kraken/issues/619 by also considering nested dependencies when the given manifest is a manifest list.

The changes have been validated by unit tests.