### PR TITLE
ci: add clamav malware scan job

### DIFF
--- a/.github/workflows/vulnerability-check.yaml
+++ b/.github/workflows/vulnerability-check.yaml
@@ -30,6 +30,34 @@ jobs:
           scanners: 'vuln,license,secret,misconfig'
           skip-version-check: true
 
+  clamav_scan:
+    name: ClamAV Malware Scan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install ClamAV
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clamav
+
+      - name: Update ClamAV signatures
+        run: |
+          sudo systemctl stop clamav-freshclam
+          # Retry up to 3 times, as ClamAV's CDN may be rate-limited.
+          for i in {0..2}; do
+            sudo freshclam && exit 0
+            [ "$i" -lt 2 ] && sleep 10
+          done
+          exit 1
+
+      - name: Run ClamAV to check for malware
+        # Enforce a 10MB file/archive limit, and fail when exceeded.
+        run: clamscan --recursive --infected --exclude-dir="(^|/)\.git$" --max-filesize=10M --max-scansize=10M --alert-exceeds-max .
+
   trivy_report:
     name: Trivy Vulnerability Report
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR adds a ClamAV malware scan job to the vulnerability scan workflow to check for malware on pull requests.

## Test plan
See [this](https://github.com/uber/kraken/actions/runs/28246319728/job/83686123243?pr=639) action run.

```
Run clamscan --recursive --infected --exclude-dir="(^|/)\.git$" --max-filesize=10M --max-scansize=10M --alert-exceeds-max .

----------- SCAN SUMMARY -----------
Known viruses: 3627882
Engine version: 1.4.4
Scanned directories: 215
Scanned files: 619
Infected files: 0
Data scanned: 6.92 MB
Data read: 8.25 MB (ratio 0.84:1)
Time: 12.225 sec (0 m 12 s)
Start Date: 2026:06:26 15:01:04
End Date:   2026:06:26 15:01:17
```