### PR TITLE
feat(TLS): emit when TLS certs will expire

### DIFF
--- a/agent/cmd/cmd.go
+++ b/agent/cmd/cmd.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber/kraken/tracker/announceclient"
 	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/configutil"
+	"github.com/uber/kraken/utils/httputil"
 	"github.com/uber/kraken/utils/log"
 	"github.com/uber/kraken/utils/netutil"
 	"go.uber.org/zap"
@@ -197,6 +198,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Error building client tls config: %s", err)
 	}
+	defer closers.Close(httputil.MonitorCertExpiration(&config.TLS, stats))
 
 	announceClient := announceclient.New(pctx, trackers, tls)
 	sched, err := scheduler.NewAgentScheduler(

--- a/build-index/cmd/cmd.go
+++ b/build-index/cmd/cmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/kraken/origin/blobclient"
 	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/configutil"
+	"github.com/uber/kraken/utils/httputil"
 	"github.com/uber/kraken/utils/log"
 
 	"github.com/uber-go/tally"
@@ -158,6 +159,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Error building client tls config: %s", err)
 	}
+	defer closers.Close(httputil.MonitorCertExpiration(&config.TLS, stats))
 
 	origins, err := config.Origin.Build(upstream.WithHealthCheck(healthcheck.Default(tls)))
 	if err != nil {

--- a/origin/cmd/cmd.go
+++ b/origin/cmd/cmd.go
@@ -42,6 +42,7 @@ import (
 	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/configutil"
 	"github.com/uber/kraken/utils/handler"
+	"github.com/uber/kraken/utils/httputil"
 	"github.com/uber/kraken/utils/log"
 	"github.com/uber/kraken/utils/netutil"
 
@@ -246,6 +247,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Error building client tls config: %s", err)
 	}
+	defer closers.Close(httputil.MonitorCertExpiration(&config.TLS, stats))
 
 	healthCheckFilter := healthcheck.NewFilter(config.HealthCheck, healthcheck.Default(tls))
 

--- a/proxy/cmd/cmd.go
+++ b/proxy/cmd/cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/configutil"
 	"github.com/uber/kraken/utils/flagutil"
+	"github.com/uber/kraken/utils/httputil"
 	"github.com/uber/kraken/utils/log"
 	"go.uber.org/zap"
 )
@@ -157,6 +158,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Error building client tls config: %s", err)
 	}
+	defer closers.Close(httputil.MonitorCertExpiration(&config.TLS, stats))
 
 	origins, err := config.Origin.Build(upstream.WithHealthCheck(healthcheck.Default(tls)))
 	if err != nil {

--- a/tracker/cmd/cmd.go
+++ b/tracker/cmd/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/kraken/tracker/trackerserver"
 	"github.com/uber/kraken/utils/closers"
 	"github.com/uber/kraken/utils/configutil"
+	"github.com/uber/kraken/utils/httputil"
 	"github.com/uber/kraken/utils/log"
 	"go.uber.org/zap"
 )
@@ -143,6 +144,7 @@ func Run(flags *Flags, opts ...Option) {
 	if err != nil {
 		log.Fatalf("Error building client tls config: %s", err)
 	}
+	defer closers.Close(httputil.MonitorCertExpiration(&config.TLS, stats))
 
 	origins, err := config.Origin.Build(upstream.WithHealthCheck(healthcheck.Default(tls)))
 	if err != nil {

--- a/utils/httputil/tls.go
+++ b/utils/httputil/tls.go
@@ -22,9 +22,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/uber/kraken/utils/log"
+
+	"github.com/uber-go/tally"
 )
+
+const _certExpiryCheckInterval = time.Hour
 
 // ErrEmptyCommonName is returned when common name is not provided for key generation.
 var ErrEmptyCommonName = errors.New("empty common name")
@@ -74,15 +79,7 @@ func (c *TLSConfig) BuildClient() (*tls.Config, error) {
 		}
 	}
 	if c.Client.Cert.Path != "" {
-		certPEM, err := parseCert(c.Client.Cert.Path)
-		if err != nil {
-			return nil, fmt.Errorf("parse client cert: %s", err)
-		}
-		keyPEM, err := parseKey(c.Client.Key.Path, c.Client.Passphrase.Path)
-		if err != nil {
-			return nil, fmt.Errorf("parse client key: %s", err)
-		}
-		cert, err := tls.X509KeyPair(certPEM, keyPEM)
+		cert, err := loadX509Pair(c.Client)
 		if err != nil {
 			return nil, fmt.Errorf("load client x509 key pair: %s", err)
 		}
@@ -96,6 +93,28 @@ func (c *TLSConfig) BuildClient() (*tls.Config, error) {
 		InsecureSkipVerify:       false, // This is important to enforce verification of server.
 	}
 	return c.tls, nil
+}
+
+// loadX509Pair reads and parses the cert/key files described by pair.
+func loadX509Pair(pair X509Pair) (tls.Certificate, error) {
+	certPEM, err := parseCert(pair.Cert.Path)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("parse cert: %s", err)
+	}
+	keyPEM, err := parseKey(pair.Key.Path, pair.Passphrase.Path)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("parse key: %s", err)
+	}
+	return tls.X509KeyPair(certPEM, keyPEM)
+}
+
+// certNotAfter returns the expiration time of cert's leaf certificate.
+func certNotAfter(cert tls.Certificate) (time.Time, error) {
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse leaf certificate: %s", err)
+	}
+	return leaf.NotAfter, nil
 }
 
 // WriteCABundle writes a list of CA to a writer.
@@ -198,4 +217,59 @@ func encodePEMKey(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("encode key: %s", err)
 	}
 	return buf.Bytes(), nil
+}
+
+type certExpiryMonitor struct {
+	stopCh chan struct{}
+}
+
+// MonitorCertExpiration starts a background goroutine to periodically emit
+// when TLS certs will expire.
+func MonitorCertExpiration(tlsConfig *TLSConfig, stats tally.Scope) io.Closer {
+	m := &certExpiryMonitor{stopCh: make(chan struct{})}
+
+	check := func() {
+		reportCertExpiry("server", tlsConfig.Server, stats)
+		reportCertExpiry("client", tlsConfig.Client, stats)
+	}
+
+	check()
+
+	go func() {
+		ticker := time.NewTicker(_certExpiryCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				check()
+			case <-m.stopCh:
+				return
+			}
+		}
+	}()
+
+	return m
+}
+
+func (m *certExpiryMonitor) Close() error {
+	close(m.stopCh)
+	return nil
+}
+
+func reportCertExpiry(name string, pair X509Pair, stats tally.Scope) {
+	if pair.Disabled || pair.Cert.Path == "" {
+		return
+	}
+	cert, err := loadX509Pair(pair)
+	if err != nil {
+		log.Errorf("Error loading %s cert for expiry check: %s", name, err)
+		return
+	}
+	notAfter, err := certNotAfter(cert)
+	if err != nil {
+		log.Errorf("Error parsing %s cert for expiry check: %s", name, err)
+		return
+	}
+	gauge := stats.Tagged(map[string]string{"cert": name}).Gauge("tls_cert_expiry_days")
+	gauge.Update(time.Until(notAfter).Hours() / 24)
 }

--- a/utils/httputil/tls_test.go
+++ b/utils/httputil/tls_test.go
@@ -24,11 +24,14 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 
 	"github.com/uber/kraken/utils/randutil"
 	"github.com/uber/kraken/utils/testutil"
@@ -262,4 +265,56 @@ func TestTLSClientFallbackError(t *testing.T) {
 
 	_, err = Get("https://some-non-existent-addr/", SendTLS(tls))
 	require.Error(err)
+}
+
+func TestStartCertExpiryMonitor(t *testing.T) {
+	t.Run("expiration date emitted correctly", func(t *testing.T) {
+		require := require.New(t)
+
+		dir := t.TempDir()
+		writeFile := func(name string, data []byte) string {
+			path := filepath.Join(dir, name)
+			require.NoError(os.WriteFile(path, data, 0o600))
+			return path
+		}
+
+		serverCertPEM, serverKeyPEM, serverSecret := genKeyPair(t, nil, nil, nil)
+		config := &TLSConfig{}
+		config.Server.Cert.Path = writeFile("server.crt", serverCertPEM)
+		config.Server.Key.Path = writeFile("server.key", serverKeyPEM)
+		config.Server.Passphrase.Path = writeFile("server.passphrase", serverSecret)
+
+		clientCertPEM, clientKeyPEM, clientSecret := genKeyPair(t, nil, nil, nil)
+		config.Client.Cert.Path = writeFile("client.crt", clientCertPEM)
+		config.Client.Key.Path = writeFile("client.key", clientKeyPEM)
+		config.Client.Passphrase.Path = writeFile("client.passphrase", clientSecret)
+
+		// genKeyPair issues certs which expire in 180 days.
+		stats := tally.NewTestScope("", nil)
+		populatedCloser := MonitorCertExpiration(config, stats)
+		defer func() { require.NoError(populatedCloser.Close()) }()
+
+		gauges := stats.Snapshot().Gauges()
+
+		serverGauge, ok := gauges["tls_cert_expiry_days+cert=server"]
+		require.True(ok)
+		require.InDelta(180, serverGauge.Value(), 0.01)
+
+		clientGauge, ok := gauges["tls_cert_expiry_days+cert=client"]
+		require.True(ok)
+		require.InDelta(180, clientGauge.Value(), 0.01)
+	})
+
+	t.Run("metric is not emitted as 0 on empty cert, avoiding a false alarm", func(t *testing.T) {
+		require := require.New(t)
+		emptyStats := tally.NewTestScope("", nil)
+		emptyCloser := MonitorCertExpiration(&TLSConfig{}, emptyStats)
+		defer func() { require.NoError(emptyCloser.Close()) }()
+
+		emptyGauges := emptyStats.Snapshot().Gauges()
+		_, ok := emptyGauges["tls_cert_expiry_days+cert=server"]
+		require.False(ok)
+		_, ok = emptyGauges["tls_cert_expiry_days+cert=client"]
+		require.False(ok)
+	})
 }


### PR DESCRIPTION
If TLS is used and the provided certs expire, Kraken goes down imediatelly. To prevent such an outage, this commit emits a metric on how many days are left until the certs expire, making it easy to set up an alert when e.g. <30 days are left to expiry.