### PR TITLE
feat: migrate m3 deprecated timers to histograms

### DIFF
--- a/agent/agentserver/server.go
+++ b/agent/agentserver/server.go
@@ -89,7 +89,7 @@ func (s *Server) Handler() http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(middleware.StatusCounter(s.stats))
-	r.Use(middleware.LatencyTimer(s.stats))
+	r.Use(middleware.LatencyHistogram(s.stats))
 
 	r.Get("/health", handler.Wrap(s.healthHandler))
 	r.Get("/readiness", handler.Wrap(s.readinessCheckHandler))

--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -192,7 +192,6 @@ func Run(flags *Flags, opts ...Option) {
 	}
 
 	tagReplicationExecutor := tagreplication.NewExecutor(
-		stats,
 		originClient,
 		tagclient.NewProvider(tls))
 	tagReplicationStore, err := tagreplication.NewStore(localDB, remotes)

--- a/build-index/tagserver/server.go
+++ b/build-index/tagserver/server.go
@@ -115,7 +115,7 @@ func (s *Server) Handler() http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(middleware.StatusCounter(s.stats))
-	r.Use(middleware.LatencyTimer(s.stats))
+	r.Use(middleware.LatencyHistogram(s.stats))
 
 	r.Get("/health", handler.Wrap(s.healthHandler))
 	r.Get("/readiness", handler.Wrap(s.readinessCheckHandler))

--- a/lib/middleware/middleware.go
+++ b/lib/middleware/middleware.go
@@ -23,6 +23,8 @@ import (
 	"github.com/uber-go/tally"
 )
 
+var _latencyBuckets = tally.MustMakeExponentialDurationBuckets(time.Millisecond, 2, 20) // 1ms-8.7m
+
 // tagEndpoint tags stats by endpoint path and method, ignoring any path variables.
 // For example, "/foo/{foo}/bar/{bar}" is tagged with endpoint "foo.bar"
 //
@@ -58,13 +60,13 @@ func isPathVariable(s string) bool {
 	return len(s) >= 2 && s[0] == '{' && s[len(s)-1] == '}'
 }
 
-// LatencyTimer measures endpoint latencies.
-func LatencyTimer(stats tally.Scope) func(next http.Handler) http.Handler {
+// LatencyHistogram measures endpoint latencies.
+func LatencyHistogram(stats tally.Scope) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			next.ServeHTTP(w, r)
-			tagEndpoint(stats, r).Timer("latency").Record(time.Since(start))
+			tagEndpoint(stats, r).Histogram("latency", _latencyBuckets).RecordDuration(time.Since(start))
 		})
 	}
 }

--- a/lib/middleware/middleware_test.go
+++ b/lib/middleware/middleware_test.go
@@ -70,12 +70,12 @@ func TestScopeByEndpoint(t *testing.T) {
 	}
 }
 
-func TestLatencyTimer(t *testing.T) {
+func TestLatencyHistogram(t *testing.T) {
 	require := require.New(t)
 	stats := tally.NewTestScope("", nil)
 
 	r := chi.NewRouter()
-	r.Use(LatencyTimer(stats))
+	r.Use(LatencyHistogram(stats))
 	r.Get("/foo/{foo}", func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(200 * time.Millisecond)
 	})
@@ -86,17 +86,22 @@ func TestLatencyTimer(t *testing.T) {
 	_, err := httputil.Get(fmt.Sprintf("http://%s/foo/x", addr))
 	require.NoError(err)
 
-	now := time.Now()
+	histograms := stats.Snapshot().Histograms()
+	require.Equal(1, len(histograms))
 
-	require.Equal(1, len(stats.Snapshot().Timers()))
-	for _, v := range stats.Snapshot().Timers() {
-		require.Equal("latency", v.Name())
-		require.WithinDuration(now, now.Add(v.Values()[0]), 500*time.Millisecond)
-		require.Equal(map[string]string{
-			"endpoint": "foo",
-			"method":   "GET",
-		}, v.Tags())
+	h, ok := histograms["latency+endpoint=foo,method=GET"]
+	require.True(ok)
+	require.Equal("latency", h.Name())
+	require.Equal(map[string]string{
+		"endpoint": "foo",
+		"method":   "GET",
+	}, h.Tags())
+
+	var total int64
+	for _, count := range h.Durations() {
+		total += count
 	}
+	require.Equal(int64(1), total)
 }
 
 func TestStatusCounter(t *testing.T) {

--- a/lib/persistedretry/tagreplication/executor.go
+++ b/lib/persistedretry/tagreplication/executor.go
@@ -15,33 +15,24 @@ package tagreplication
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/uber/kraken/build-index/tagclient"
 	"github.com/uber/kraken/lib/persistedretry"
 	"github.com/uber/kraken/origin/blobclient"
-
-	"github.com/uber-go/tally"
 )
 
 // Executor executes tag replication tasks.
 type Executor struct {
-	stats             tally.Scope
 	originCluster     blobclient.ClusterClient
 	tagClientProvider tagclient.Provider
 }
 
 // NewExecutor creates a new Executor.
 func NewExecutor(
-	stats tally.Scope,
 	originCluster blobclient.ClusterClient,
 	tagClientProvider tagclient.Provider) *Executor {
 
-	stats = stats.Tagged(map[string]string{
-		"module": "tagreplicationexecutor",
-	})
-
-	return &Executor{stats, originCluster, tagClientProvider}
+	return &Executor{originCluster, tagClientProvider}
 }
 
 // Name returns the executor name.
@@ -56,7 +47,6 @@ func (e *Executor) Exec(r persistedretry.Task) error {
 	if !ok {
 		return fmt.Errorf("expected *Task, got %T", r)
 	}
-	start := time.Now()
 	remoteTagClient := e.tagClientProvider.Provide(t.Destination)
 
 	if ok, err := remoteTagClient.Has(t.Tag); err == nil && ok {
@@ -81,10 +71,6 @@ func (e *Executor) Exec(r persistedretry.Task) error {
 	if err := remoteTagClient.PutAndReplicate(t.Tag, t.Digest); err != nil {
 		return fmt.Errorf("put and replicate tag: %s", err)
 	}
-
-	// We don't want to time noops nor errors.
-	e.stats.Timer("replicate").Record(time.Since(start))
-	e.stats.Timer("lifetime").Record(time.Since(t.CreatedAt))
 
 	return nil
 }

--- a/lib/persistedretry/tagreplication/executor_test.go
+++ b/lib/persistedretry/tagreplication/executor_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 	mocktagclient "github.com/uber/kraken/mocks/build-index/tagclient"
 	mockblobclient "github.com/uber/kraken/mocks/origin/blobclient"
 )
@@ -43,7 +42,7 @@ func newExecutorMocks(t *testing.T) (*executorMocks, func()) {
 }
 
 func (m *executorMocks) new() *Executor {
-	return NewExecutor(tally.NoopScope, m.originCluster, m.tagClientProvider)
+	return NewExecutor(m.originCluster, m.tagClientProvider)
 }
 
 func (m *executorMocks) newTagClient() *mocktagclient.MockClient {

--- a/origin/blobserver/metrics.go
+++ b/origin/blobserver/metrics.go
@@ -1,17 +1,21 @@
 package blobserver
 
 import (
+	"time"
+
 	"github.com/uber-go/tally"
 )
 
 type metrics struct {
-	replicateBlobTimer  tally.Timer
-	replicateBlobErrors tally.Counter
+	replicateBlobLatency tally.Histogram
+	replicateBlobErrors  tally.Counter
 }
 
 func newMetrics(s tally.Scope) *metrics {
 	return &metrics{
-		replicateBlobTimer:  s.Timer("replicate_blob"),
+		replicateBlobLatency: s.Histogram(
+			"replicate_blob",
+			tally.MustMakeExponentialDurationBuckets(10*time.Millisecond, 2, 18)), // 10ms-21.8m
 		replicateBlobErrors: s.Counter("replicate_blob_errors"),
 	}
 }

--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -132,7 +132,7 @@ func (s *Server) Handler() http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(middleware.StatusCounter(s.stats))
-	r.Use(middleware.LatencyTimer(s.stats))
+	r.Use(middleware.LatencyHistogram(s.stats))
 
 	tracingMiddleware := otelhttp.NewMiddleware("kraken-origin",
 		otelhttp.WithTracerProvider(otel.GetTracerProvider()))
@@ -478,7 +478,6 @@ type localReplicationHook struct {
 func (h *localReplicationHook) Run(d core.Digest) {
 	start := time.Now()
 	log.With("digest", d.Hex()).Info("Starting local replication")
-	timer := h.server.metrics.replicateBlobTimer.Start()
 	if err := h.server.replicateBlobLocally(d); err != nil {
 		// Don't return error here as we only want to cache storage backend errors.
 		duration := time.Since(start)
@@ -486,8 +485,8 @@ func (h *localReplicationHook) Run(d core.Digest) {
 		h.server.metrics.replicateBlobErrors.Inc(1)
 		return
 	}
-	timer.Stop()
 	duration := time.Since(start)
+	h.server.metrics.replicateBlobLatency.RecordDuration(duration)
 	log.With("digest", d.Hex(), "duration_s", duration.Seconds()).Info("Successfully completed local replication")
 }
 

--- a/proxy/proxyserver/prefetch.go
+++ b/proxy/proxyserver/prefetch.go
@@ -43,6 +43,7 @@ type PrefetchHandler struct {
 	metrics            tally.Scope
 	getManifestLatency tally.Histogram
 	getTagLatency      tally.Histogram
+	blobDownloadTime   tally.Histogram
 }
 
 // blobInfo holds digest and size information for a blob.
@@ -121,6 +122,7 @@ func NewPrefetchHandler(
 		metrics:            m,
 		getManifestLatency: m.Histogram("download_manifest_latency", tally.MustMakeExponentialDurationBuckets(1*time.Second, 2, 12)),
 		getTagLatency:      m.Histogram("get_tag_latency", tally.MustMakeExponentialDurationBuckets(100*time.Millisecond, 2, 10)),
+		blobDownloadTime:   m.Histogram("blob_download_time", tally.MustMakeExponentialDurationBuckets(time.Millisecond, 2, 20)), // 1ms-8.7m
 	}
 }
 
@@ -278,7 +280,7 @@ func (ph *PrefetchHandler) downloadBlobs(input *prefetchInput) {
 			blobStart := time.Now()
 			err := ph.clusterClient.DownloadBlob(context.Background(), input.namespace, blob.digest, io.Discard)
 			blobDuration := time.Since(blobStart)
-			ph.metrics.Timer("blob_download_time").Record(blobDuration)
+			ph.blobDownloadTime.RecordDuration(blobDuration)
 			ph.metrics.Counter("bytes_downloaded").Inc(blob.size)
 			if err != nil {
 				if serr, ok := err.(httputil.StatusError); ok && serr.Status == http.StatusAccepted {

--- a/proxy/proxyserver/server.go
+++ b/proxy/proxyserver/server.go
@@ -58,7 +58,7 @@ func (s *Server) Handler() http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(middleware.StatusCounter(s.stats))
-	r.Use(middleware.LatencyTimer(s.stats))
+	r.Use(middleware.LatencyHistogram(s.stats))
 
 	r.Get("/health", handler.Wrap(s.healthHandler))
 

--- a/tracker/trackerserver/metainfo.go
+++ b/tracker/trackerserver/metainfo.go
@@ -31,7 +31,6 @@ func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) erro
 		return handler.Errorf("parse digest: %s", err).Status(http.StatusBadRequest)
 	}
 
-	timer := s.stats.Timer("get_metainfo").Start()
 	mi, err := s.originCluster.GetMetaInfo(namespace, d)
 	if err != nil {
 		if serr, ok := err.(httputil.StatusError); ok {
@@ -40,7 +39,6 @@ func (s *Server) getMetaInfoHandler(w http.ResponseWriter, r *http.Request) erro
 		}
 		return err
 	}
-	timer.Stop()
 
 	b, err := mi.Serialize()
 	if err != nil {

--- a/tracker/trackerserver/server.go
+++ b/tracker/trackerserver/server.go
@@ -74,7 +74,7 @@ func (s *Server) Handler() http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(middleware.StatusCounter(s.stats))
-	r.Use(middleware.LatencyTimer(s.stats))
+	r.Use(middleware.LatencyHistogram(s.stats))
 
 	r.Get("/health", handler.Wrap(s.healthHandler))
 	r.Get("/readiness", handler.Wrap(s.readinessCheckHandler))


### PR DESCRIPTION
## Summary

This PR migrates all timers used in Kraken to histograms, as timers are slowly being deprecated by M3. Timers not used in any dashboard panel or alert are dropped instead.

## Metrics

The bucket ranges for the metrics are based on seven days of production data.

| Metric | Range | Reason |
| - | - | - |
| `lib/middleware:latency` | 1ms-8.7m (n=20) | Tracker 50ms p95, proxy 500s p99.9, agent alert 2m/5m, proxy alert 10s/20s  |
| `origin/blobserver:replicate_blob` | 10ms-21.8m (n=18) | Fast zones 50ms p50, regular 5-10m spikes, 21m outliers |
| `proxy/proxyserver:blob_download_time` | 1ms-8.7m (n=20) | 5ms p1, avg 0.4-1.7s p95, alert 2m/5m |

The following metrics were dropped, as they were not used in any panel or alert:
- `tracker/trackerserver:get_metainfo`
- `lib/persistedretry/tagreplication:replicate`
- `lib/persistedretry/tagreplication:lifetime`

## Future work

- [ ] Update queries for dashboard panels and alerts.
- [ ] Validate appropriate histogram bucket distribution.