### PR TITLE
feat(bandwidth.Limiter): emit how much bandwidth throttling happens

### DIFF
--- a/lib/backend/manager.go
+++ b/lib/backend/manager.go
@@ -88,7 +88,8 @@ func NewManager(managerConfig ManagerConfig, configs []Config, auth AuthConfig, 
 		}
 
 		if config.Bandwidth.Enable {
-			l, err := bandwidth.NewLimiter(config.Bandwidth)
+			l, err := bandwidth.NewLimiter(
+				config.Bandwidth, stats.Tagged(map[string]string{"namespace": config.Namespace}))
 			if err != nil {
 				return nil, fmt.Errorf("bandwidth: %s", err)
 			}

--- a/lib/torrent/scheduler/conn/handshaker.go
+++ b/lib/torrent/scheduler/conn/handshaker.go
@@ -210,7 +210,7 @@ func NewHandshaker(
 		"module": "conn",
 	})
 
-	bl, err := bandwidth.NewLimiter(config.Bandwidth, bandwidth.WithLogger(logger))
+	bl, err := bandwidth.NewLimiter(config.Bandwidth, stats, bandwidth.WithLogger(logger))
 	if err != nil {
 		return nil, fmt.Errorf("bandwidth: %s", err)
 	}

--- a/utils/bandwidth/limiter.go
+++ b/utils/bandwidth/limiter.go
@@ -21,21 +21,29 @@ import (
 	"github.com/uber/kraken/utils/log"
 	"github.com/uber/kraken/utils/memsize"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 )
 
+const _sleepDurationMetric = "throttle_sleep_duration"
+
+var _sleepDurationBuckets = append(
+	tally.DurationBuckets{0},
+	tally.MustMakeExponentialDurationBuckets(5*time.Second, 2, 7)...)
+
 // Config defines Limiter configuration.
 type Config struct {
-	EgressBitsPerSec  uint64 `yaml:"egress_bits_per_sec"`
+	// When used in origin, the limit applies to the WHOLE HASHRING'S THROUGHPUT and is NOT per origin,
+	// i.e. each origin has a limit of configured_throughput/num_origins.
+	EgressBitsPerSec uint64 `yaml:"egress_bits_per_sec"`
+	// Check the comment under [Config.EgressBitsPerSec].
 	IngressBitsPerSec uint64 `yaml:"ingress_bits_per_sec"`
-
 	// TokenSize defines the granularity of a token in the bucket. It is used to
 	// avoid integer overflow errors that would occur if we mapped each bit to a
 	// token.
 	TokenSize uint64 `yaml:"token_size"`
-
-	Enable bool `yaml:"enable"`
+	Enable    bool   `yaml:"enable"`
 }
 
 func (c Config) applyDefaults() Config {
@@ -51,6 +59,7 @@ type Limiter struct {
 	egress  *rate.Limiter
 	ingress *rate.Limiter
 	logger  *zap.SugaredLogger
+	stats   tally.Scope
 }
 
 // Option allows setting optional parameters in Limiter.
@@ -62,12 +71,13 @@ func WithLogger(logger *zap.SugaredLogger) Option {
 }
 
 // NewLimiter creates a new Limiter.
-func NewLimiter(config Config, opts ...Option) (*Limiter, error) {
+func NewLimiter(config Config, stats tally.Scope, opts ...Option) (*Limiter, error) {
 	config = config.applyDefaults()
 
 	l := &Limiter{
 		config: config,
 		logger: log.Default(),
+		stats:  stats.Tagged(map[string]string{"module": "bandwidth"}),
 	}
 	for _, opt := range opts {
 		opt(l)
@@ -97,7 +107,7 @@ func NewLimiter(config Config, opts ...Option) (*Limiter, error) {
 	return l, nil
 }
 
-func (l *Limiter) reserve(rl *rate.Limiter, nbytes int64) error {
+func (l *Limiter) reserve(rl *rate.Limiter, nbytes int64, direction string) error {
 	if !l.config.Enable {
 		return nil
 	}
@@ -112,20 +122,23 @@ func (l *Limiter) reserve(rl *rate.Limiter, nbytes int64) error {
 			memsize.Format(uint64(nbytes)),
 			memsize.BitFormat(l.config.TokenSize*uint64(rl.Burst())))
 	}
-	time.Sleep(r.Delay())
+	delay := r.Delay()
+	l.stats.Tagged(map[string]string{"direction": direction}).
+		Histogram(_sleepDurationMetric, _sleepDurationBuckets).RecordDuration(delay)
+	time.Sleep(delay)
 	return nil
 }
 
 // ReserveEgress blocks until egress bandwidth for nbytes is available.
 // Returns error if nbytes is larger than the maximum egress bandwidth.
 func (l *Limiter) ReserveEgress(nbytes int64) error {
-	return l.reserve(l.egress, nbytes)
+	return l.reserve(l.egress, nbytes, "egress")
 }
 
 // ReserveIngress blocks until ingress bandwidth for nbytes is available.
 // Returns error if nbytes is larger than the maximum ingress bandwidth.
 func (l *Limiter) ReserveIngress(nbytes int64) error {
-	return l.reserve(l.ingress, nbytes)
+	return l.reserve(l.ingress, nbytes, "ingress")
 }
 
 // Adjust divides the originally configured egress and ingress bps by denominator.

--- a/utils/bandwidth/limiter_test.go
+++ b/utils/bandwidth/limiter_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 const (
@@ -43,7 +44,7 @@ func TestLimiterInvalidConfig(t *testing.T) {
 		IngressBitsPerSec: bps,
 		TokenSize:         1,
 		Enable:            true,
-	})
+	}, tally.NoopScope)
 	require.Error(err)
 
 	_, err = NewLimiter(Config{
@@ -51,7 +52,7 @@ func TestLimiterInvalidConfig(t *testing.T) {
 		IngressBitsPerSec: 0,
 		TokenSize:         1,
 		Enable:            true,
-	})
+	}, tally.NoopScope)
 	require.Error(err)
 }
 
@@ -65,7 +66,7 @@ func TestLimiterDisabled(t *testing.T) {
 		IngressBitsPerSec: bps,
 		TokenSize:         1,
 		Enable:            false,
-	})
+	}, tally.NoopScope)
 	require.NoError(err)
 	require.Nil(l.egress)
 	require.Nil(l.ingress)
@@ -87,7 +88,7 @@ func TestLimiterReserveConcurrency(t *testing.T) {
 				IngressBitsPerSec: bps,
 				TokenSize:         1,
 				Enable:            true,
-			})
+			}, tally.NoopScope)
 			require.NoError(err)
 
 			// This test starts a bunch of goroutines and see how many bytes
@@ -143,7 +144,7 @@ func TestLimiterReserveBytesTokenScaling(t *testing.T) {
 				IngressBitsPerSec: bps,
 				TokenSize:         10, // Bucket has 8 tokens.
 				Enable:            true,
-			})
+			}, tally.NoopScope)
 			require.NoError(err)
 
 			start := time.Now()
@@ -171,7 +172,7 @@ func TestLimiterReserveBytesSmallerThanTokenSize(t *testing.T) {
 				IngressBitsPerSec: bps,
 				TokenSize:         10, // Bucket has 8 tokens.
 				Enable:            true,
-			})
+			}, tally.NoopScope)
 			require.NoError(err)
 
 			start := time.Now()
@@ -200,12 +201,32 @@ func TestLimiterReserveErrorWhenBytesLargerThanBucket(t *testing.T) {
 				IngressBitsPerSec: bps,
 				TokenSize:         10, // Bucket has 8 tokens.
 				Enable:            true,
-			})
+			}, tally.NoopScope)
 			require.NoError(err)
 
 			require.Error(reserve(l, 12, direction))
 		})
 	}
+}
+
+func TestLimiterReserveRecordsSleepDuration(t *testing.T) {
+	require := require.New(t)
+
+	testScope := tally.NewTestScope("", nil)
+	l, err := NewLimiter(Config{
+		EgressBitsPerSec:  160,
+		IngressBitsPerSec: 160,
+		TokenSize:         8,
+		Enable:            true,
+	}, testScope)
+	require.NoError(err)
+	require.NoError(l.ReserveEgress(20)) // 0 delay.
+	require.NoError(l.ReserveEgress(10)) // ~500ms delay.
+	histograms := testScope.Snapshot().Histograms()
+	histogram, ok := histograms["throttle_sleep_duration+direction=egress,module=bandwidth"]
+	require.True(ok)
+	require.Equal(int64(1), histogram.Durations()[_sleepDurationBuckets[0]])
+	require.Equal(int64(1), histogram.Durations()[_sleepDurationBuckets[1]])
 }
 
 func TestLimiterAdjustError(t *testing.T) {
@@ -216,7 +237,7 @@ func TestLimiterAdjustError(t *testing.T) {
 		IngressBitsPerSec: 10,
 		TokenSize:         1,
 		Enable:            true,
-	})
+	}, tally.NoopScope)
 	require.NoError(err)
 	require.Error(l.Adjust(0))
 }
@@ -229,7 +250,7 @@ func TestLimiterAdjust(t *testing.T) {
 		IngressBitsPerSec: 10,
 		TokenSize:         1,
 		Enable:            true,
-	})
+	}, tally.NoopScope)
 	require.NoError(err)
 
 	// No subtests since we want to ensure the calls don't affect each other.

--- a/utils/httputil/tls.go
+++ b/utils/httputil/tls.go
@@ -86,11 +86,10 @@ func (c *TLSConfig) BuildClient() (*tls.Config, error) {
 		certs = []tls.Certificate{cert}
 	}
 	c.tls = &tls.Config{
-		Certificates:             certs,
-		RootCAs:                  caPool,
-		ServerName:               c.Name,
-		PreferServerCipherSuites: true,
-		InsecureSkipVerify:       false, // This is important to enforce verification of server.
+		Certificates:       certs,
+		RootCAs:            caPool,
+		ServerName:         c.Name,
+		InsecureSkipVerify: false, // This is important to enforce verification of server.
 	}
 	return c.tls, nil
 }


### PR DESCRIPTION
When downloading/uploading data in origin, we throttle ourselves for various reasons. However, that throttling is dangerously silent - it simply does `time.Sleep` without any metric on how much we sleep or warning that we are doing so. There are no error codes to show that we are sleeping, performance just drops. Thus, to measure how badly we are throttling ourselves, I'm adding a metric that lets us know how much we spend in `time.Sleep`.