### PR TITLE
fix(build-index): include sub-manifest blobs for multi-arch replication

### DIFF
--- a/lib/persistedretry/tagreplication/executor.go
+++ b/lib/persistedretry/tagreplication/executor.go
@@ -14,12 +14,19 @@
 package tagreplication
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+
 	"github.com/uber/kraken/build-index/tagclient"
+	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/persistedretry"
 	"github.com/uber/kraken/origin/blobclient"
+	"github.com/uber/kraken/utils/dockerutil"
 
 	"github.com/uber-go/tally"
 )
@@ -69,8 +76,13 @@ func (e *Executor) Exec(r persistedretry.Task) error {
 	if err != nil {
 		return fmt.Errorf("lookup remote origin cluster: %s", err)
 	}
-	for _, d := range t.Dependencies {
+	deps, err := e.resolveDeps(t.Tag, t.Digest)
+	if err != nil {
+		return fmt.Errorf("get deps: %w", err)
+	}
+	for _, d := range deps {
 		if err := e.originCluster.ReplicateToRemote(t.Tag, d, remoteOrigin); err != nil {
+			e.stats.Counter("replicate_blob_failures").Inc(1)
 			return fmt.Errorf("origin cluster replicate: %s", err)
 		}
 	}
@@ -87,4 +99,46 @@ func (e *Executor) Exec(r persistedretry.Task) error {
 	e.stats.Timer("lifetime").Record(time.Since(t.CreatedAt))
 
 	return nil
+}
+
+func (e *Executor) resolveDeps(tag string, d core.Digest) (core.DigestList, error) {
+	deps := core.DigestList{d}
+	m, err := e.downloadManifest(tag, d)
+	if err != nil {
+		return nil, fmt.Errorf("download manifest: %w", err)
+	}
+	refs, err := dockerutil.GetManifestReferences(m)
+	if err != nil {
+		return nil, fmt.Errorf("get manifest references: %w", err)
+	}
+	if _, ok := m.(*manifestlist.DeserializedManifestList); !ok {
+		return append(deps, refs...), nil
+	}
+
+	for _, subDigest := range refs {
+		subManifest, err := e.downloadManifest(tag, subDigest)
+		if err != nil {
+			return nil, fmt.Errorf("download sub-manifest %s: %w", subDigest, err)
+		}
+		subRefs, err := dockerutil.GetManifestReferences(subManifest)
+		if err != nil {
+			return nil, fmt.Errorf("get sub-manifest references: %w", err)
+		}
+		deps = append(deps, subDigest)
+		deps = append(deps, subRefs...)
+	}
+
+	return deps, nil
+}
+
+func (e *Executor) downloadManifest(tag string, d core.Digest) (distribution.Manifest, error) {
+	var buf bytes.Buffer
+	if err := e.originCluster.DownloadBlob(context.Background(), tag, d, &buf); err != nil {
+		return nil, err
+	}
+	m, _, err := dockerutil.ParseManifest(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	return m, nil
 }

--- a/lib/persistedretry/tagreplication/executor_test.go
+++ b/lib/persistedretry/tagreplication/executor_test.go
@@ -19,8 +19,12 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"github.com/uber/kraken/core"
 	mocktagclient "github.com/uber/kraken/mocks/build-index/tagclient"
 	mockblobclient "github.com/uber/kraken/mocks/origin/blobclient"
+	"github.com/uber/kraken/origin/blobclient"
+	"github.com/uber/kraken/utils/dockerutil"
+	"github.com/uber/kraken/utils/mockutil"
 )
 
 const (
@@ -58,18 +62,23 @@ func TestExecutor(t *testing.T) {
 
 	executor := mocks.new()
 	tagClient := mocks.newTagClient()
-	task := TaskFixture()
+
+	tag := core.TagFixture()
+	layers := core.DigestListFixture(3)
+	manifest, manifestBytes := dockerutil.ManifestFixture(layers[0], layers[1], layers[2])
+	task := NewTask(tag, manifest, core.DigestListFixture(3), "some-dest", 0)
 
 	gomock.InOrder(
 		mocks.tagClientProvider.EXPECT().Provide(task.Destination).Return(tagClient),
 		tagClient.EXPECT().Has(task.Tag).Return(false, nil),
 		tagClient.EXPECT().Origin().Return(_testRemoteOrigin, nil),
-		mocks.originCluster.EXPECT().ReplicateToRemote(
-			task.Tag, task.Dependencies[0], _testRemoteOrigin).Return(nil),
-		mocks.originCluster.EXPECT().ReplicateToRemote(
-			task.Tag, task.Dependencies[1], _testRemoteOrigin).Return(nil),
-		mocks.originCluster.EXPECT().ReplicateToRemote(
-			task.Tag, task.Dependencies[2], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().
+			DownloadBlob(gomock.Any(), tag, manifest, mockutil.MatchWriter(manifestBytes)).
+			Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, manifest, _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, layers[0], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, layers[1], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, layers[2], _testRemoteOrigin).Return(nil),
 		tagClient.EXPECT().PutAndReplicate(task.Tag, task.Digest).Return(nil),
 	)
 
@@ -92,4 +101,81 @@ func TestExecutorNoopsWhenTagAlreadyReplicated(t *testing.T) {
 	)
 
 	require.NoError(executor.Exec(task))
+}
+
+func TestExecutorManifestList(t *testing.T) {
+	require := require.New(t)
+
+	mocks, cleanup := newExecutorMocks(t)
+	defer cleanup()
+
+	executor := mocks.new()
+	tagClient := mocks.newTagClient()
+
+	tag := core.TagFixture()
+	m1Layers := core.DigestListFixture(3)
+	m2Layers := core.DigestListFixture(3)
+	m1Digest, m1Bytes := dockerutil.ManifestFixture(m1Layers[0], m1Layers[1], m1Layers[2])
+	m2Digest, m2Bytes := dockerutil.ManifestFixture(m2Layers[0], m2Layers[1], m2Layers[2])
+	mlDigest, mlBytes := dockerutil.ManifestListFixture(m1Digest, m2Digest)
+
+	task := NewTask(tag, mlDigest, core.DigestList{m1Digest, m2Digest}, "some-dest", 0)
+
+	gomock.InOrder(
+		mocks.tagClientProvider.EXPECT().Provide(task.Destination).Return(tagClient),
+		tagClient.EXPECT().Has(task.Tag).Return(false, nil),
+		tagClient.EXPECT().Origin().Return(_testRemoteOrigin, nil),
+		mocks.originCluster.EXPECT().
+			DownloadBlob(gomock.Any(), tag, mlDigest, mockutil.MatchWriter(mlBytes)).
+			Return(nil),
+		mocks.originCluster.EXPECT().
+			DownloadBlob(gomock.Any(), tag, m1Digest, mockutil.MatchWriter(m1Bytes)).
+			Return(nil),
+		mocks.originCluster.EXPECT().
+			DownloadBlob(gomock.Any(), tag, m2Digest, mockutil.MatchWriter(m2Bytes)).
+			Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, mlDigest, _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m1Digest, _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m1Layers[0], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m1Layers[1], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m1Layers[2], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m2Digest, _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m2Layers[0], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m2Layers[1], _testRemoteOrigin).Return(nil),
+		mocks.originCluster.EXPECT().ReplicateToRemote(tag, m2Layers[2], _testRemoteOrigin).Return(nil),
+		tagClient.EXPECT().PutAndReplicate(task.Tag, task.Digest).Return(nil),
+	)
+
+	require.NoError(executor.Exec(task))
+}
+
+func TestExecutorSubManifestDownloadError(t *testing.T) {
+	require := require.New(t)
+
+	mocks, cleanup := newExecutorMocks(t)
+	defer cleanup()
+
+	executor := mocks.new()
+	tagClient := mocks.newTagClient()
+
+	tag := core.TagFixture()
+	m1Digest, _ := dockerutil.ManifestFixture(core.DigestFixture(), core.DigestFixture(), core.DigestFixture())
+	mlDigest, mlBytes := dockerutil.ManifestListFixture(m1Digest, core.DigestFixture())
+
+	task := NewTask(tag, mlDigest, core.DigestList{m1Digest}, "some-dest", 0)
+
+	gomock.InOrder(
+		mocks.tagClientProvider.EXPECT().Provide(task.Destination).Return(tagClient),
+		tagClient.EXPECT().Has(task.Tag).Return(false, nil),
+		tagClient.EXPECT().Origin().Return(_testRemoteOrigin, nil),
+		mocks.originCluster.EXPECT().
+			DownloadBlob(gomock.Any(), tag, mlDigest, mockutil.MatchWriter(mlBytes)).
+			Return(nil),
+		mocks.originCluster.EXPECT().
+			DownloadBlob(gomock.Any(), tag, m1Digest, gomock.Any()).
+			Return(blobclient.ErrBlobNotFound),
+	)
+
+	err := executor.Exec(task)
+	require.ErrorContains(err, "download sub-manifest")
 }


### PR DESCRIPTION
## Summary
This PR fixes https://github.com/uber/kraken/issues/619 by adding recursion to dependency resolution in the tag replication executor only, ensuring multi-arch images are replicated completely, while leaving the validation path untouched.

## Context
Currently, the dependency resolver does not traverse more than one layer, meaning that for multi-arch images, their nested dependencies are not considered for tag uploads or replication.

Therefore, the dependency validation on tag uploads became stricter in https://github.com/uber/kraken/pull/620, by making `Resolve()` recurse into sub-manifests for both validation and replication. However, this was reverted, as uBuild can push images to different zones, meaning nested blob validation started failing.

The decision has been made to not validate the nested dependencies when the tag of a multi-arch image is uploaded, because it is already done indirectly. That is, when the sub-manifests are uploaded, their dependencies are validated. This means that when the multi-arch manifest is uploaded, only the top-level sub-manifests are considered for indirect validation.