### PR TITLE
fix(scheduler): correctly handle torrent eviction from cache

### DIFF
--- a/lib/torrent/scheduler/events.go
+++ b/lib/torrent/scheduler/events.go
@@ -322,7 +322,7 @@ type newTorrentEvent struct {
 func (e newTorrentEvent) apply(s *state) {
 	ctrl, ok := s.torrentControls[e.torrent.InfoHash()]
 	if ok && ctrl.dispatcher.Complete() && !e.torrent.Complete() {
-		// The scheduler consider the torrent complete, while it is
+		// The scheduler considers the torrent complete, while it is
 		// actually not on disk. This happens when the disk cache
 		// asynchronously evicts the torrent, leaving the scheduler
 		// incorrectly thinking the torrent is still on disk.

--- a/lib/torrent/scheduler/events.go
+++ b/lib/torrent/scheduler/events.go
@@ -321,6 +321,15 @@ type newTorrentEvent struct {
 // apply begins seeding / leeching a new torrent.
 func (e newTorrentEvent) apply(s *state) {
 	ctrl, ok := s.torrentControls[e.torrent.InfoHash()]
+	if ok && ctrl.dispatcher.Complete() && !e.torrent.Complete() {
+		// The scheduler consider the torrent complete, while it is
+		// actually not on disk. This happens when the disk cache
+		// asynchronously evicts the torrent, leaving the scheduler
+		// incorrectly thinking the torrent is still on disk.
+		// We fix this by removing the mem entry for the torrent.
+		s.removeTorrent(e.torrent.InfoHash(), nil)
+		ok = false
+	}
 	if !ok {
 		var err error
 		ctrl, err = s.addTorrent(e.namespace, e.torrent, true)

--- a/lib/torrent/scheduler/scheduler_test.go
+++ b/lib/torrent/scheduler/scheduler_test.go
@@ -464,6 +464,47 @@ func TestSchedulerRemoveTorrent(t *testing.T) {
 	require.True(os.IsNotExist(err))
 }
 
+func TestDownloadAfterCacheEviction(t *testing.T) {
+	require := require.New(t)
+
+	mocks, cleanup := newTestMocks(t)
+	defer cleanup()
+
+	blob := core.NewBlobFixture()
+	namespace := core.TagFixture()
+
+	mocks.metaInfoClient.EXPECT().Download(
+		namespace, blob.Digest).Return(blob.MetaInfo, nil).AnyTimes()
+
+	config := configFixture()
+	config.ConnState.BlacklistDuration = time.Second
+
+	seeder := mocks.newPeer(config)
+	seeder.writeTorrent(namespace, blob)
+	require.NoError(seeder.scheduler.Download(namespace, blob.Digest))
+
+	leecher := mocks.newPeer(config)
+
+	// Download the blob successfully.
+	require.NoError(leecher.scheduler.Download(namespace, blob.Digest))
+	leecher.checkTorrent(t, namespace, blob)
+
+	// Wait for connections to close and blacklist to expire so the
+	// leecher can reconnect to the seeder for the re-download.
+	h := blob.MetaInfo.InfoHash()
+	waitForConnRemoved(t, leecher.scheduler, seeder.pctx.PeerID, h)
+	time.Sleep(config.ConnState.BlacklistDuration)
+
+	// Simulate cache cleanup evicting the file from disk while the
+	// scheduler still considers the torrent complete in memory.
+	require.NoError(leecher.cads.Cache().DeleteFile(blob.Digest.Hex()))
+
+	// A second download for the same blob must succeed by
+	// re-downloading from the seeder.
+	require.NoError(leecher.scheduler.Download(namespace, blob.Digest))
+	leecher.checkTorrent(t, namespace, blob)
+}
+
 func TestSchedulerProbe(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
# TLDR
This PR fixes a bug in agent where blob downloads fail if 1) a blob is being seeded to other agents, 2) it got evicted by the disk cache, and 3) 5 minutes have not passed since the eviction.

# Details
Agent keeps track of whether a blob is in cache or not based on its presence on disk. However, that is not the single SOT. The P2P scheduler also briefly keeps track of which torrents (aka blobs) are available for seeding. This is only done temporarily if another peer requests a blob. The bug happens when the 2 states are out of sync, i.e. when the scheduler's mem state thinks a blob exists, but the disk cache's eviction mechanism has deleted it to make space for other blobs.

The specific order to trigger the bug is the following:
1. Agent downloads a blob.
2. Another peer requests the blob. This triggers the scheduler to create a new `Torrent` and store in memory that the torrent is available.
3. The disk cache's cleanup job deletes the blob from disk (e.g. due to the 12h TTL we enforce). Now the scheduler's mem state thinks the torrent (blob) is present, while it is actually not.
4. A download request for the blob comes in to our agent.
5. The agent checks the disk cache and sees the blob is missing.
6. The agent calls the scheduler and triggers a blob download.
7. However, instead of triggering the download, the scheduler INCORRECTLY sees in its mem state that the blob is already present and returns as a no-op.
8. The client that called the scheduler's Download function looks for the blob in the disk cache, expecting the scheduler to have downloaded it BUT it never got downloaded by the scheduler.
9. Agent returns a 500 error due to the invariant violation.

This actually happened in production and can be seen in the agent's logs - a blob gets downloaded and then ~12h later the bug happens, leading to download errors (12h because the blob gets evicted due to the 12h TTL).

5 minutes after the blob is evicted, the agent cleans the scheduler's mem state, as it has a 5m TTI on memory torrent entries that are not being seeded. So the bug only happens if the blob is requested within that 5min window.

## The fix
To fix this, I change the behavior in step 7) - the scheduler now does not use its memory state to decide whether a `Download` call should be a no-op, but instead checks the `Torrent` struct's fields, which are not out-of-sync.

# Test Plan
I added a unit test that covers the scenario and fails. After this PR, the test passes.