### PR TITLE
feat(proxy): Add metric for number of seeders per torrent

### DIFF
--- a/tracker/peerhandoutpolicy/completeness_policy_test.go
+++ b/tracker/peerhandoutpolicy/completeness_policy_test.go
@@ -26,7 +26,8 @@ import (
 func TestCompletenessPriorityPolicy(t *testing.T) {
 	require := require.New(t)
 
-	policy, err := NewPriorityPolicy(tally.NoopScope, _completenessPolicy)
+	testScope := tally.NewTestScope("", nil)
+	policy, err := NewPriorityPolicy(testScope, _completenessPolicy)
 	require.NoError(err)
 
 	seeders := 10
@@ -51,7 +52,7 @@ func TestCompletenessPriorityPolicy(t *testing.T) {
 		peers[i], peers[j] = peers[j], peers[i]
 	}
 
-	policy.SortPeers(core.PeerInfoFixture(), peers)
+	peers = policy.SortPeers(core.PeerInfoFixture(), peers)
 	require.Len(peers, seeders+origins+incomplete)
 	for k := 0; k < len(peers); k++ {
 		p := peers[k]
@@ -66,4 +67,23 @@ func TestCompletenessPriorityPolicy(t *testing.T) {
 			require.False(p.Origin)
 		}
 	}
+
+	histograms := testScope.Snapshot().Histograms()
+	tags := "module=peerhandoutpolicy,priority=completeness"
+
+	total, ok := histograms["total_seeders+"+tags]
+	require.True(ok)
+	require.Equal(int64(1), total.Values()[10])
+
+	complete, ok := histograms["complete_agent_seeders+"+tags]
+	require.True(ok)
+	require.Equal(int64(1), complete.Values()[10])
+
+	origin, ok := histograms["origin_seeders+"+tags]
+	require.True(ok)
+	require.Equal(int64(1), origin.Values()[0])
+
+	incompleteHist, ok := histograms["incomplete_agent_seeders+"+tags]
+	require.True(ok)
+	require.Equal(int64(1), incompleteHist.Values()[0])
 }

--- a/tracker/peerhandoutpolicy/peerhandoutpolicy.go
+++ b/tracker/peerhandoutpolicy/peerhandoutpolicy.go
@@ -22,6 +22,11 @@ import (
 	"github.com/uber/kraken/core"
 )
 
+// On the client-side, agent leeches only from the top N seeders.
+const _maxSeedersUsedPerTorrent = 10
+
+var _numSeedersHistogramBuckets = tally.MustMakeLinearValueBuckets(0, 1, 20)
+
 type peerPriorityInfo struct {
 	peer     *core.PeerInfo
 	priority int
@@ -63,33 +68,49 @@ func NewPriorityPolicy(stats tally.Scope, priorityPolicy string) (*PriorityPolic
 // SortPeers returns the given list of peers sorted by the priority assigned to them
 // by the priorityPolicy. Excludes the source peer from the list.
 func (p *PriorityPolicy) SortPeers(source *core.PeerInfo, peers []*core.PeerInfo) []*core.PeerInfo {
-
 	peerPriorities := make([]*peerPriorityInfo, 0, len(peers))
-	for k := 0; k < len(peers); k++ {
-		if peers[k] != source {
-			priority, label := p.policy.assignPriority(peers[k])
-			peerPriorities = append(peerPriorities,
-				&peerPriorityInfo{peers[k], priority, label})
+	for _, peer := range peers {
+		if peer == source {
+			continue
 		}
+		priority, label := p.policy.assignPriority(peer)
+		peerPriorities = append(peerPriorities, &peerPriorityInfo{peer, priority, label})
 	}
 
 	sort.Slice(peerPriorities, func(i, j int) bool {
 		return peerPriorities[i].priority < peerPriorities[j].priority
 	})
 
-	priorityCounts := make(map[string]int)
-	for k := 0; k < len(peerPriorities); k++ {
-		p := peerPriorities[k]
-		peers[k] = p.peer
-		priorityCounts[p.label]++
-	}
-	peers = peers[:len(peerPriorities)]
+	p.emitNumSeeders(peerPriorities)
 
-	for label, count := range priorityCounts {
-		p.stats.Tagged(map[string]string{
-			"label": label,
-		}).Gauge("count").Update(float64(count))
+	sortedPeers := []*core.PeerInfo{}
+	for _, peerPrio := range peerPriorities {
+		sortedPeers = append(sortedPeers, peerPrio.peer)
 	}
 
-	return peers
+	return sortedPeers
+}
+
+func (p *PriorityPolicy) emitNumSeeders(peerPriorities []*peerPriorityInfo) {
+	if len(peerPriorities) > _maxSeedersUsedPerTorrent {
+		peerPriorities = peerPriorities[:_maxSeedersUsedPerTorrent]
+	}
+
+	numOrigins, numCompleteAgents, numIncompleteAgents := 0, 0, 0
+	for _, peerPrio := range peerPriorities {
+		switch peerPrio.label {
+		case "peer_seeder":
+			numCompleteAgents++
+		case "peer_incomplete":
+			numIncompleteAgents++
+		case "origin":
+			numOrigins++
+		}
+	}
+
+	total := numOrigins + numCompleteAgents + numIncompleteAgents
+	p.stats.Histogram("total_seeders", _numSeedersHistogramBuckets).RecordValue(float64(total))
+	p.stats.Histogram("origin_seeders", _numSeedersHistogramBuckets).RecordValue(float64(numOrigins))
+	p.stats.Histogram("complete_agent_seeders", _numSeedersHistogramBuckets).RecordValue(float64(numCompleteAgents))
+	p.stats.Histogram("incomplete_agent_seeders", _numSeedersHistogramBuckets).RecordValue(float64(numIncompleteAgents))
 }

--- a/tracker/peerhandoutpolicy/peerhandoutpolicy.go
+++ b/tracker/peerhandoutpolicy/peerhandoutpolicy.go
@@ -91,6 +91,7 @@ func (p *PriorityPolicy) SortPeers(source *core.PeerInfo, peers []*core.PeerInfo
 	return sortedPeers
 }
 
+// Assumes that the completeness priority policy is used.
 func (p *PriorityPolicy) emitNumSeeders(peerPriorities []*peerPriorityInfo) {
 	if len(peerPriorities) > _maxSeedersUsedPerTorrent {
 		peerPriorities = peerPriorities[:_maxSeedersUsedPerTorrent]


### PR DESCRIPTION
Add a metric for the number of seeders per torrent download. The metric will help with evaluating the efficiency of the p2p algorithm.

 - It's broken down between different seeder classes
 - I simplified the code to pick peers