### PR TITLE
feat(nginx): add config to update the backlog of nginx

### DIFF
--- a/nginx/config/agent.go
+++ b/nginx/config/agent.go
@@ -25,7 +25,7 @@ upstream agent-server {
 }
 
 server {
-  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}}{{if .listen_backlog}} backlog={{.listen_backlog}}{{end}};
 
   {{range .allowed_cidrs}}
     allow {{.}};

--- a/nginx/config/build-index.go
+++ b/nginx/config/build-index.go
@@ -24,7 +24,7 @@ upstream build-index {
 }
 
 server {
-  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}}{{if .listen_backlog}} backlog={{.listen_backlog}}{{end}};
 
   {{.client_verification}}
 

--- a/nginx/config/origin.go
+++ b/nginx/config/origin.go
@@ -16,7 +16,7 @@ package config
 // OriginTemplate is the default origin nginx tmpl.
 const OriginTemplate = `
 server {
-  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}}{{if .listen_backlog}} backlog={{.listen_backlog}}{{end}};
 
   {{.client_verification}}
 

--- a/nginx/config/proxy.go
+++ b/nginx/config/proxy.go
@@ -29,7 +29,7 @@ upstream proxy-server {
 
 {{range .ports}}
 server {
-  listen {{.}}{{if $.ssl_enabled}} ssl{{end}};
+  listen {{.}}{{if $.ssl_enabled}} ssl{{end}}{{if $.listen_backlog}} backlog={{$.listen_backlog}}{{end}};
 
   {{$.client_verification}}
 

--- a/nginx/config/tracker.go
+++ b/nginx/config/tracker.go
@@ -22,7 +22,7 @@ upstream tracker {
 }
 
 server {
-  listen {{.port}}{{if .ssl_enabled}} ssl{{end}};
+  listen {{.port}}{{if .ssl_enabled}} ssl{{end}}{{if .listen_backlog}} backlog={{.listen_backlog}}{{end}};
 
   {{.client_verification}}
 

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -59,6 +59,10 @@ type Config struct {
 	// ProxyTimeout defines the proxy_read_timeout for nginx (e.g. "15m", "3m", "60s")
 	ProxyTimeout string `yaml:"proxy_timeout"`
 
+	// ListenBacklog sets the backlog parameter on nginx listen directives.
+	// Zero means use nginx's default.
+	ListenBacklog int `yaml:"listen_backlog"`
+
 	tls httputil.TLSConfig
 }
 
@@ -83,6 +87,9 @@ func (c *Config) applyDefaults() error {
 			return errors.New("one of log_dir or error_log_path must be set")
 		}
 		c.ErrorLogPath = filepath.Join(c.LogDir, "nginx-error.log")
+	}
+	if c.ListenBacklog < 0 {
+		return errors.New("listen_backlog must be non-negative")
 	}
 	return nil
 }
@@ -121,12 +128,15 @@ func (c *Config) Build(params map[string]interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get template: %s", err)
 	}
+	// Add config-level defaults to params for site template.
 	if _, ok := params["client_verification"]; !ok {
 		params["client_verification"] = config.DefaultClientVerification
 	}
-	// Add proxy_read_timeout to params for site template
 	if _, ok := params["proxy_read_timeout"]; !ok {
 		params["proxy_read_timeout"] = c.ProxyTimeout
+	}
+	if _, ok := params["listen_backlog"]; !ok {
+		params["listen_backlog"] = c.ListenBacklog
 	}
 	if _, ok := params["ssl_enabled"]; !ok {
 		params["ssl_enabled"] = !c.tls.Server.Disabled


### PR DESCRIPTION
# What?
Add a configurable backlog value for nginx for all kraken services

# Why?
Although the max value of the accept queue in the host is 
```
cat /proc/sys/net/core/somaxconn
4096
```
The actual value still [defaults](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen:~:text=more%20than%20once.-,backlog,-%3Dnumber) to the accept queue limit from nginx (511) since 
$$\text{Send-Q} = \min(\text{Application Backlog}, \text{somaxconn})$$
```
ss -lnt
State             Recv-Q            Send-Q                        Local Address:Port                          Peer Address:Port            Process
LISTEN            0                 511                                 0.0.0.0:8351                               0.0.0.0:*
LISTEN            0                 511                                 0.0.0.0:9003                               0.0.0.0:*
```
This has caused listen drops on the hosts during sudden load (such as prefetching).
This change aims to add a config option to set this limit. If config is not defined, the current defaults are used for backward compatibility.
