### PR TITLE
feat: Send blob size to origin when sending a blob

### DIFF
--- a/lib/dockerregistry/transfer/rw_transferer.go
+++ b/lib/dockerregistry/transfer/rw_transferer.go
@@ -205,7 +205,7 @@ func (t *ReadWriteTransferer) Upload(
 	)
 	defer span.End()
 
-	if err := t.originCluster.UploadBlob(ctx, namespace, d, blob); err != nil {
+	if err := t.originCluster.UploadBlob(ctx, namespace, d, blob, uint64(blob.Size())); err != nil {
 		t.failureStats.Counter("upload_blob").Inc(1)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "upload failed")

--- a/mocks/origin/blobclient/client.go
+++ b/mocks/origin/blobclient/client.go
@@ -94,17 +94,17 @@ func (mr *MockClientMockRecorder) DownloadBlob(arg0, arg1, arg2, arg3 interface{
 }
 
 // DuplicateUploadBlob mocks base method.
-func (m *MockClient) DuplicateUploadBlob(arg0 string, arg1 core.Digest, arg2 io.Reader, arg3 time.Duration) error {
+func (m *MockClient) DuplicateUploadBlob(arg0 string, arg1 core.Digest, arg2 io.Reader, arg3 uint64, arg4 time.Duration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DuplicateUploadBlob", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "DuplicateUploadBlob", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DuplicateUploadBlob indicates an expected call of DuplicateUploadBlob.
-func (mr *MockClientMockRecorder) DuplicateUploadBlob(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) DuplicateUploadBlob(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DuplicateUploadBlob", reflect.TypeOf((*MockClient)(nil).DuplicateUploadBlob), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DuplicateUploadBlob", reflect.TypeOf((*MockClient)(nil).DuplicateUploadBlob), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ForceCleanup mocks base method.
@@ -239,29 +239,29 @@ func (mr *MockClientMockRecorder) StatLocal(arg0, arg1 interface{}) *gomock.Call
 }
 
 // TransferBlob mocks base method.
-func (m *MockClient) TransferBlob(arg0 core.Digest, arg1 io.Reader) error {
+func (m *MockClient) TransferBlob(arg0 core.Digest, arg1 io.Reader, arg2 uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransferBlob", arg0, arg1)
+	ret := m.ctrl.Call(m, "TransferBlob", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TransferBlob indicates an expected call of TransferBlob.
-func (mr *MockClientMockRecorder) TransferBlob(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) TransferBlob(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferBlob", reflect.TypeOf((*MockClient)(nil).TransferBlob), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferBlob", reflect.TypeOf((*MockClient)(nil).TransferBlob), arg0, arg1, arg2)
 }
 
 // UploadBlob mocks base method.
-func (m *MockClient) UploadBlob(arg0 context.Context, arg1 string, arg2 core.Digest, arg3 io.Reader) error {
+func (m *MockClient) UploadBlob(arg0 context.Context, arg1 string, arg2 core.Digest, arg3 io.Reader, arg4 uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadBlob", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UploadBlob", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UploadBlob indicates an expected call of UploadBlob.
-func (mr *MockClientMockRecorder) UploadBlob(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) UploadBlob(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBlob", reflect.TypeOf((*MockClient)(nil).UploadBlob), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBlob", reflect.TypeOf((*MockClient)(nil).UploadBlob), arg0, arg1, arg2, arg3, arg4)
 }

--- a/mocks/origin/blobclient/clusterclient.go
+++ b/mocks/origin/blobclient/clusterclient.go
@@ -152,15 +152,15 @@ func (mr *MockClusterClientMockRecorder) Stat(arg0, arg1 interface{}) *gomock.Ca
 }
 
 // UploadBlob mocks base method.
-func (m *MockClusterClient) UploadBlob(arg0 context.Context, arg1 string, arg2 core.Digest, arg3 io.ReadSeeker) error {
+func (m *MockClusterClient) UploadBlob(arg0 context.Context, arg1 string, arg2 core.Digest, arg3 io.ReadSeeker, arg4 uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadBlob", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UploadBlob", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UploadBlob indicates an expected call of UploadBlob.
-func (mr *MockClusterClientMockRecorder) UploadBlob(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClusterClientMockRecorder) UploadBlob(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBlob", reflect.TypeOf((*MockClusterClient)(nil).UploadBlob), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBlob", reflect.TypeOf((*MockClusterClient)(nil).UploadBlob), arg0, arg1, arg2, arg3, arg4)
 }

--- a/origin/blobclient/client.go
+++ b/origin/blobclient/client.go
@@ -48,7 +48,7 @@ type Client interface {
 	CheckReadiness() error
 	Locations(d core.Digest) ([]string, error)
 	DeleteBlob(d core.Digest) error
-	TransferBlob(d core.Digest, blob io.Reader) error
+	TransferBlob(d core.Digest, blob io.Reader, size uint64) error
 
 	Stat(namespace string, d core.Digest) (*core.BlobInfo, error)
 	StatLocal(namespace string, d core.Digest) (*core.BlobInfo, error)
@@ -56,8 +56,8 @@ type Client interface {
 	GetMetaInfo(namespace string, d core.Digest) (*core.MetaInfo, error)
 	OverwriteMetaInfo(d core.Digest, pieceLength int64) error
 
-	UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.Reader) error
-	DuplicateUploadBlob(namespace string, d core.Digest, blob io.Reader, delay time.Duration) error
+	UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.Reader, size uint64) error
+	DuplicateUploadBlob(namespace string, d core.Digest, blob io.Reader, size uint64, delay time.Duration) error
 
 	DownloadBlob(ctx context.Context, namespace string, d core.Digest, dst io.Writer) error
 	PrefetchBlob(namespace string, d core.Digest) error
@@ -192,14 +192,14 @@ func (c *HTTPClient) DeleteBlob(d core.Digest) error {
 
 // TransferBlob uploads a blob to a single origin server. Unlike its cousin UploadBlob,
 // TransferBlob is an internal API which does not replicate the blob.
-func (c *HTTPClient) TransferBlob(d core.Digest, blob io.Reader) error {
+func (c *HTTPClient) TransferBlob(d core.Digest, blob io.Reader, size uint64) error {
 	tc := newTransferClient(c.addr, c.tls)
-	return runChunkedUpload(tc, d, blob, int64(c.chunkSize))
+	return runChunkedUpload(tc, d, blob, size, int64(c.chunkSize))
 }
 
 // UploadBlob uploads and replicates blob to the origin cluster, asynchronously
 // backing the blob up to the remote storage configured for namespace.
-func (c *HTTPClient) UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.Reader) error {
+func (c *HTTPClient) UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.Reader, size uint64) error {
 	ctx, span := c.tracer.Start(ctx, "blobclient.upload_blob",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -212,7 +212,7 @@ func (c *HTTPClient) UploadBlob(ctx context.Context, namespace string, d core.Di
 	defer span.End()
 
 	uc := newUploadClientWithContext(ctx, c.addr, namespace, _publicUpload, 0, c.tls)
-	if err := runChunkedUpload(uc, d, blob, int64(c.chunkSize)); err != nil {
+	if err := runChunkedUpload(uc, d, blob, size, int64(c.chunkSize)); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "upload failed")
 		return err
@@ -225,10 +225,10 @@ func (c *HTTPClient) UploadBlob(ctx context.Context, namespace string, d core.Di
 // DuplicateUploadBlob duplicates an blob upload request, which will attempt to
 // write-back at the given delay.
 func (c *HTTPClient) DuplicateUploadBlob(
-	namespace string, d core.Digest, blob io.Reader, delay time.Duration,
+	namespace string, d core.Digest, blob io.Reader, size uint64, delay time.Duration,
 ) error {
 	uc := newUploadClient(c.addr, namespace, _duplicateUpload, delay, c.tls)
-	return runChunkedUpload(uc, d, blob, int64(c.chunkSize))
+	return runChunkedUpload(uc, d, blob, size, int64(c.chunkSize))
 }
 
 // DownloadBlob downloads blob for d. If the blob of d is not available yet

--- a/origin/blobclient/client_test.go
+++ b/origin/blobclient/client_test.go
@@ -883,7 +883,7 @@ func TestTransferBlob(t *testing.T) {
 				}
 			}, WithChunkSize(uint64(len(tt.content)+1)))
 
-			err := client.TransferBlob(d, bytes.NewReader(tt.content))
+			err := client.TransferBlob(d, bytes.NewReader(tt.content), uint64(len(tt.content)))
 			if tt.wantErr {
 				require.Error(err)
 				if tt.errContain != "" {
@@ -927,7 +927,7 @@ func TestUploadBlob(t *testing.T) {
 			}
 		}, WithChunkSize(uint64(len(content)+1)))
 
-		err := client.UploadBlob(context.Background(), namespace, d, bytes.NewReader(content))
+		err := client.UploadBlob(context.Background(), namespace, d, bytes.NewReader(content), uint64(len(content)))
 		require.NoError(err)
 	})
 
@@ -955,7 +955,7 @@ func TestUploadBlob(t *testing.T) {
 			}
 		}, WithChunkSize(chunkSize))
 
-		err := client.UploadBlob(context.Background(), namespace, d, bytes.NewReader(content))
+		err := client.UploadBlob(context.Background(), namespace, d, bytes.NewReader(content), uint64(len(content)))
 		require.NoError(err)
 		require.Equal(5, patchCount) // 49 bytes / 10 bytes per chunk = 5 chunks
 	})
@@ -993,7 +993,7 @@ func TestDuplicateUploadBlob(t *testing.T) {
 			}
 		}, WithChunkSize(uint64(len(content)+1)))
 
-		err := client.DuplicateUploadBlob(namespace, d, bytes.NewReader(content), delay)
+		err := client.DuplicateUploadBlob(namespace, d, bytes.NewReader(content), uint64(len(content)), delay)
 		require.NoError(err)
 	})
 }

--- a/origin/blobclient/client_test.go
+++ b/origin/blobclient/client_test.go
@@ -867,6 +867,7 @@ func TestTransferBlob(t *testing.T) {
 
 				switch {
 				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/uploads"):
+					require.Equal(fmt.Sprintf("%d", len(tt.content)), r.URL.Query().Get("size"))
 					if tt.setLocation {
 						w.Header().Set("Location", tt.uploadID)
 					}
@@ -911,6 +912,7 @@ func TestUploadBlob(t *testing.T) {
 			switch {
 			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/uploads"):
 				require.Contains(r.URL.Path, fmt.Sprintf("/namespace/%s/blobs/%s/uploads", namespace, d))
+				require.Equal(fmt.Sprintf("%d", len(content)), r.URL.Query().Get("size"))
 				w.Header().Set("Location", uploadID)
 				w.WriteHeader(http.StatusOK)
 
@@ -943,6 +945,7 @@ func TestUploadBlob(t *testing.T) {
 		client := testServer(t, func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/uploads"):
+				require.Equal(fmt.Sprintf("%d", len(content)), r.URL.Query().Get("size"))
 				w.Header().Set("Location", uploadID)
 				w.WriteHeader(http.StatusOK)
 
@@ -973,6 +976,7 @@ func TestDuplicateUploadBlob(t *testing.T) {
 		client := testServer(t, func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/uploads"):
+				require.Equal(fmt.Sprintf("%d", len(content)), r.URL.Query().Get("size"))
 				w.Header().Set("Location", uploadID)
 				w.WriteHeader(http.StatusOK)
 

--- a/origin/blobclient/cluster_client.go
+++ b/origin/blobclient/cluster_client.go
@@ -88,7 +88,7 @@ var _ ClusterClient = &clusterClient{}
 // location resolution and retries.
 type ClusterClient interface {
 	CheckReadiness() error
-	UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.ReadSeeker) error
+	UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.ReadSeeker, size uint64) error
 	DownloadBlob(ctx context.Context, namespace string, d core.Digest, dst io.Writer) error
 	PrefetchBlob(namespace string, d core.Digest) error
 	GetMetaInfo(namespace string, d core.Digest) (*core.MetaInfo, error)
@@ -129,7 +129,7 @@ func (c *clusterClient) CheckReadiness() error {
 }
 
 // UploadBlob uploads blob to origin cluster. See Client.UploadBlob for more details.
-func (c *clusterClient) UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.ReadSeeker) (err error) {
+func (c *clusterClient) UploadBlob(ctx context.Context, namespace string, d core.Digest, blob io.ReadSeeker, size uint64) (err error) {
 	ctx, span := otel.Tracer("kraken-origin-cluster-client").Start(ctx, "cluster.upload_blob",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -159,7 +159,7 @@ func (c *clusterClient) UploadBlob(ctx context.Context, namespace string, d core
 		span.SetAttributes(attribute.Int("cluster.attempt", i))
 
 		log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex(), "origin", originAddr, "attempt", i).Debug("Attempting blob upload to origin")
-		err = client.UploadBlob(ctx, namespace, d, blob)
+		err = client.UploadBlob(ctx, namespace, d, blob, size)
 		if err == nil {
 			log.WithTraceContext(ctx).With("namespace", namespace, "digest", d.Hex(), "origin", originAddr).Debug("Blob upload succeeded")
 			span.SetAttributes(attribute.String("cluster.successful_origin", originAddr))

--- a/origin/blobclient/cluster_client_test.go
+++ b/origin/blobclient/cluster_client_test.go
@@ -355,7 +355,7 @@ func TestClusterClientUploadBlob(t *testing.T) {
 				client := mockblobclient.NewMockClient(ctrl)
 				resolver.EXPECT().Resolve(gomock.Any()).Return([]blobclient.Client{client}, nil)
 				client.EXPECT().Addr().Return(_testOrigin1).AnyTimes()
-				client.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				client.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				return resolver
 			},
 			blob: func() io.ReadSeeker { return bytes.NewReader([]byte("test data")) },
@@ -379,10 +379,10 @@ func TestClusterClientUploadBlob(t *testing.T) {
 				client2 := mockblobclient.NewMockClient(ctrl)
 				resolver.EXPECT().Resolve(gomock.Any()).Return([]blobclient.Client{client1, client2}, nil)
 				client1.EXPECT().Addr().Return(_testOrigin1).AnyTimes()
-				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					httputil.StatusError{Status: http.StatusServiceUnavailable})
 				client2.EXPECT().Addr().Return(_testOrigin2).AnyTimes()
-				client2.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				client2.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				return resolver
 			},
 			blob: func() io.ReadSeeker { return bytes.NewReader([]byte("test data")) },
@@ -394,7 +394,7 @@ func TestClusterClientUploadBlob(t *testing.T) {
 				client := mockblobclient.NewMockClient(ctrl)
 				resolver.EXPECT().Resolve(gomock.Any()).Return([]blobclient.Client{client}, nil)
 				client.EXPECT().Addr().Return(_testOrigin1).AnyTimes()
-				client.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				client.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					httputil.StatusError{Status: http.StatusBadRequest})
 				return resolver
 			},
@@ -409,10 +409,10 @@ func TestClusterClientUploadBlob(t *testing.T) {
 				client2 := mockblobclient.NewMockClient(ctrl)
 				resolver.EXPECT().Resolve(gomock.Any()).Return([]blobclient.Client{client1, client2}, nil)
 				client1.EXPECT().Addr().Return(_testOrigin1).AnyTimes()
-				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					httputil.StatusError{Status: http.StatusServiceUnavailable})
 				client2.EXPECT().Addr().Return(_testOrigin2).AnyTimes()
-				client2.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				client2.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					httputil.StatusError{Status: http.StatusServiceUnavailable})
 				return resolver
 			},
@@ -427,9 +427,9 @@ func TestClusterClientUploadBlob(t *testing.T) {
 				client2 := mockblobclient.NewMockClient(ctrl)
 				resolver.EXPECT().Resolve(gomock.Any()).Return([]blobclient.Client{client1, client2}, nil)
 				client1.EXPECT().Addr().Return(_testOrigin1).AnyTimes()
-				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(httputil.NetworkError{})
+				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(httputil.NetworkError{})
 				client2.EXPECT().Addr().Return(_testOrigin2).AnyTimes()
-				client2.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				client2.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				return resolver
 			},
 			blob: func() io.ReadSeeker { return bytes.NewReader([]byte("test data")) },
@@ -443,7 +443,7 @@ func TestClusterClientUploadBlob(t *testing.T) {
 				client1 := mockblobclient.NewMockClient(ctrl)
 				resolver.EXPECT().Resolve(gomock.Any()).Return([]blobclient.Client{client1, mockblobclient.NewMockClient(ctrl)}, nil)
 				client1.EXPECT().Addr().Return(_testOrigin1).AnyTimes()
-				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				client1.EXPECT().UploadBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					httputil.StatusError{Status: http.StatusServiceUnavailable})
 				return resolver
 			},
@@ -460,7 +460,7 @@ func TestClusterClientUploadBlob(t *testing.T) {
 
 			resolver := tt.setup(ctrl)
 			client := blobclient.NewClusterClient(resolver)
-			err := client.UploadBlob(context.Background(), _testNamespace, core.DigestFixture(), tt.blob())
+			err := client.UploadBlob(context.Background(), _testNamespace, core.DigestFixture(), tt.blob(), uint64(len("test data")))
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/origin/blobclient/transfer_bench_test.go
+++ b/origin/blobclient/transfer_bench_test.go
@@ -122,7 +122,7 @@ func BenchmarkTransferBlob(b *testing.B) {
 			digest := core.DigestFixture()
 			b.SetBytes(int64(len(blob)))
 			for b.Loop() {
-				if err := client.TransferBlob(digest, bytes.NewReader(blob)); err != nil {
+				if err := client.TransferBlob(digest, bytes.NewReader(blob), uint64(len(blob))); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/origin/blobclient/uploader.go
+++ b/origin/blobclient/uploader.go
@@ -30,20 +30,20 @@ import (
 
 // uploader provides methods for executing a chunked upload.
 type uploader interface {
-	start(d core.Digest) (uid string, err error)
+	start(d core.Digest, size uint64) (uid string, err error)
 	patch(d core.Digest, uid string, start, stop int64, chunk io.Reader) error
 	commit(d core.Digest, uid string) error
 }
 
-func runChunkedUpload(u uploader, d core.Digest, blob io.Reader, chunkSize int64) error {
-	if err := runChunkedUploadHelper(u, d, blob, chunkSize); err != nil && !httputil.IsConflict(err) {
+func runChunkedUpload(u uploader, d core.Digest, blob io.Reader, size uint64, chunkSize int64) error {
+	if err := runChunkedUploadHelper(u, d, blob, size, chunkSize); err != nil && !httputil.IsConflict(err) {
 		return err
 	}
 	return nil
 }
 
-func runChunkedUploadHelper(u uploader, d core.Digest, blob io.Reader, chunkSize int64) error {
-	uid, err := u.start(d)
+func runChunkedUploadHelper(u uploader, d core.Digest, blob io.Reader, size uint64, chunkSize int64) error {
+	uid, err := u.start(d, size)
 	if err != nil {
 		return err
 	}
@@ -77,9 +77,9 @@ func newTransferClient(addr string, tls *tls.Config) *transferClient {
 	return &transferClient{addr, tls}
 }
 
-func (c *transferClient) start(d core.Digest) (uid string, err error) {
+func (c *transferClient) start(d core.Digest, size uint64) (uid string, err error) {
 	r, err := httputil.Post(
-		fmt.Sprintf("http://%s/internal/blobs/%s/uploads", c.addr, d),
+		fmt.Sprintf("http://%s/internal/blobs/%s/uploads?size=%d", c.addr, d, size),
 		httputil.SendTLS(c.tls))
 	if err != nil {
 		return "", err
@@ -148,10 +148,10 @@ func newUploadClientWithContext(
 	}
 }
 
-func (c *uploadClient) start(d core.Digest) (uid string, err error) {
+func (c *uploadClient) start(d core.Digest, size uint64) (uid string, err error) {
 	r, err := httputil.Post(
-		fmt.Sprintf("http://%s/namespace/%s/blobs/%s/uploads",
-			c.addr, url.PathEscape(c.namespace), d),
+		fmt.Sprintf("http://%s/namespace/%s/blobs/%s/uploads?size=%d",
+			c.addr, url.PathEscape(c.namespace), d, size),
 		httputil.SendContext(c.ctx),
 		httputil.SendTLS(c.tls))
 	if err != nil {

--- a/origin/blobserver/cluster_client_test.go
+++ b/origin/blobserver/cluster_client_test.go
@@ -57,7 +57,7 @@ func TestClusterClientResilientToUnavailableMasters(t *testing.T) {
 		s.writeBackManager.EXPECT().Add(
 			writeback.MatchTask(writeback.NewTask(
 				backend.NoopNamespace, blob.Digest.Hex(), 0))).Return(nil)
-		require.NoError(cc.UploadBlob(context.Background(), backend.NoopNamespace, blob.Digest, store.NewBufferFileReader(blob.Content)))
+		require.NoError(cc.UploadBlob(context.Background(), backend.NoopNamespace, blob.Digest, store.NewBufferFileReader(blob.Content), uint64(len(blob.Content))))
 
 		bi, err := cc.Stat(backend.NoopNamespace, blob.Digest)
 		require.NoError(err)
@@ -92,7 +92,7 @@ func TestClusterClientReturnsErrorOnNoAvailability(t *testing.T) {
 
 	blob := core.NewBlobFixture()
 
-	require.Error(cc.UploadBlob(context.Background(), backend.NoopNamespace, blob.Digest, store.NewBufferFileReader(blob.Content)))
+	require.Error(cc.UploadBlob(context.Background(), backend.NoopNamespace, blob.Digest, store.NewBufferFileReader(blob.Content), uint64(len(blob.Content))))
 
 	_, err := cc.Stat(backend.NoopNamespace, blob.Digest)
 	require.Error(err)
@@ -180,12 +180,13 @@ func TestPollSkipsOriginOnRetryableError(t *testing.T) {
 	mockResolver.EXPECT().Resolve(blob.Digest).Return([]blobclient.Client{mockClient1, mockClient2}, nil)
 
 	reader := store.NewBufferFileReader(blob.Content)
+	size := uint64(len(blob.Content))
 	mockClient1.EXPECT().Addr().Return("client1").AnyTimes()
-	mockClient1.EXPECT().UploadBlob(gomock.Any(), namespace, blob.Digest, reader).Return(httputil.StatusError{Status: 503})
+	mockClient1.EXPECT().UploadBlob(gomock.Any(), namespace, blob.Digest, reader, size).Return(httputil.StatusError{Status: 503})
 	mockClient2.EXPECT().Addr().Return("client2").AnyTimes()
-	mockClient2.EXPECT().UploadBlob(gomock.Any(), namespace, blob.Digest, reader).Return(nil)
+	mockClient2.EXPECT().UploadBlob(gomock.Any(), namespace, blob.Digest, reader, size).Return(nil)
 
-	require.NoError(cc.UploadBlob(context.Background(), namespace, blob.Digest, reader))
+	require.NoError(cc.UploadBlob(context.Background(), namespace, blob.Digest, reader, size))
 }
 
 func TestClusterClientReturnsErrorOnNoAvailableOrigins(t *testing.T) {

--- a/origin/blobserver/server.go
+++ b/origin/blobserver/server.go
@@ -344,7 +344,7 @@ func (s *Server) replicateToRemote(ctx context.Context, namespace string, d core
 		log.With("namespace", namespace, "digest", d.Hex(), "remote", remoteDNS, "size_bytes", blobSize, "duration_s", duration.Seconds()).Errorf("Failed to get remote cluster provider: %s", err)
 		return handler.Errorf("remote cluster provider: %s", err)
 	}
-	if err := remote.UploadBlob(ctx, namespace, d, f); err != nil {
+	if err := remote.UploadBlob(ctx, namespace, d, f, uint64(blobSize)); err != nil {
 		duration := time.Since(start)
 		log.With("namespace", namespace, "digest", d.Hex(), "remote", remoteDNS, "size_bytes", blobSize, "duration_s", duration.Seconds()).Errorf("Failed to upload blob to remote: %s", err)
 		return err
@@ -531,7 +531,7 @@ func (s *Server) replicateBlobLocally(d core.Digest) error {
 			log.With("digest", d.Hex(), "replica", client.Addr()).Errorf("Failed to get cache reader: %s", err)
 			return fmt.Errorf("get cache reader: %s", err)
 		}
-		if err := client.TransferBlob(d, f); err != nil {
+		if err := client.TransferBlob(d, f, uint64(blobSize)); err != nil {
 			duration := time.Since(start)
 			log.With("digest", d.Hex(), "replica", client.Addr(), "size_bytes", blobSize, "duration_s", duration.Seconds()).Errorf("Failed to transfer blob: %s", err)
 			return fmt.Errorf("transfer blob: %s", err)
@@ -888,7 +888,7 @@ func (s *Server) commitClusterUploadHandler(w http.ResponseWriter, r *http.Reque
 		if err != nil {
 			return fmt.Errorf("get cache file: %s", err)
 		}
-		if err := client.DuplicateUploadBlob(namespace, d, f, delay); err != nil {
+		if err := client.DuplicateUploadBlob(namespace, d, f, uint64(blobSize), delay); err != nil {
 			duration := time.Since(replicaStart)
 			log.With("namespace", namespace, "digest", d.Hex(), "replica", client.Addr(), "size_bytes", blobSize, "duration_s", duration.Seconds()).Errorf("Failed to duplicate upload: %s", err)
 			return fmt.Errorf("duplicate upload: %s", err)

--- a/origin/blobserver/server_test.go
+++ b/origin/blobserver/server_test.go
@@ -185,7 +185,7 @@ func TestStatHandlerReturnSize(t *testing.T) {
 	blob := core.SizedBlobFixture(256, 8)
 	namespace := core.TagFixture()
 
-	require.NoError(client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content)))
+	require.NoError(client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content))))
 
 	ensureHasBlob(t, cp.Provide(s.host), namespace, blob)
 
@@ -207,7 +207,7 @@ func TestPrefetchHandler(t *testing.T) {
 	blob := core.SizedBlobFixture(256, 8)
 	namespace := core.TagFixture()
 
-	require.NoError(client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content)))
+	require.NoError(client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content))))
 
 	ensureHasBlob(t, cp.Provide(s.host), namespace, blob)
 
@@ -283,7 +283,7 @@ func TestDeleteBlob(t *testing.T) {
 	blob := core.NewBlobFixture()
 	namespace := core.TagFixture()
 
-	require.NoError(client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content)))
+	require.NoError(client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content))))
 
 	ensureHasBlob(t, cp.Provide(s.host), namespace, blob)
 
@@ -440,7 +440,7 @@ func TestTransferBlob(t *testing.T) {
 	blob := core.NewBlobFixture()
 	namespace := core.TagFixture()
 
-	err := cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content))
+	err := cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.NoError(err)
 	ensureHasBlob(t, cp.Provide(master1), namespace, blob)
 
@@ -449,7 +449,7 @@ func TestTransferBlob(t *testing.T) {
 	require.NoError(s.cas.GetCacheFileMetadata(blob.Digest.Hex(), &tm))
 
 	// Pushing again should be a no-op.
-	err = cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content))
+	err = cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.NoError(err)
 	ensureHasBlob(t, cp.Provide(master1), namespace, blob)
 }
@@ -554,7 +554,7 @@ func TestTransferBlobSmallChunkSize(t *testing.T) {
 
 	client := blobclient.New(s.addr, blobclient.WithChunkSize(13))
 
-	err := client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content))
+	err := client.TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.NoError(err)
 	ensureHasBlob(t, client, namespace, blob)
 }
@@ -570,7 +570,7 @@ func TestOverwriteMetainfo(t *testing.T) {
 	blob := core.NewBlobFixture()
 	namespace := core.TagFixture()
 
-	err := cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content))
+	err := cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.NoError(err)
 
 	mi, err := cp.Provide(master1).GetMetaInfo(namespace, blob.Digest)
@@ -596,13 +596,13 @@ func TestReplicateToRemote(t *testing.T) {
 	blob := core.NewBlobFixture()
 	namespace := core.TagFixture()
 
-	require.NoError(cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content)))
+	require.NoError(cp.Provide(master1).TransferBlob(blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content))))
 
 	remote := "remote:80"
 
 	remoteCluster := s.expectRemoteCluster(remote)
 	remoteCluster.EXPECT().UploadBlob(
-		gomock.Any(), namespace, blob.Digest, mockutil.MatchReader(blob.Content)).Return(nil)
+		gomock.Any(), namespace, blob.Digest, mockutil.MatchReader(blob.Content), uint64(len(blob.Content))).Return(nil)
 
 	require.NoError(cp.Provide(master1).ReplicateToRemote(namespace, blob.Digest, remote))
 }
@@ -661,7 +661,7 @@ func TestReplicateToRemoteWhenBlobInStorageBackend(t *testing.T) {
 
 	remoteCluster := s.expectRemoteCluster(remote)
 	remoteCluster.EXPECT().UploadBlob(
-		gomock.Any(), namespace, blob.Digest, mockutil.MatchReader(blob.Content)).Return(nil)
+		gomock.Any(), namespace, blob.Digest, mockutil.MatchReader(blob.Content), uint64(len(blob.Content))).Return(nil)
 
 	require.NoError(testutil.PollUntilTrue(5*time.Second, func() bool {
 		err := cp.Provide(master1).ReplicateToRemote(namespace, blob.Digest, remote)
@@ -690,7 +690,7 @@ func TestUploadBlobDuplicatesWriteBackTaskToReplicas(t *testing.T) {
 	s2.writeBackManager.EXPECT().Add(
 		writeback.MatchTask(writeback.NewTask(namespace, blob.Digest.Hex(), 30*time.Minute)))
 
-	err := cp.Provide(s1.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content))
+	err := cp.Provide(s1.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.NoError(err)
 
 	ensureHasBlob(t, cp.Provide(s1.host), namespace, blob)
@@ -723,12 +723,12 @@ func TestUploadBlobRetriesWriteBackFailure(t *testing.T) {
 
 	// Upload should "fail" because we failed to add a write-back task, but blob
 	// should still be present.
-	err := cp.Provide(s.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content))
+	err := cp.Provide(s.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.Error(err)
 	ensureHasBlob(t, cp.Provide(s.host), namespace, blob)
 
 	// Uploading again should succeed.
-	err = cp.Provide(s.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content))
+	err = cp.Provide(s.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.NoError(err)
 
 	// Shouldn't be able to delete blob since it is still being written back.
@@ -753,7 +753,7 @@ func TestUploadBlobResilientToDuplicationFailure(t *testing.T) {
 	s.writeBackManager.EXPECT().Add(
 		writeback.MatchTask(writeback.NewTask(namespace, blob.Digest.Hex(), 0))).Return(nil)
 
-	err := cp.Provide(s.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content))
+	err := cp.Provide(s.host).UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content)))
 	require.NoError(err)
 
 	ensureHasBlob(t, cp.Provide(s.host), namespace, blob)
@@ -777,7 +777,7 @@ func TestForceCleanupTTL(t *testing.T) {
 	s.writeBackManager.EXPECT().Add(
 		writeback.MatchTask(writeback.NewTask(namespace, blob.Digest.Hex(), 0))).Return(nil)
 
-	require.NoError(client.UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content)))
+	require.NoError(client.UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content))))
 
 	ensureHasBlob(t, client, namespace, blob)
 
@@ -822,7 +822,7 @@ func TestForceCleanupNonOwner(t *testing.T) {
 	s2.writeBackManager.EXPECT().Add(
 		writeback.MatchTask(writeback.NewTask(namespace, blob.Digest.Hex(), 30*time.Minute)))
 
-	require.NoError(client.UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content)))
+	require.NoError(client.UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content))))
 
 	ensureHasBlob(t, client, namespace, blob)
 
@@ -854,7 +854,7 @@ func TestForceCleanupWriteBackFailures(t *testing.T) {
 
 	s.writeBackManager.EXPECT().Add(writeback.MatchTask(task)).Return(nil)
 
-	require.NoError(client.UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content)))
+	require.NoError(client.UploadBlob(context.Background(), namespace, blob.Digest, bytes.NewReader(blob.Content), uint64(len(blob.Content))))
 
 	ensureHasBlob(t, client, namespace, blob)
 


### PR DESCRIPTION
This PR propagates the size of a blob from origin's clients to it when they want to cache the blob in the origin. The APIs changed are UploadBlob, TransferBlob, and DuplicateUploadBlob.

This is needed for the migration from CAStore to disk.Store and tiered.Store (more info in https://github.com/uber/kraken/pull/633), as the new store implementations require the size of a blob in order to add it to the store, as they use an LRU eviction policy and thus need to reserve space for the blob before adding it, in order to avoid disk exhaustion or OOMs.

Since this requires an API change, we must first change the clients to send the param (this PR), then rollout, and only then change the servers to actually parse the param (a future PR).