### PR TITLE
ci(integration): add containerd snapshotter matrix

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -68,19 +68,23 @@ jobs:
           CGO_CFLAGS: "-Wno-return-local-addr"
 
   integration_tests:
+    name: integration tests (snapshotter ${{ matrix.snapshotter && 'enabled' || 'disabled' }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run with and without the containerd snapshotter to cover both OCI and
+        # Docker v2 manifest formats.
+        snapshotter: [true, false]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-docker-action@v4
         with:
           version: latest
-          # Disable containerd snapshotter which defaults to using OCI manifests,
-          # which are currently not supported by Kraken.
-          # TODO(thijmv): Remove this override once OCI manifests are supported.
           daemon-config: |
             {
               "features": {
-                "containerd-snapshotter": false
+                "containerd-snapshotter": ${{ matrix.snapshotter }}
               }
             }
       - uses: actions/setup-python@v5

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -48,7 +48,7 @@ def _setup_test_image(name):
     return new_name
 
 
-TEST_IMAGE = _setup_test_image('alpine:latest') # todo: switch to latest after supporting oci format manifests
+TEST_IMAGE = _setup_test_image('alpine:latest')
 TEST_IMAGE_2 = _setup_test_image('redis:latest')
 
 


### PR DESCRIPTION
## Summary

This PR (3/3) enables the integration tests to run with and without the containerd snapshotter, utilising a matrix strategy to introduce coverage for both OCI and Docker v2 manifests.

## Stack
1. https://github.com/uber/kraken/pull/628
2. https://github.com/uber/kraken/pull/631
3. @ https://github.com/uber/kraken/pull/632