### PR TITLE
fix(build-index): return 404 on backend unavailability to unblock docker pushes

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -68,19 +68,23 @@ jobs:
           CGO_CFLAGS: "-Wno-return-local-addr"
 
   integration_tests:
+    name: integration tests (snapshotter ${{ matrix.snapshotter && 'enabled' || 'disabled' }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run with and without the containerd snapshotter to cover both OCI and
+        # Docker v2 manifest formats.
+        snapshotter: [true, false]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-docker-action@v4
         with:
           version: latest
-          # Disable containerd snapshotter which defaults to using OCI manifests,
-          # which are currently not supported by Kraken.
-          # TODO(thijmv): Remove this override once OCI manifests are supported.
           daemon-config: |
             {
               "features": {
-                "containerd-snapshotter": false
+                "containerd-snapshotter": ${{ matrix.snapshotter }}
               }
             }
       - uses: actions/setup-python@v5

--- a/build-index/tagstore/store.go
+++ b/build-index/tagstore/store.go
@@ -182,12 +182,17 @@ func (s *tagStore) resolveFromBackend(tag string) (core.Digest, error) {
 	}
 	var b bytes.Buffer
 	if err := backendClient.Download(tag, tag, &b); err != nil {
-		if err == backenderrors.ErrBlobNotFound {
+		if errors.Is(err, backenderrors.ErrBlobNotFound) {
 			log.With("tag", tag).Debug("Tag not found in backend")
-			return core.Digest{}, ErrTagNotFound
+		} else {
+			// Kraken is expected to accept image pushes even when remote storage is
+			// down by storing the blob on disk and flushing it to the remote storage
+			// once it becomes available again. When we experience a backend error,
+			// we return 404, instead of 500, as the latter would abort Docker pushes
+			// that HEAD before PUT (e.g. containerd snapshotter).
+			log.With("tag", tag, "error", err).Error("Failed to download tag from backend")
 		}
-		log.With("tag", tag).Errorf("Failed to download tag from backend: %s", err)
-		return core.Digest{}, fmt.Errorf("backend client: %s", err)
+		return core.Digest{}, ErrTagNotFound
 	}
 	d, err := core.ParseSHA256Digest(b.String())
 	if err != nil {

--- a/build-index/tagstore/store_test.go
+++ b/build-index/tagstore/store_test.go
@@ -143,7 +143,7 @@ func TestGetFromBackendUnkownError(t *testing.T) {
 	mocks.backendClient.EXPECT().Download(tag, tag, w).Return(fmt.Errorf("test error"))
 
 	_, err := store.Get(tag)
-	require.Error(err)
+	require.Equal(ErrTagNotFound, err)
 }
 
 func TestGetFromBackendInvalidValue(t *testing.T) {

--- a/nginx/config/build-index.go
+++ b/nginx/config/build-index.go
@@ -47,7 +47,6 @@ server {
     proxy_cache         tags;
     proxy_cache_methods GET;
     proxy_cache_valid   200 5m;
-    proxy_cache_valid   any 1s;
     proxy_cache_lock    on;
 
     proxy_read_timeout {{if .proxy_read_timeout}}{{.proxy_read_timeout}}{{else}}3m{{end}};

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -48,7 +48,7 @@ def _setup_test_image(name):
     return new_name
 
 
-TEST_IMAGE = _setup_test_image('alpine:latest') # todo: switch to latest after supporting oci format manifests
+TEST_IMAGE = _setup_test_image('alpine:latest')
 TEST_IMAGE_2 = _setup_test_image('redis:latest')
 
 


### PR DESCRIPTION
## Summary

This PR (2/3) makes the following changes:
- Tag store: Return 404 instead of 500 when the backend returns an error during tag resolution. This prevents a Docker push flow that issues a HEAD before PUT, e.g. the containerd snapshotter, from being aborted by a server error. On the subsequent PUT, the tag is written to disk and flushed to the backend once it becomes available.
- Build-index nginx: Drop the 1s cache on tag lookups, which was causing poisoned tag resolutions for subsequent pulls after the previous HEAD returned 404.

## Test plan

Integration tests. Without this change, 5/25 tests would [fail](https://github.com/uber/kraken/actions/runs/26636231799).

## Monitoring

To validate no regression was introduced by removing the non-200 1s cache, the following metrics should be observed post-land:
- Build-index
  - Get tag: QPS and error distribution
  - CPU usage
  - Write back failures
- Agent
  - Get tag errors
- Upload performance
  - UploadBlob reliability
  - PutTag reliability

## Stack
1. https://github.com/uber/kraken/pull/628
2. @ https://github.com/uber/kraken/pull/631
3. https://github.com/uber/kraken/pull/632