### PR TITLE
ci: declare contents:read on Build and Test workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,6 +10,9 @@ on:
 env:
   GO_VERSION: '1.24'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
build-and-test.yaml is the only Kraken workflow that doesn't declare a `permissions:` block. labeler.yml ties its own scopes down inside the job, and vulnerability-check.yaml declares `contents: read` + `security-events: write` per job.

This patch adds `permissions: contents: read` at workflow scope. All four jobs (lint, build, unit_tests, integration_tests) only call `actions/checkout`, `actions/setup-go`, golangci-lint, `go test`, and Make targets, so `contents: read` is enough. Several third-party actions are pulled in (`golangci/golangci-lint-action`, `docker/setup-docker-action`), which is the case worth narrowing the token for.

No behavioural change. The change is one block in one file.