### PR TITLE
feat(proxy): add support for oci manifest images

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -68,19 +68,23 @@ jobs:
           CGO_CFLAGS: "-Wno-return-local-addr"
 
   integration_tests:
+    name: integration tests (snapshotter ${{ matrix.snapshotter && 'enabled' || 'disabled' }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run with and without the containerd snapshotter to cover both OCI and
+        # Docker v2 manifest formats.
+        snapshotter: [true, false]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-docker-action@v4
         with:
           version: latest
-          # Disable containerd snapshotter which defaults to using OCI manifests,
-          # which are currently not supported by Kraken.
-          # TODO(thijmv): Remove this override once OCI manifests are supported.
           daemon-config: |
             {
               "features": {
-                "containerd-snapshotter": false
+                "containerd-snapshotter": ${{ matrix.snapshotter }}
               }
             }
       - uses: actions/setup-python@v5

--- a/build-index/tagstore/store.go
+++ b/build-index/tagstore/store.go
@@ -182,12 +182,17 @@ func (s *tagStore) resolveFromBackend(tag string) (core.Digest, error) {
 	}
 	var b bytes.Buffer
 	if err := backendClient.Download(tag, tag, &b); err != nil {
-		if err == backenderrors.ErrBlobNotFound {
+		if errors.Is(err, backenderrors.ErrBlobNotFound) {
 			log.With("tag", tag).Debug("Tag not found in backend")
-			return core.Digest{}, ErrTagNotFound
+		} else {
+			// Kraken is expected to accept image pushes even when remote storage is
+			// down by storing the blob on disk and flushing it to the remote storage
+			// once it becomes available again. When we experience a backend error,
+			// we return 404, instead of 500, as the latter would abort Docker pushes
+			// that HEAD before PUT (e.g. containerd snapshotter).
+			log.With("tag", tag, "error", err).Error("Failed to download tag from backend")
 		}
-		log.With("tag", tag).Errorf("Failed to download tag from backend: %s", err)
-		return core.Digest{}, fmt.Errorf("backend client: %s", err)
+		return core.Digest{}, ErrTagNotFound
 	}
 	d, err := core.ParseSHA256Digest(b.String())
 	if err != nil {

--- a/build-index/tagstore/store_test.go
+++ b/build-index/tagstore/store_test.go
@@ -143,7 +143,7 @@ func TestGetFromBackendUnkownError(t *testing.T) {
 	mocks.backendClient.EXPECT().Download(tag, tag, w).Return(fmt.Errorf("test error"))
 
 	_, err := store.Get(tag)
-	require.Error(err)
+	require.Equal(ErrTagNotFound, err)
 }
 
 func TestGetFromBackendInvalidValue(t *testing.T) {

--- a/nginx/config/build-index.go
+++ b/nginx/config/build-index.go
@@ -47,7 +47,6 @@ server {
     proxy_cache         tags;
     proxy_cache_methods GET;
     proxy_cache_valid   200 5m;
-    proxy_cache_valid   any 1s;
     proxy_cache_lock    on;
 
     proxy_read_timeout {{if .proxy_read_timeout}}{{.proxy_read_timeout}}{{else}}3m{{end}};

--- a/proxy/proxyserver/prefetch.go
+++ b/proxy/proxyserver/prefetch.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
-	"github.com/docker/distribution/manifest/schema2"
 	"github.com/uber-go/tally"
 	"github.com/uber/kraken/build-index/tagclient"
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/origin/blobclient"
+	"github.com/uber/kraken/utils/dockerutil"
 	"github.com/uber/kraken/utils/httputil"
 	"github.com/uber/kraken/utils/log"
 	"go.uber.org/zap"
@@ -326,59 +326,55 @@ func (ph *PrefetchHandler) shouldSkipPrefetch(b blobInfo, logger *zap.SugaredLog
 	return false
 }
 
-// processManifest handles both ManifestLists and single Manifests.
+// processManifest parses the manifest and returns all blob infos, including
+// the manifest blob itself.
 func (ph *PrefetchHandler) processManifest(logger *zap.SugaredLogger, namespace string, manifestBytes []byte) ([]blobInfo, error) {
-	// Attempt to process as a manifest list.
-	blobs, err := ph.tryProcessManifestList(logger, namespace, manifestBytes)
-	if err == nil && len(blobs) > 0 {
-		return blobs, nil
+	manifest, digest, err := dockerutil.ParseManifest(bytes.NewReader(manifestBytes))
+	if err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
 	}
-
-	// Fallback to single manifest.
-	var manifest schema2.Manifest
-	if err := json.NewDecoder(bytes.NewReader(manifestBytes)).Decode(&manifest); err != nil {
-		logger.With("namespace", namespace).Errorf("Failed to parse single manifest: %v", err)
-		return nil, fmt.Errorf("invalid single manifest: %w", err)
+	self := blobInfo{digest: digest, size: int64(len(manifestBytes))}
+	blobs, err := ph.getBlobInfos(logger, namespace, manifest)
+	if err != nil {
+		return nil, err
 	}
-	return ph.processLayers(manifest.Layers)
+	return append([]blobInfo{self}, blobs...), nil
 }
 
-// tryProcessManifestList attempts to decode a manifest list.
-func (ph *PrefetchHandler) tryProcessManifestList(logger *zap.SugaredLogger, namespace string, manifestBytes []byte) ([]blobInfo, error) {
-	var manifestList manifestlist.ManifestList
-	if err := json.NewDecoder(bytes.NewReader(manifestBytes)).Decode(&manifestList); err != nil || len(manifestList.Manifests) == 0 {
-		return nil, fmt.Errorf("not a valid manifest list")
+// getBlobInfos returns all blob infos for a manifest. For manifest lists and
+// OCI indexes, it also descends one level to collect sub-manifest blob infos.
+func (ph *PrefetchHandler) getBlobInfos(logger *zap.SugaredLogger, namespace string, manifest distribution.Manifest) ([]blobInfo, error) {
+	ml, ok := manifest.(*manifestlist.DeserializedManifestList)
+	if !ok {
+		return ph.processLayers(manifest.References())
 	}
-	logger.With("namespace", namespace).Info("Processing manifest list")
-	return ph.processManifestList(logger, namespace, manifestList)
-}
 
-// processManifestList processes a manifest list.
-func (ph *PrefetchHandler) processManifestList(logger *zap.SugaredLogger, namespace string, manifestList manifestlist.ManifestList) ([]blobInfo, error) {
 	var allBlobs []blobInfo
-	for _, descriptor := range manifestList.Manifests {
-		manifestDigestHex := descriptor.Digest.Hex()
-		digest, err := core.NewSHA256DigestFromHex(manifestDigestHex)
+	for _, subDesc := range ml.Manifests {
+		subDigest, err := core.NewSHA256DigestFromHex(subDesc.Digest.Hex())
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse manifest digest %s: %w", manifestDigestHex, err)
+			return nil, fmt.Errorf("parse sub-manifest digest: %w", err)
 		}
+
 		buf := &bytes.Buffer{}
 		startTime := time.Now()
-		if err := ph.clusterClient.DownloadBlob(context.Background(), namespace, digest, buf); err != nil {
+		if err := ph.clusterClient.DownloadBlob(context.Background(), namespace, subDigest, buf); err != nil {
 			ph.metrics.Counter("download_manifest_error").Inc(1)
-			logger.With("error", err).Error("Failed to download manifest blob")
-			continue
+			logger.With("error", err).Error("Failed to download sub-manifest blob")
+			return nil, fmt.Errorf("download sub-manifest %s: %w", subDigest, err)
 		}
 		ph.getManifestLatency.RecordDuration(time.Since(startTime))
-		var manifest schema2.Manifest
-		if err := json.NewDecoder(buf).Decode(&manifest); err != nil {
-			return nil, fmt.Errorf("failed to parse manifest: %w", err)
-		}
-		blobs, err := ph.processLayers(manifest.Layers)
+
+		subManifest, _, err := dockerutil.ParseManifest(buf)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse sub-manifest %s: %w", subDigest, err)
 		}
-		allBlobs = append(allBlobs, blobs...)
+		subBlobs, err := ph.processLayers(subManifest.References())
+		if err != nil {
+			return nil, fmt.Errorf("get blob infos for sub-manifest %s: %w", subDigest, err)
+		}
+		allBlobs = append(allBlobs, blobInfo{digest: subDigest, size: subDesc.Size})
+		allBlobs = append(allBlobs, subBlobs...)
 	}
 	return allBlobs, nil
 }

--- a/proxy/proxyserver/preheat.go
+++ b/proxy/proxyserver/preheat.go
@@ -32,7 +32,9 @@ import (
 	"github.com/uber/kraken/utils/log"
 )
 
-var _manifestRegexp = regexp.MustCompile(`^application/vnd.docker.distribution.manifest.v\d\+(json|prettyjws)`)
+var _manifestRegexp = regexp.MustCompile(
+	`^application/vnd\.(docker\.distribution\.manifest\.v\d\+(json|prettyjws)|oci\.image\.manifest\.v1\+json)`,
+)
 
 // PreheatHandler defines the handler of preheat.
 type PreheatHandler struct {

--- a/proxy/proxyserver/server_test.go
+++ b/proxy/proxyserver/server_test.go
@@ -208,8 +208,56 @@ func TestPrefetchV1(t *testing.T) {
 	tagRequest := url.QueryEscape(fmt.Sprintf("%s/%s", namespace, tag))
 	mocks.tagClient.EXPECT().Get(tagRequest).Return(manifest, nil)
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, manifest, mockutil.MatchWriter(bs)).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, manifest, io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, layers[0], io.Discard).Return(nil)
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, layers[1], io.Discard).Return(nil)
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, layers[2], io.Discard).Return(nil)
+	_, err = httputil.Post(
+		fmt.Sprintf("http://%s/proxy/v1/registry/prefetch", addr),
+		httputil.SendBody(bytes.NewReader(b)))
+	require.NoError(err)
+}
+
+func TestPrefetchV1WithManifestList(t *testing.T) {
+	require := require.New(t)
+
+	mocks, cleanup := newServerMocks(t)
+	defer cleanup()
+
+	addr := mocks.startServer()
+
+	repo := "kraken-test"
+	namespace := "preheat"
+	tag := "abcdef:v1.0.0"
+
+	m1Refs := core.DigestListFixture(3)
+	m2Refs := core.DigestListFixture(3)
+	m1Digest, m1Bytes := dockerutil.ManifestFixture(m1Refs[0], m1Refs[1], m1Refs[2])
+	m2Digest, m2Bytes := dockerutil.ManifestFixture(m2Refs[0], m2Refs[1], m2Refs[2])
+	mlDigest, mlBytes := dockerutil.ManifestListFixture(m1Digest, m2Digest)
+
+	b, err := json.Marshal(prefetchBody{
+		Tag:     fmt.Sprintf("%s/%s/%s", repo, namespace, tag),
+		TraceId: "abc",
+	})
+	require.NoError(err)
+
+	tagRequest := url.QueryEscape(fmt.Sprintf("%s/%s", namespace, tag))
+	mocks.tagClient.EXPECT().Get(tagRequest).Return(mlDigest, nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, mlDigest, mockutil.MatchWriter(mlBytes)).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m1Digest, mockutil.MatchWriter(m1Bytes)).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m2Digest, mockutil.MatchWriter(m2Bytes)).Return(nil)
+
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, mlDigest, io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m1Digest, io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m2Digest, io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m1Refs[0], io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m1Refs[1], io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m1Refs[2], io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m2Refs[0], io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m2Refs[1], io.Discard).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m2Refs[2], io.Discard).Return(nil)
+
 	_, err = httputil.Post(
 		fmt.Sprintf("http://%s/proxy/v1/registry/prefetch", addr),
 		httputil.SendBody(bytes.NewReader(b)))
@@ -241,8 +289,70 @@ func TestPrefetchV2(t *testing.T) {
 	mocks.tagClient.EXPECT().Get(tagRequest).Return(manifest, nil)
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, manifest, mockutil.MatchWriter(bs)).Return(nil)
 
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, manifest).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[0]).Return(nil)
 	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[1]).Return(nil)
 	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[2]).Return(nil)
+	res, err := httputil.Post(
+		fmt.Sprintf("http://%s/proxy/v2/registry/prefetch", addr),
+		httputil.SendBody(bytes.NewReader(b)))
+	require.NoError(err)
+
+	var resBody prefetchResponse
+	resBodyBytes, err := io.ReadAll(res.Body)
+	require.NoError(err)
+	err = json.Unmarshal(resBodyBytes, &resBody)
+	require.NoError(err)
+
+	require.Equal(prefetchResponse{
+		Message:    "prefetching initiated successfully",
+		TraceId:    "abc",
+		Status:     "success",
+		Tag:        "abcdef:v1.0.0",
+		Prefetched: true,
+	}, resBody)
+}
+
+func TestPrefetchV2WithOCIIndex(t *testing.T) {
+	require := require.New(t)
+
+	mocks, cleanup := newServerMocks(t)
+	defer cleanup()
+
+	addr := mocks.startServer()
+
+	repo := "kraken-test"
+	namespace := "preheat"
+	tag := "abcdef:v1.0.0"
+
+	m1Refs := core.DigestListFixture(3)
+	m2Refs := core.DigestListFixture(3)
+	m1Digest, m1Bytes := dockerutil.OCIManifestFixture(m1Refs[0], m1Refs[1], m1Refs[2])
+	m2Digest, m2Bytes := dockerutil.OCIManifestFixture(m2Refs[0], m2Refs[1], m2Refs[2])
+	mlDigest, mlBytes := dockerutil.OCIIndexFixture(m1Digest, m2Digest)
+
+	b, err := json.Marshal(prefetchBody{
+		Tag:     fmt.Sprintf("%s/%s/%s", repo, namespace, tag),
+		TraceId: "abc",
+	})
+	require.NoError(err)
+
+	tagRequest := url.QueryEscape(fmt.Sprintf("%s/%s", namespace, tag))
+	mocks.tagClient.EXPECT().Get(tagRequest).Return(mlDigest, nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, mlDigest, mockutil.MatchWriter(mlBytes)).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m1Digest, mockutil.MatchWriter(m1Bytes)).Return(nil)
+	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, m2Digest, mockutil.MatchWriter(m2Bytes)).Return(nil)
+
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, mlDigest).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m1Digest).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m2Digest).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m1Refs[0]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m1Refs[1]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m1Refs[2]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m2Refs[0]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m2Refs[1]).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, m2Refs[2]).Return(nil)
+
 	res, err := httputil.Post(
 		fmt.Sprintf("http://%s/proxy/v2/registry/prefetch", addr),
 		httputil.SendBody(bytes.NewReader(b)))
@@ -288,6 +398,8 @@ func TestPrefetchV2OriginError(t *testing.T) {
 	mocks.tagClient.EXPECT().Get(tagRequest).Return(manifest, nil)
 	mocks.originClient.EXPECT().DownloadBlob(gomock.Any(), namespace, manifest, mockutil.MatchWriter(bs)).Return(nil)
 
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, manifest).Return(nil)
+	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[0]).Return(nil)
 	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[1]).Return(errors.New("foo err"))
 	mocks.originClient.EXPECT().PrefetchBlob(namespace, layers[2]).Return(nil)
 	_, err = httputil.Post(

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -48,7 +48,7 @@ def _setup_test_image(name):
     return new_name
 
 
-TEST_IMAGE = _setup_test_image('alpine:latest') # todo: switch to latest after supporting oci format manifests
+TEST_IMAGE = _setup_test_image('alpine:latest')
 TEST_IMAGE_2 = _setup_test_image('redis:latest')
 
 

--- a/tools/bin/puller/pull.go
+++ b/tools/bin/puller/pull.go
@@ -25,10 +25,11 @@ import (
 	"time"
 
 	"github.com/docker/distribution"
-	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/uber/kraken/utils/closers"
+	"github.com/uber/kraken/utils/dockerutil"
 	"github.com/uber/kraken/utils/errutil"
 	"github.com/uber/kraken/utils/log"
 )
@@ -63,19 +64,14 @@ func PullImage(source, repo, tag string, useDocker bool) error {
 		return fmt.Errorf("failed to pull manifest %s:%s: %s", repo, tag, err)
 	}
 
-	layerDigests, err := getLayerDigestsFromManifest(&manifest)
-	if err != nil {
-		return fmt.Errorf("failed to get layer digests from manifest: %s", err)
-	}
-
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errs errutil.MultiError
-	for _, d := range layerDigests {
+	for _, desc := range manifest.References() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			err := pullLayer(http.Client{Timeout: transferTimeout}, source, repo, d)
+			err := pullLayer(http.Client{Timeout: transferTimeout}, source, repo, desc.Digest.String())
 			if err != nil {
 				mu.Lock()
 				defer mu.Unlock()
@@ -100,8 +96,9 @@ func pullManifest(client http.Client, source string, name string, reference stri
 	if err != nil {
 		return nil, err
 	}
-	// Add `Accept` header to indicate schema2 is supported
+	// Accept single-arch manifests only; the puller does not support multi-arch images.
 	req.Header.Add("Accept", schema2.MediaTypeManifest)
+	req.Header.Add("Accept", v1.MediaTypeImageManifest)
 	resp, err := client.Do(req)
 
 	if err != nil {
@@ -117,53 +114,8 @@ func pullManifest(client http.Client, source string, name string, reference stri
 		return nil, fmt.Errorf("server returned %v", resp.Status)
 	}
 
-	version := resp.Header.Get("Content-Type")
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	manifest, _, err := distribution.UnmarshalManifest(version, body)
-	if err != nil {
-		return nil, err
-	}
-
-	return manifest, nil
-}
-
-func getLayerDigestsFromManifest(manifest *distribution.Manifest) ([]string, error) {
-	var digests []string
-	// Get layers from manifest
-	switch (*manifest).(type) {
-	case *schema1.SignedManifest:
-		signedManifest, ok := (*manifest).(*schema1.SignedManifest)
-		if !ok {
-			return nil, fmt.Errorf("failed to cast to SignedManifest")
-		}
-		fsLayers := signedManifest.FSLayers
-		for _, fsLayer := range fsLayers {
-			digests = append(digests, fsLayer.BlobSum.String())
-		}
-	case *schema2.DeserializedManifest:
-		deserializedManifest, ok := (*manifest).(*schema2.DeserializedManifest)
-		if !ok {
-			return nil, fmt.Errorf("failed to cast to DeserializedManifest")
-		}
-		layerDescriptors := deserializedManifest.Layers
-		for _, descriptor := range layerDescriptors {
-			digests = append(digests, descriptor.Digest.String())
-		}
-		// for schema2, we also need a config layer
-		config := deserializedManifest.Config
-		digests = append(digests, config.Digest.String())
-	default:
-		mt, _, err := (*manifest).Payload()
-		if err == nil {
-			err = fmt.Errorf("manifest type %s is not supported", mt)
-		}
-		return nil, err
-	}
-
-	return digests, nil
+	manifest, _, err := dockerutil.ParseManifest(resp.Body)
+	return manifest, err
 }
 
 func pullLayer(client http.Client, source, name string, layerDigest string) error {

--- a/utils/dockerutil/dockerutil.go
+++ b/utils/dockerutil/dockerutil.go
@@ -14,79 +14,68 @@
 package dockerutil
 
 import (
-	"errors"
+	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
+	_ "github.com/docker/distribution/manifest/ocischema"
 	"github.com/docker/distribution/manifest/schema2"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/uber/kraken/core"
 )
 
-const (
-	_v2ManifestType     = "application/vnd.docker.distribution.manifest.v2+json"
-	_v2ManifestListType = "application/vnd.docker.distribution.manifest.list.v2+json"
-)
+type manifestPeek struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	Manifests     []json.RawMessage `json:"manifests"`
+}
 
 func ParseManifest(r io.Reader) (distribution.Manifest, core.Digest, error) {
 	b, err := io.ReadAll(r)
 	if err != nil {
-		return nil, core.Digest{}, fmt.Errorf("read: %s", err)
+		return nil, core.Digest{}, fmt.Errorf("read manifest: %w", err)
 	}
 
-	manifest, d, err := ParseManifestV2(b)
-	if err == nil {
-		return manifest, d, err
+	var p manifestPeek
+	if err := json.Unmarshal(b, &p); err != nil {
+		return nil, core.Digest{}, fmt.Errorf("peek manifest: %w", err)
+	}
+	if p.SchemaVersion != 2 {
+		return nil, core.Digest{}, fmt.Errorf("unsupported schema version: %d", p.SchemaVersion)
+	}
+	// OCI manifests may omit their mediatype. Use the "manifests" field
+	// to differentiate between an OCI manifest and an OCI index.
+	if p.MediaType == "" {
+		if len(p.Manifests) > 0 {
+			p.MediaType = v1.MediaTypeImageIndex
+		} else {
+			p.MediaType = v1.MediaTypeImageManifest
+		}
 	}
 
-	// Retry with v2 manifest list.
-	return ParseManifestV2List(b)
+	switch p.MediaType {
+	case schema2.MediaTypeManifest, manifestlist.MediaTypeManifestList, v1.MediaTypeImageManifest, v1.MediaTypeImageIndex:
+		return unmarshalManifest(p.MediaType, b)
+	default:
+		return nil, core.Digest{}, fmt.Errorf("unknown manifest mediatype: %s", p.MediaType)
+	}
 }
 
-// ParseManifestV2 returns a parsed v2 manifest and its digest.
-func ParseManifestV2(bytes []byte) (distribution.Manifest, core.Digest, error) {
-	manifest, desc, err := distribution.UnmarshalManifest(schema2.MediaTypeManifest, bytes)
+func unmarshalManifest(mediaType string, b []byte) (distribution.Manifest, core.Digest, error) {
+	manifest, desc, err := distribution.UnmarshalManifest(mediaType, b)
 	if err != nil {
-		return nil, core.Digest{}, fmt.Errorf("unmarshal manifest: %s", err)
+		return nil, core.Digest{}, fmt.Errorf("unmarshal manifest: %w", err)
 	}
-	deserializedManifest, ok := manifest.(*schema2.DeserializedManifest)
-	if !ok {
-		return nil, core.Digest{}, errors.New("expected schema2.DeserializedManifest")
-	}
-	version := deserializedManifest.SchemaVersion
-	if version != 2 {
-		return nil, core.Digest{}, fmt.Errorf("unsupported manifest version: %d", version)
-	}
-	d, err := core.ParseSHA256Digest(string(desc.Digest))
+	digest, err := core.ParseSHA256Digest(string(desc.Digest))
 	if err != nil {
-		return nil, core.Digest{}, fmt.Errorf("parse digest: %s", err)
+		return nil, core.Digest{}, fmt.Errorf("parse digest: %w", err)
 	}
-	return manifest, d, nil
+	return manifest, digest, nil
 }
 
-// ParseManifestV2List returns a parsed v2 manifest list and its digest.
-func ParseManifestV2List(bytes []byte) (distribution.Manifest, core.Digest, error) {
-	manifestList, desc, err := distribution.UnmarshalManifest(manifestlist.MediaTypeManifestList, bytes)
-	if err != nil {
-		return nil, core.Digest{}, fmt.Errorf("unmarshal manifestlist: %s", err)
-	}
-	deserializedManifestList, ok := manifestList.(*manifestlist.DeserializedManifestList)
-	if !ok {
-		return nil, core.Digest{}, errors.New("expected manifestlist.DeserializedManifestList")
-	}
-	version := deserializedManifestList.SchemaVersion
-	if version != 2 {
-		return nil, core.Digest{}, fmt.Errorf("unsupported manifest list version: %d", version)
-	}
-	d, err := core.ParseSHA256Digest(string(desc.Digest))
-	if err != nil {
-		return nil, core.Digest{}, fmt.Errorf("parse digest: %s", err)
-	}
-	return manifestList, d, nil
-}
-
-// GetManifestReferences returns a list of references by a V2 manifest
+// GetManifestReferences returns a list of references by a manifest.
 func GetManifestReferences(manifest distribution.Manifest) ([]core.Digest, error) {
 	var refs []core.Digest
 	for _, desc := range manifest.References() {
@@ -100,5 +89,9 @@ func GetManifestReferences(manifest distribution.Manifest) ([]core.Digest, error
 }
 
 func GetSupportedManifestTypes() string {
-	return fmt.Sprintf("%s,%s", _v2ManifestType, _v2ManifestListType)
+	return fmt.Sprintf("%s,%s,%s,%s",
+		schema2.MediaTypeManifest,
+		manifestlist.MediaTypeManifestList,
+		v1.MediaTypeImageManifest,
+		v1.MediaTypeImageIndex)
 }

--- a/utils/dockerutil/dockerutil_test.go
+++ b/utils/dockerutil/dockerutil_test.go
@@ -1,90 +1,132 @@
 package dockerutil_test
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"testing"
+	"testing/iotest"
 
 	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema2"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
+
+	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/utils/dockerutil"
 )
 
-var testManifestListBytes = []byte(`{
-	"schemaVersion": 2,
-	"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-	"manifests": [
-	   {
-		  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-		  "size": 985,
-		  "digest": "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
-		  "platform": {
-			 "architecture": "amd64",
-			 "os": "linux",
-			 "features": [
-				"sse4"
-			 ]
-		  }
-	   },
-	   {
-		  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-		  "size": 2392,
-		  "digest": "sha256:6346340964309634683409684360934680934608934608934608934068934608",
-		  "platform": {
-			 "architecture": "sun4m",
-			 "os": "sunos"
-		  }
-	   }
-	]
- }`)
-
-var testManifestBytes = []byte(`{
-	"schemaVersion": 2,
-	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-	"config": {
-	   "mediaType": "application/vnd.docker.container.image.v1+json",
-	   "size": 985,
-	   "digest": "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
-	},
-	"layers": [
-	   {
-		  "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
-		  "size": 153263,
-		  "digest": "sha256:62d8908bee94c202b2d35224a221aaa2058318bfa9879fa541efaecba272331b"
-	   }
-	]
- }`)
-
-func TestParseManifestV2List(t *testing.T) {
-	require := require.New(t)
-
-	tests := []struct {
-		name          string
-		hasError      bool
-		manifestBytes []byte
+func TestParseManifest(t *testing.T) {
+	tests := map[string]struct {
+		fixture       func() (core.Digest, []byte)
+		wantErr       string
+		wantMediaType string
 	}{
-		{
-			name:          "success",
-			hasError:      false,
-			manifestBytes: testManifestListBytes,
+		"success with v2 manifest": {
+			fixture: func() (core.Digest, []byte) {
+				return dockerutil.ManifestFixture(core.DigestFixture(), core.DigestFixture(), core.DigestFixture())
+			},
+			wantMediaType: schema2.MediaTypeManifest,
 		},
-		{
-			name:          "wrong manifest type",
-			hasError:      true,
-			manifestBytes: testManifestBytes,
+		"success with v2 manifest list": {
+			fixture: func() (core.Digest, []byte) {
+				return dockerutil.ManifestListFixture(core.DigestFixture(), core.DigestFixture())
+			},
+			wantMediaType: manifestlist.MediaTypeManifestList,
+		},
+		"success with OCI manifest": {
+			fixture: func() (core.Digest, []byte) {
+				return dockerutil.OCIManifestFixture(core.DigestFixture(), core.DigestFixture(), core.DigestFixture())
+			},
+			wantMediaType: v1.MediaTypeImageManifest,
+		},
+		"success with OCI index": {
+			fixture: func() (core.Digest, []byte) {
+				return dockerutil.OCIIndexFixture(core.DigestFixture(), core.DigestFixture())
+			},
+			wantMediaType: v1.MediaTypeImageIndex,
+		},
+		"success with OCI manifest without mediaType": {
+			fixture: func() (core.Digest, []byte) {
+				raw := []byte(fmt.Sprintf(`{
+					"schemaVersion": 2,
+					"config": {"mediaType": "application/vnd.oci.image.config.v1+json", "size": 1, "digest": "%s"},
+					"layers": [
+						{"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "size": 1, "digest": "%s"},
+						{"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "size": 1, "digest": "%s"}
+					]
+				}`, core.DigestFixture(), core.DigestFixture(), core.DigestFixture()))
+				d, err := core.NewDigester().FromBytes(raw)
+				if err != nil {
+					panic(err)
+				}
+				return d, raw
+			},
+			wantMediaType: v1.MediaTypeImageManifest,
+		},
+		"success with OCI index without mediaType": {
+			fixture: func() (core.Digest, []byte) {
+				raw := []byte(fmt.Sprintf(`{
+					"schemaVersion": 2,
+					"manifests": [
+						{"mediaType": "application/vnd.oci.image.manifest.v1+json", "size": 1, "digest": "%s", "platform": {"architecture": "amd64", "os": "linux"}},
+						{"mediaType": "application/vnd.oci.image.manifest.v1+json", "size": 1, "digest": "%s", "platform": {"architecture": "arm64", "os": "linux"}}
+					]
+				}`, core.DigestFixture(), core.DigestFixture()))
+				d, err := core.NewDigester().FromBytes(raw)
+				if err != nil {
+					panic(err)
+				}
+				return d, raw
+			},
+			wantMediaType: v1.MediaTypeImageIndex,
+		},
+		"failure with invalid JSON": {
+			fixture: func() (core.Digest, []byte) { return core.Digest{}, []byte("not json") },
+			wantErr: "peek manifest",
+		},
+		"failure when manifest schema version is not 2": {
+			fixture: func() (core.Digest, []byte) {
+				return core.Digest{}, []byte(`{"schemaVersion":1,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}`)
+			},
+			wantErr: "unsupported schema version: 1",
+		},
+		"failure when manifest is malformed": {
+			fixture: func() (core.Digest, []byte) {
+				return core.Digest{}, []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","layers":"not-an-array"}`)
+			},
+			wantErr: "unmarshal manifest",
+		},
+		"failure with unknown mediatype": {
+			fixture: func() (core.Digest, []byte) {
+				return core.Digest{}, []byte(`{"schemaVersion":2,"mediaType":"application/unknown"}`)
+			},
+			wantErr: "unknown manifest mediatype: application/unknown",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			manifest, d, err := dockerutil.ParseManifestV2List(tt.manifestBytes)
-			if tt.hasError {
-				require.Error(err)
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixtureD, fixtureB := tt.fixture()
+			manifest, d, err := dockerutil.ParseManifest(bytes.NewReader(fixtureB))
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 
-			require.NoError(err)
-			mediaType, _, err := manifest.Payload()
-			require.NoError(err)
-			require.EqualValues(manifestlist.MediaTypeManifestList, mediaType)
-			require.Equal("sha256", d.Algo())
+			require.NoError(t, err)
+			mediaType, payload, err := manifest.Payload()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMediaType, mediaType)
+			require.Equal(t, fixtureB, payload)
+			require.Equal(t, fixtureD, d)
 		})
 	}
+}
+
+func TestParseManifest_ReaderError(t *testing.T) {
+	giveReader := iotest.ErrReader(errors.New("test error"))
+	_, _, err := dockerutil.ParseManifest(giveReader)
+	require.ErrorContains(t, err, "read manifest")
 }

--- a/utils/dockerutil/fixtures.go
+++ b/utils/dockerutil/fixtures.go
@@ -84,3 +84,68 @@ func ManifestListFixture(manifest1 core.Digest, manifest2 core.Digest) (core.Dig
 	}
 	return d, raw
 }
+
+// OCIManifestFixture creates an OCI image manifest blob for testing purposes.
+func OCIManifestFixture(config core.Digest, layer1 core.Digest, layer2 core.Digest) (core.Digest, []byte) {
+	raw := []byte(fmt.Sprintf(`{
+		"schemaVersion": 2,
+		"mediaType": "application/vnd.oci.image.manifest.v1+json",
+		"config": {
+			"mediaType": "application/vnd.oci.image.config.v1+json",
+			"size": 2940,
+			"digest": "%s"
+		},
+		"layers": [
+			{
+				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+				"size": 1902063,
+				"digest": "%s"
+			},
+			{
+				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+				"size": 2345077,
+				"digest": "%s"
+			}
+		]
+	}`, config, layer1, layer2))
+
+	d, err := core.NewDigester().FromBytes(raw)
+	if err != nil {
+		panic(err)
+	}
+	return d, raw
+}
+
+// OCIIndexFixture creates an OCI image index blob for testing purposes.
+func OCIIndexFixture(manifest1 core.Digest, manifest2 core.Digest) (core.Digest, []byte) {
+	raw := []byte(fmt.Sprintf(`{
+		"schemaVersion": 2,
+		"mediaType": "application/vnd.oci.image.index.v1+json",
+		"manifests": [
+			{
+				"mediaType": "application/vnd.oci.image.manifest.v1+json",
+				"size": 1024,
+				"digest": "%s",
+				"platform": {
+					"architecture": "amd64",
+					"os": "linux"
+				}
+			},
+			{
+				"mediaType": "application/vnd.oci.image.manifest.v1+json",
+				"size": 1024,
+				"digest": "%s",
+				"platform": {
+					"architecture": "arm64",
+					"os": "linux"
+				}
+			}
+		]
+	}`, manifest1, manifest2))
+
+	d, err := core.NewDigester().FromBytes(raw)
+	if err != nil {
+		panic(err)
+	}
+	return d, raw
+}


### PR DESCRIPTION
## Summary

This PR (1/3) adds OCI manifest support to Kraken. OCI manifests are the modern Docker standard and enable layer compression with additional algorithms (e.g. zstd), which may improve transfer and decompression times.

This PR makes the following changes:
- OCI parsing
  - Add parsing support for OCI manifests.
  - Peek at the media type of manifests, rather than trying each possible format.
- Prefetching
  - Fix dependency resolution for prefetching, which excluded (sub-)manifest and config blobs.
  - Return an error when sub-manifest blobs cannot be downloaded, instead of silently continuing with a partial dependency list.

Fixes #574.

## Stack
1. @ https://github.com/uber/kraken/pull/628
2. https://github.com/uber/kraken/pull/631
3. https://github.com/uber/kraken/pull/632