### PR TITLE
fix: preserve nested repository paths in proxy prefetch

### DIFF
--- a/proxy/proxyserver/prefetch.go
+++ b/proxy/proxyserver/prefetch.go
@@ -82,7 +82,7 @@ type DefaultTagParser struct{}
 // ParseTag implements the TagParser interface.
 // Expects tag strings in the format <hostname>/<namespace>/<imagename:tag>.
 func (p *DefaultTagParser) ParseTag(tag string) (namespace, name string, err error) {
-	parts := strings.Split(tag, "/")
+	parts := strings.SplitN(tag, "/", 3)
 	if len(parts) < 3 {
 		return "", "", fmt.Errorf("invalid tag format: %s", tag)
 	}

--- a/proxy/proxyserver/server_test.go
+++ b/proxy/proxyserver/server_test.go
@@ -216,6 +216,39 @@ func TestPrefetchV1(t *testing.T) {
 	require.NoError(err)
 }
 
+func TestPrefetchV1NestedRepositoryPath(t *testing.T) {
+	require := require.New(t)
+
+	mocks, cleanup := newServerMocks(t)
+	defer cleanup()
+
+	addr := mocks.startServer()
+
+	repo := "kraken-test"
+	namespace := "preheat"
+	tag := "team/service/abcdef:v1.0.0"
+
+	layers := core.DigestListFixture(3)
+	manifest, bs := dockerutil.ManifestFixture(layers[0], layers[1], layers[2])
+
+	b, err := json.Marshal(prefetchBody{
+		Tag:     fmt.Sprintf("%s/%s/%s", repo, namespace, tag),
+		TraceId: "abc",
+	})
+	require.NoError(err)
+
+	tagRequest := url.QueryEscape(fmt.Sprintf("%s/%s", namespace, tag))
+	mocks.tagClient.EXPECT().Get(tagRequest).Return(manifest, nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, manifest, mockutil.MatchWriter(bs)).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, layers[1], io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, layers[2], io.Discard).Return(nil)
+
+	_, err = httputil.Post(
+		fmt.Sprintf("http://%s/proxy/v1/registry/prefetch", addr),
+		httputil.SendBody(bytes.NewReader(b)))
+	require.NoError(err)
+}
+
 func TestPrefetchV2(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
Fixes proxy prefetch for valid image refs with nested repo paths, like `ghcr.io/acme/preheat/team/service:v1`

What was up:
`DefaultTagParser` split on every `/` and only kept chunks 2 and 3, so `registry/preheat/team/service:v1` got turned into `preheat/team`. Build-index lookup then misses, kinda sneaky

Repro:
1. Call `POST /proxy/v1/registry/prefetch` with `{"tag":"registry/preheat/team/service:v1"}`
2. Proxy asks build-index for `preheat/team`
3. Prefetch fails, even though the image ref is valid

Fix:
Use `strings.SplitN(tag, "/", 3)` so the full repo tail stays intact

Checks:
- `go test ./proxy/...`
- `go test ./proxy/proxyserver -run TestPrefetchV1NestedRepositoryPath -count=10`
- `golangci-lint run ./proxy/proxyserver/...`