### PR TITLE
refactor(lib/metainfogen): deduplicate metainfo generation

### DIFF
--- a/lib/metainfogen/generator.go
+++ b/lib/metainfogen/generator.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/uber/kraken/core"
 	"github.com/uber/kraken/lib/store"
-	"github.com/uber/kraken/lib/store/metadata"
 )
 
 // Generator wraps static piece length configuration in order to determinstically
@@ -43,19 +42,8 @@ func (g *Generator) Generate(d core.Digest) error {
 	if err != nil {
 		return fmt.Errorf("cache stat: %s", err)
 	}
-	f, err := g.cas.GetCacheFileReader(d.Hex())
-	if err != nil {
-		return fmt.Errorf("get cache file: %s", err)
-	}
 	pieceLength := g.pieceLengthConfig.get(info.Size())
-	mi, err := core.NewMetaInfo(d, f, pieceLength)
-	if err != nil {
-		return fmt.Errorf("create metainfo: %s", err)
-	}
-	if _, err := g.cas.SetCacheFileMetadata(d.Hex(), metadata.NewTorrentMeta(mi)); err != nil {
-		return fmt.Errorf("set metainfo: %s", err)
-	}
-	return nil
+	return g.cas.GenerateCacheFileMetaInfo(d, pieceLength)
 }
 
 // Get the piece length for the blob

--- a/lib/metainfogen/generator.go
+++ b/lib/metainfogen/generator.go
@@ -43,7 +43,7 @@ func (g *Generator) Generate(d core.Digest) error {
 		return fmt.Errorf("cache stat: %s", err)
 	}
 	pieceLength := g.pieceLengthConfig.get(info.Size())
-	return g.cas.GenerateCacheFileMetaInfo(d, pieceLength)
+	return g.cas.GenerateMetadataFromFile(d.Hex(), pieceLength)
 }
 
 // Get the piece length for the blob

--- a/lib/store/ca_store.go
+++ b/lib/store/ca_store.go
@@ -310,10 +310,17 @@ func (s *CAStore) generateMetadataFromFile(name string, pieceLength int64) error
 	if err != nil {
 		return fmt.Errorf("get digest from file: %w", err)
 	}
-	f, err := s.GetCacheFileReader(name)
+	return s.GenerateCacheFileMetaInfo(d, pieceLength)
+}
+
+// GenerateCacheFileMetaInfo generates torrent metainfo for a cached blob
+// and persists it alongside the cache file.
+func (s *CAStore) GenerateCacheFileMetaInfo(d core.Digest, pieceLength int64) error {
+	f, err := s.GetCacheFileReader(d.Hex())
 	if err != nil {
 		return fmt.Errorf("get cache file: %w", err)
 	}
+	defer closers.Close(f)
 	mi, err := core.NewMetaInfo(d, f, pieceLength)
 	if err != nil {
 		return fmt.Errorf("create metainfo: %w", err)

--- a/lib/store/ca_store.go
+++ b/lib/store/ca_store.go
@@ -223,7 +223,7 @@ func (s *CAStore) writeCacheFile(name string, write func(w FileReadWriter) error
 		return fmt.Errorf("move upload file to cache: %s", err)
 	}
 	if addMetadata {
-		return s.generateMetadataFromFile(name, pieceLength)
+		return s.GenerateMetadataFromFile(name, pieceLength)
 	}
 	return nil
 }
@@ -305,18 +305,14 @@ func (s *CAStore) generateMetadataFromBytes(name string, data []byte, pieceLengt
 	return metaInfo, nil
 }
 
-func (s *CAStore) generateMetadataFromFile(name string, pieceLength int64) error {
+// GenerateMetadataFromFile generates metainfo for a cached file and writes it
+// alongside the cache file.
+func (s *CAStore) GenerateMetadataFromFile(name string, pieceLength int64) error {
 	d, err := core.NewSHA256DigestFromHex(name)
 	if err != nil {
 		return fmt.Errorf("get digest from file: %w", err)
 	}
-	return s.GenerateCacheFileMetaInfo(d, pieceLength)
-}
-
-// GenerateCacheFileMetaInfo generates torrent metainfo for a cached blob
-// and persists it alongside the cache file.
-func (s *CAStore) GenerateCacheFileMetaInfo(d core.Digest, pieceLength int64) error {
-	f, err := s.GetCacheFileReader(d.Hex())
+	f, err := s.GetCacheFileReader(name)
 	if err != nil {
 		return fmt.Errorf("get cache file: %w", err)
 	}

--- a/lib/store/ca_store_test.go
+++ b/lib/store/ca_store_test.go
@@ -243,6 +243,50 @@ func TestCAStoreCreateCacheFile(t *testing.T) {
 	require.NoError(err)
 	require.Equal(s1, string(b2))
 }
+
+func TestCAStore_GenerateCacheFileMetaInfo(t *testing.T) {
+	require := require.New(t)
+
+	s, cleanup := CAStoreFixture()
+	defer cleanup()
+
+	const pieceLength = 10
+	blob := core.SizedBlobFixture(100, pieceLength)
+	require.NoError(s.CreateCacheFile(blob.Digest.Hex(), bytes.NewReader(blob.Content)))
+
+	require.NoError(s.GenerateCacheFileMetaInfo(blob.Digest, pieceLength))
+
+	var tm metadata.TorrentMeta
+	require.NoError(s.GetCacheFileMetadata(blob.Digest.Hex(), &tm))
+	require.Equal(blob.MetaInfo, tm.MetaInfo)
+}
+
+func TestCAStore_GenerateCacheFileMetaInfo_CacheFileMissing(t *testing.T) {
+	require := require.New(t)
+
+	s, cleanup := CAStoreFixture()
+	defer cleanup()
+
+	err := s.GenerateCacheFileMetaInfo(core.DigestFixture(), 10)
+	require.ErrorContains(err, "get cache file")
+}
+
+func TestCAStore_GenerateCacheFileMetaInfo_InvalidPieceLength(t *testing.T) {
+	require := require.New(t)
+
+	s, cleanup := CAStoreFixture()
+	defer cleanup()
+
+	blob := core.NewBlobFixture()
+	require.NoError(s.CreateCacheFile(blob.Digest.Hex(), bytes.NewReader(blob.Content)))
+
+	err := s.GenerateCacheFileMetaInfo(blob.Digest, 0)
+	require.EqualError(err, "create metainfo: piece length must be positive")
+
+	var tm metadata.TorrentMeta
+	require.Error(s.GetCacheFileMetadata(blob.Digest.Hex(), &tm))
+}
+
 func TestCAStoreConfig_WithMemoryCache(t *testing.T) {
 	require := require.New(t)
 

--- a/lib/store/ca_store_test.go
+++ b/lib/store/ca_store_test.go
@@ -244,7 +244,7 @@ func TestCAStoreCreateCacheFile(t *testing.T) {
 	require.Equal(s1, string(b2))
 }
 
-func TestCAStore_GenerateCacheFileMetaInfo(t *testing.T) {
+func TestCAStore_GenerateMetadataFromFile(t *testing.T) {
 	require := require.New(t)
 
 	s, cleanup := CAStoreFixture()
@@ -254,24 +254,24 @@ func TestCAStore_GenerateCacheFileMetaInfo(t *testing.T) {
 	blob := core.SizedBlobFixture(100, pieceLength)
 	require.NoError(s.CreateCacheFile(blob.Digest.Hex(), bytes.NewReader(blob.Content)))
 
-	require.NoError(s.GenerateCacheFileMetaInfo(blob.Digest, pieceLength))
+	require.NoError(s.GenerateMetadataFromFile(blob.Digest.Hex(), pieceLength))
 
 	var tm metadata.TorrentMeta
 	require.NoError(s.GetCacheFileMetadata(blob.Digest.Hex(), &tm))
 	require.Equal(blob.MetaInfo, tm.MetaInfo)
 }
 
-func TestCAStore_GenerateCacheFileMetaInfo_CacheFileMissing(t *testing.T) {
+func TestCAStore_GenerateMetadataFromFile_CacheFileMissing(t *testing.T) {
 	require := require.New(t)
 
 	s, cleanup := CAStoreFixture()
 	defer cleanup()
 
-	err := s.GenerateCacheFileMetaInfo(core.DigestFixture(), 10)
+	err := s.GenerateMetadataFromFile(core.DigestFixture().Hex(), 10)
 	require.ErrorContains(err, "get cache file")
 }
 
-func TestCAStore_GenerateCacheFileMetaInfo_InvalidPieceLength(t *testing.T) {
+func TestCAStore_GenerateMetadataFromFile_InvalidPieceLength(t *testing.T) {
 	require := require.New(t)
 
 	s, cleanup := CAStoreFixture()
@@ -280,7 +280,7 @@ func TestCAStore_GenerateCacheFileMetaInfo_InvalidPieceLength(t *testing.T) {
 	blob := core.NewBlobFixture()
 	require.NoError(s.CreateCacheFile(blob.Digest.Hex(), bytes.NewReader(blob.Content)))
 
-	err := s.GenerateCacheFileMetaInfo(blob.Digest, 0)
+	err := s.GenerateMetadataFromFile(blob.Digest.Hex(), 0)
 	require.EqualError(err, "create metainfo: piece length must be positive")
 
 	var tm metadata.TorrentMeta


### PR DESCRIPTION
## Summary

- expose the existing `CAStore.GenerateMetadataFromFile` operation so cache writes and `metainfogen.Generator` share the same file-level generation path
- keep piece-length selection in `metainfogen.Generator`, then call the shared CAStore operation directly as suggested in review
- close the cache reader after generation and cover successful persistence, missing cache files, and invalid piece lengths

This keeps the existing error prefixes and metadata overwrite behavior while removing the duplicate workflow introduced with the in-memory cache path.

Fixes #488.

## Test plan

- `go test -count=1 -race ./lib/store ./lib/metainfogen`
- `CGO_CFLAGS="-Wno-return-local-addr" go test -count=1 $(go list ./...) -cover`
- `CGO_CFLAGS="-Wno-return-local-addr" go build ./...`
- `golangci-lint run ./...`
- `go vet ./lib/store ./lib/metainfogen`
- repeat the race, full test, build, lint, and vet checks after applying the PR cleanly to current `master` (`c76945b`)